### PR TITLE
feat: mask sensitive information

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
       label: Current Behavior
       description: |
         What actually happened?
-        Please include full errors, uncaught exceptions, stack traces, and relevant logs.
+        Please include full errors, uncaught exceptions, stack traces, and relevant logs. Remember to review and remove sensitive information from logs if uploading.
     validations:
       required: true
   - type: textarea

--- a/driver/plugin/base_plugin.cpp
+++ b/driver/plugin/base_plugin.cpp
@@ -58,7 +58,7 @@ SQLRETURN BasePlugin::Connect(
     // DSN should be read from the original input
     // and a new connection string should be built without DSN & Driver
     RDS_STR conn_in = ConnectionStringHelper::BuildMinimumConnectionString(dbc->conn_attr);
-    DLOG(INFO) << "Built minimum connection string for underlying driver: " << conn_in;
+    DLOG(INFO) << "Built minimum connection string for underlying driver: " << ConnectionStringHelper::MaskSensitiveInformation(conn_in);
     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLDriverConnect, RDS_STR_SQLDriverConnect,
         dbc->wrapped_dbc, WindowHandle, AS_SQLTCHAR(conn_in.c_str()), SQL_NTS, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion
     );

--- a/driver/plugin/federated/adfs_auth_plugin.cpp
+++ b/driver/plugin/federated/adfs_auth_plugin.cpp
@@ -150,7 +150,6 @@ std::string AdfsSamlUtil::GetSamlAssertion()
     std::string sign_in_content = GetFormActionBody(url, sign_in_parameters);
 
     if (std::regex_search(sign_in_content, matches, std::regex(SAML_RESPONSE_PATTERN))) {
-        DLOG(INFO) << "SAML Response: " << matches.str(1);
         return matches.str(1);
     }
     LOG(WARNING) << "Failed SAML Asesertion";

--- a/driver/util/auth_provider.cpp
+++ b/driver/util/auth_provider.cpp
@@ -77,7 +77,7 @@ std::pair<std::string, bool> AuthProvider::GetToken(
         std::lock_guard<std::recursive_mutex> lock_guard(token_cache_mutex);
         token_cache.insert_or_assign(cache_key, token_info);
     }
-    DLOG(INFO) << "Returning Token: " << token_info.token;
+    DLOG(INFO) << "Returning Token Length: " << token_info.token.length();
     return std::pair<std::string, bool>(token_info.token, false);
 }
 

--- a/driver/util/connection_string_helper.h
+++ b/driver/util/connection_string_helper.h
@@ -52,8 +52,9 @@ static std::unordered_set<RDS_STR> const aws_odbc_key_set = {
 
 namespace ConnectionStringHelper {
     void ParseConnectionString(const RDS_STR &conn_str, std::map<RDS_STR, RDS_STR> &conn_map);
-    RDS_STR BuildMinimumConnectionString(const std::map<RDS_STR, RDS_STR> &conn_map, bool redact_sensitive = false);
-    RDS_STR BuildFullConnectionString(const std::map<RDS_STR, RDS_STR> &conn_map, bool redact_sensitive = false);
+    RDS_STR BuildMinimumConnectionString(const std::map<RDS_STR, RDS_STR> &conn_map);
+    RDS_STR BuildFullConnectionString(const std::map<RDS_STR, RDS_STR> &conn_map);
+    RDS_STR MaskSensitiveInformation(const RDS_STR &conn_str);
     bool IsAwsOdbcKey(const RDS_STR &aws_odbc_key);
     bool IsSensitiveData(const RDS_STR &sensitive_key);
 }

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TEST_SUITE
     ${CMAKE_CURRENT_SOURCE_DIR}/adfs_auth_plugin_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/adfs_saml_util_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/auth_provider_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/connection_string_helper_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/iam_auth_plugin_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/secrets_manager_plugin_test.cpp
 )

--- a/test/unit_test/connection_string_helper_test.cpp
+++ b/test/unit_test/connection_string_helper_test.cpp
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <map>
+
+#include "../../driver/util/connection_string_helper.h"
+#include "../../driver/util/connection_string_keys.h"
+
+class ConnectionStringHelperTest : public testing::Test {
+protected:
+    // Runs once per suite
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(ConnectionStringHelperTest, ParseConnectionString) {
+    RDS_STR conn_str(
+        KEY_DB_USERNAME TEXT("=jane_doe;")
+        KEY_DB_PASSWORD TEXT("=password;")
+    );
+    std::map<RDS_STR, RDS_STR> conn_map;
+
+    ConnectionStringHelper::ParseConnectionString(conn_str, conn_map);
+
+    EXPECT_EQ(2, conn_map.size());
+    EXPECT_TRUE(conn_map.contains(KEY_DB_USERNAME));
+    EXPECT_TRUE(conn_map.contains(KEY_DB_PASSWORD));
+    EXPECT_STREQ(TEXT("jane_doe"), conn_map.at(KEY_DB_USERNAME).c_str());
+    EXPECT_STREQ(TEXT("password"), conn_map.at(KEY_DB_PASSWORD).c_str());
+}
+
+TEST_F(ConnectionStringHelperTest, BuildFullConnectionString) {
+    std::map<RDS_STR, RDS_STR> conn_map;
+    conn_map.insert_or_assign(KEY_DB_USERNAME, "jane_doe");
+    conn_map.insert_or_assign(KEY_DB_PASSWORD, "password");
+    conn_map.insert_or_assign(KEY_AUTH_TYPE, "iam");
+    RDS_STR expected(
+        KEY_DB_USERNAME TEXT("=jane_doe;")
+        KEY_DB_PASSWORD TEXT("=password;")
+        KEY_AUTH_TYPE TEXT("=iam;")
+    );
+
+    std::map<RDS_STR, RDS_STR> result_map;
+    RDS_STR conn_str = ConnectionStringHelper::BuildFullConnectionString(conn_map);
+    ConnectionStringHelper::ParseConnectionString(conn_str, result_map);
+
+    EXPECT_EQ(3, result_map.size());
+    EXPECT_TRUE(result_map.contains(KEY_DB_USERNAME));
+    EXPECT_TRUE(result_map.contains(KEY_DB_PASSWORD));
+    EXPECT_TRUE(result_map.contains(KEY_AUTH_TYPE));
+    EXPECT_STREQ(TEXT("jane_doe"), result_map.at(KEY_DB_USERNAME).c_str());
+    EXPECT_STREQ(TEXT("password"), result_map.at(KEY_DB_PASSWORD).c_str());
+    EXPECT_STREQ(TEXT("iam"), result_map.at(KEY_AUTH_TYPE).c_str());
+}
+
+TEST_F(ConnectionStringHelperTest, BuildMinimumConnectionString) {
+    std::map<RDS_STR, RDS_STR> conn_map;
+    conn_map.insert_or_assign(KEY_DB_USERNAME, "jane_doe");
+    conn_map.insert_or_assign(KEY_DB_PASSWORD, "password");
+    conn_map.insert_or_assign(KEY_AUTH_TYPE, "iam");
+
+    std::map<RDS_STR, RDS_STR> result_map;
+    RDS_STR conn_str = ConnectionStringHelper::BuildMinimumConnectionString(conn_map);
+    ConnectionStringHelper::ParseConnectionString(conn_str, result_map);
+
+    EXPECT_EQ(2, result_map.size());
+    EXPECT_TRUE(result_map.contains(KEY_DB_USERNAME));
+    EXPECT_TRUE(result_map.contains(KEY_DB_PASSWORD));
+    EXPECT_STREQ(TEXT("jane_doe"), result_map.at(KEY_DB_USERNAME).c_str());
+    EXPECT_STREQ(TEXT("password"), result_map.at(KEY_DB_PASSWORD).c_str());
+}
+
+TEST_F(ConnectionStringHelperTest, MaskConnectionString) {
+    RDS_STR conn_str(
+        KEY_DB_USERNAME TEXT("=jane_doe;")
+        KEY_DB_PASSWORD TEXT("=password;")
+        KEY_IDP_PASSWORD TEXT("=idp_password;")
+    );
+
+    RDS_STR expected(
+        KEY_DB_USERNAME TEXT("=jane_doe;")
+        KEY_DB_PASSWORD TEXT("=[REDACTED];")
+        KEY_IDP_PASSWORD TEXT("=[REDACTED];")
+    );
+
+    RDS_STR masked_str = ConnectionStringHelper::MaskSensitiveInformation(conn_str);
+
+    EXPECT_STREQ(expected.c_str(), masked_str.c_str());
+}


### PR DESCRIPTION
### Summary

Mask Sensitive Information

### Description

- Removed ADFS SAML token from being logged even in debug mode
- Debug mode connection string log will also redact passwords
- Additional reminder to remove sensitive information when creating issues

### Testing

- Added additional tests for connection string builder

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
