### PR TITLE
feat: host selector strategies

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -26,6 +26,13 @@ include(FetchContent)
 
 # Sources ----------------------------------------------------------------------------------------------------
 set(INC
+    # Host Selectors
+    ${CMAKE_CURRENT_SOURCE_DIR}/host_selector/highest_weight_host_selector.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/host_selector/host_selector.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/host_selector/random_host_selector.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/host_selector/round_robin_host_selector.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/host_selector/round_robin_property.h
+
     # Plugins
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin/base_plugin.h
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin/federated/adfs_auth_plugin.h
@@ -44,10 +51,12 @@ set(INC
     ${CMAKE_CURRENT_SOURCE_DIR}/util/odbc_dsn_helper.h
     ${CMAKE_CURRENT_SOURCE_DIR}/util/rds_lib_loader.h
     ${CMAKE_CURRENT_SOURCE_DIR}/util/rds_strings.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/util/sliding_cache_map.h
 
     # Core
     ${CMAKE_CURRENT_SOURCE_DIR}/driver.h
     ${CMAKE_CURRENT_SOURCE_DIR}/error.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/host_info.h
     ${CMAKE_CURRENT_SOURCE_DIR}/odbcapi.h
     ${CMAKE_CURRENT_SOURCE_DIR}/odbcapi_rds_helper.h
 )
@@ -55,6 +64,11 @@ set(INC
 set(SRC
     # GUI
     ${CMAKE_CURRENT_SOURCE_DIR}/gui/setup.cpp
+
+    # Host Selectors
+    ${CMAKE_CURRENT_SOURCE_DIR}/host_selector/highest_weight_host_selector.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/host_selector/random_host_selector.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/host_selector/round_robin_host_selector.cpp
 
     # Plugins
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin/base_plugin.cpp
@@ -72,8 +86,10 @@ set(SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/util/logger_wrapper.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/util/odbc_dsn_helper.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/util/rds_lib_loader.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/util/sliding_cache_map.cpp
 
     # Core
+    ${CMAKE_CURRENT_SOURCE_DIR}/host_info.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/odbcapi_common.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/odbcapi_rds_helper.cpp
 )

--- a/driver/dialect/dialect.h
+++ b/driver/dialect/dialect.h
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DIALECT_H
+#define DIALECT_H
+
+#include "../util/rds_strings.h"
+
+class Dialect {
+public:
+    virtual int GetDefaultPort() { return 0; };
+    virtual RDS_STR GetTopologyQuery() { return AS_RDS_STR(TEXT("")); };
+    virtual RDS_STR GetWriterIdQuery() { return AS_RDS_STR(TEXT("")); };
+    virtual RDS_STR GetNodeIdQuery() { return AS_RDS_STR(TEXT("")); };
+    virtual RDS_STR GetIsReaderQuery() { return AS_RDS_STR(TEXT("")); };
+};
+
+#endif // DIALECT_H

--- a/driver/dialect/dialect_aurora_postgres.h
+++ b/driver/dialect/dialect_aurora_postgres.h
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DIALECT_AURORA_POSTGRES_H
+#define DIALECT_AURORA_POSTGRES_H
+
+#include "dialect.h"
+
+class DialectAuroraPostgres : public Dialect {
+public:
+    int GetDefaultPort() override { return DEFAULT_POSTGRES_PORT; };
+    RDS_STR GetTopologyQuery() override { return TOPOLOGY_QUERY; };
+    RDS_STR GetWriterIdQuery() override { return WRITER_ID_QUERY; };
+    RDS_STR GetNodeIdQuery() override { return NODE_ID_QUERY; };
+    RDS_STR GetIsReaderQuery() override { return IS_READER_QUERY; };
+
+private:
+    const int DEFAULT_POSTGRES_PORT = 5432;
+    const RDS_STR TOPOLOGY_QUERY = AS_RDS_STR(TEXT(
+        "SELECT SERVER_ID, CASE WHEN SESSION_ID = 'MASTER_SESSION_ID' THEN TRUE ELSE FALSE END, \
+        CPU, COALESCE(REPLICA_LAG_IN_MSEC, 0) \
+        FROM aurora_replica_status() \
+        WHERE EXTRACT(EPOCH FROM(NOW() - LAST_UPDATE_TIMESTAMP)) <= 300 OR SESSION_ID = 'MASTER_SESSION_ID' \
+        OR LAST_UPDATE_TIMESTAMP IS NULL"));
+
+    const RDS_STR WRITER_ID_QUERY = AS_RDS_STR(TEXT(
+        "SELECT SERVER_ID FROM aurora_replica_status() WHERE SESSION_ID = 'MASTER_SESSION_ID' \
+        AND SERVER_ID = aurora_db_instance_identifier()"));
+
+    const RDS_STR NODE_ID_QUERY = AS_RDS_STR(TEXT("SELECT aurora_db_instance_identifier()"));
+
+    const RDS_STR IS_READER_QUERY = AS_RDS_STR(TEXT("SELECT pg_is_in_recovery()"));
+};
+
+#endif  // DIALECT_AURORA_POSTGRES_H

--- a/driver/host_info.cpp
+++ b/driver/host_info.cpp
@@ -1,0 +1,99 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "host_info.h"
+
+HostInfo::HostInfo(const std::string& host, int port, HOST_STATE state, bool is_writer, uint64_t weight) :
+    host { std::move(host) },
+    port { port },
+    host_state { state },
+    is_writer { is_writer },
+    weight { weight }
+{
+}
+
+/**
+ * Returns the host.
+ *
+ * @return the host
+ */
+std::string HostInfo::GetHost() const
+{
+    return host;
+}
+
+/**
+ * Returns the port.
+ *
+ * @return the port
+ */
+int HostInfo::GetPort() const
+{
+    return port;
+}
+
+/**
+ * Returns the weight
+ *
+ * @return the weight
+ */
+uint64_t HostInfo::GetWeight() const
+{
+    return weight;
+}
+
+/**
+ * Returns a host:port representation of this host.
+ *
+ * @return the host:port representation of this host
+ */
+std::string HostInfo::GetHostPortPair() const
+{
+    return GetHost() + host_port_separator + std::to_string(GetPort());
+}
+
+bool HostInfo::EqualHostPortPair(const HostInfo& hi) const
+{
+    return GetHostPortPair() == hi.GetHostPortPair();
+}
+
+HOST_STATE HostInfo::GetHostState() const
+{
+    return host_state;
+}
+
+void HostInfo::SetHostState(HOST_STATE state)
+{
+    host_state = state;
+}
+
+bool HostInfo::IsHostUp() const
+{
+    return host_state == UP;
+}
+
+bool HostInfo::IsHostDown() const
+{
+    return host_state == DOWN;
+}
+
+bool HostInfo::IsHostWriter() const
+{
+    return is_writer;
+}
+
+void HostInfo::MarkAsWriter(bool writer)
+{
+    is_writer = writer;
+}

--- a/driver/host_info.h
+++ b/driver/host_info.h
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HOST_INFO_H_
+#define HOST_INFO_H_
+
+#include <memory>
+#include <ostream>
+#include <string>
+
+typedef enum {
+    UP,
+    DOWN
+} HOST_STATE;
+
+class HostInfo {
+public:
+    static constexpr uint64_t DEFAULT_WEIGHT = 100;
+    static constexpr int NO_PORT = -1;
+    static constexpr int MAX_HOST_INFO_BUFFER_SIZE = 1024;
+
+    HostInfo() = default;
+
+    HostInfo(
+        const std::string& host,
+        int port,
+        HOST_STATE state,
+        bool is_writer,
+        uint64_t weight = DEFAULT_WEIGHT
+    );
+
+    ~HostInfo() = default;
+
+    bool EqualHostPortPair(const HostInfo& hi) const;
+    bool IsHostDown() const;
+    bool IsHostUp() const;
+    bool IsHostWriter() const;
+
+    void MarkAsWriter(bool writer);
+
+    std::string GetHost() const;
+    int GetPort() const;
+    std::string GetHostPortPair() const;
+    uint64_t GetWeight() const;
+
+    void SetHostState(HOST_STATE state);
+    HOST_STATE GetHostState() const;
+
+    std::string session_id;
+    std::string replica_lag;
+
+    bool operator==(const HostInfo& other) const {
+        return this->EqualHostPortPair(other) && this->weight == other.GetWeight() && this->is_writer == other.IsHostWriter();
+    }
+
+private:
+    std::string host_port_separator = ":";
+    std::string host;
+    int port = NO_PORT;
+    uint64_t weight = DEFAULT_WEIGHT;
+
+    HOST_STATE host_state;
+    bool is_writer;
+};
+
+inline std::ostream& operator<<(std::ostream& str, const HostInfo& v) {
+    char buf[HostInfo::MAX_HOST_INFO_BUFFER_SIZE];
+    sprintf(buf, "HostInfo[host=%s, port=%d, %s]", v.GetHost().c_str(), v.GetPort(), v.IsHostWriter() ? "WRITER" : "READER");
+    return str << std::string(buf);
+}
+
+#endif // HOST_INFO_H_

--- a/driver/host_selector/highest_weight_host_selector.cpp
+++ b/driver/host_selector/highest_weight_host_selector.cpp
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "highest_weight_host_selector.h"
+
+#include <algorithm>
+#include <stdexcept>
+
+HostInfo HighestWeightHostSelector::GetHost(std::vector<HostInfo> hosts, bool is_writer, std::unordered_map<std::string, std::string>) {
+    std::vector<HostInfo> eligible_hosts;
+    eligible_hosts.reserve(hosts.size());
+
+    std::copy_if(hosts.begin(), hosts.end(), std::back_inserter(eligible_hosts), [&is_writer](const HostInfo& host) {
+        return host.IsHostUp() && is_writer == host.IsHostWriter();
+    });
+
+    if (eligible_hosts.empty()) {
+        throw std::runtime_error("No eligible hosts found in list");
+    }
+
+    auto highest_weight_host = std::max_element(
+        eligible_hosts.begin(),
+        eligible_hosts.end(),
+        [](const HostInfo& a, const HostInfo& b) {
+            return a.GetWeight() < b.GetWeight();
+        }
+    );
+
+    if (highest_weight_host == eligible_hosts.end()) {
+        throw std::runtime_error("No eligible hosts found in list");
+    }
+
+    return *highest_weight_host;
+}

--- a/driver/host_selector/highest_weight_host_selector.h
+++ b/driver/host_selector/highest_weight_host_selector.h
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HIGHEST_WEIGHT_HOST_SELECTOR_H_
+#define HIGHEST_WEIGHT_HOST_SELECTOR_H_
+
+#include "../host_info.h"
+#include "host_selector.h"
+
+class HighestWeightHostSelector: public HostSelector {
+public:
+    HostInfo GetHost(std::vector<HostInfo> hosts, bool is_writer,
+        std::unordered_map<std::string, std::string> properties) override;
+};
+
+#endif //HIGHEST_WEIGHT_HOST_SELECTOR_H_

--- a/driver/host_selector/host_selector.h
+++ b/driver/host_selector/host_selector.h
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HOST_SELECTOR_H_
+#define HOST_SELECTOR_H_
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "../host_info.h"
+
+class HostSelector {
+public:
+    virtual ~HostSelector() = default;
+    virtual HostInfo GetHost(std::vector<HostInfo> hosts, bool is_writer,
+        std::unordered_map<std::string, std::string> properties) = 0;
+};
+
+#endif // HOST_SELECTOR_H_

--- a/driver/host_selector/random_host_selector.cpp
+++ b/driver/host_selector/random_host_selector.cpp
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "random_host_selector.h"
+
+#include <algorithm>
+#include <random>
+#include <stdexcept>
+
+HostInfo RandomHostSelector::GetHost(std::vector<HostInfo> hosts, bool is_writer,
+    std::unordered_map<std::string, std::string>) {
+
+    std::vector<HostInfo> selection;
+    selection.reserve(hosts.size());
+
+    std::copy_if(hosts.begin(), hosts.end(), std::back_inserter(selection), [&is_writer](const HostInfo& host) {
+        return host.IsHostUp() && (is_writer ? host.IsHostWriter() : true);
+    });
+
+    if (selection.empty()) {
+        throw std::runtime_error("No available hosts found in list");
+    }
+
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> dis(0, selection.size() - 1);
+
+    int rand_idx = dis(gen);
+    return selection[rand_idx];
+}

--- a/driver/host_selector/random_host_selector.h
+++ b/driver/host_selector/random_host_selector.h
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RANDOM_HOST_SELECTOR_H_
+#define RANDOM_HOST_SELECTOR_H_
+
+#include "../host_info.h"
+#include "host_selector.h"
+
+class RandomHostSelector: public HostSelector {
+public:
+    HostInfo GetHost(std::vector<HostInfo> hosts, bool is_writer,
+        std::unordered_map<std::string, std::string> properties) override;
+};
+
+#endif // RANDOM_HOST_SELECTOR_H_

--- a/driver/host_selector/round_robin_host_selector.cpp
+++ b/driver/host_selector/round_robin_host_selector.cpp
@@ -1,0 +1,241 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "round_robin_host_selector.h"
+
+#include <algorithm>
+#include <sstream>
+#include <stdexcept>
+
+// Initialize static members
+std::mutex RoundRobinHostSelector::cache_mutex;
+SlidingCacheMap<std::string, std::shared_ptr<round_robin_property::RoundRobinClusterInfo>> RoundRobinHostSelector::round_robin_cache;
+
+void RoundRobinHostSelector::SetRoundRobinWeight(std::vector<HostInfo> hosts,
+    std::unordered_map<std::string, std::string>& properties) {
+
+    std::string host_weight_str;
+    for (int i = 0; i < hosts.size(); i++) {
+        host_weight_str += hosts.at(i).GetHost();
+        host_weight_str += ":";
+        host_weight_str += std::to_string(hosts.at(i).GetWeight());
+        if (i < hosts.size() - 1) {
+            host_weight_str += ",";
+        }
+    }
+    properties[round_robin_property::HOST_WEIGHT_KEY] = host_weight_str;
+}
+
+void RoundRobinHostSelector::ClearCache() {
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    round_robin_cache.Clear();
+}
+
+HostInfo RoundRobinHostSelector::GetHost(std::vector<HostInfo> hosts, bool is_writer,
+    std::unordered_map<std::string, std::string> properties) {
+
+    std::lock_guard<std::mutex> lock(cache_mutex);
+
+    std::vector<HostInfo> selection;
+    selection.reserve(hosts.size());
+
+    std::copy_if(hosts.begin(), hosts.end(), std::back_inserter(selection), [&is_writer](const HostInfo& host) {
+        return host.IsHostUp() && (is_writer ? host.IsHostWriter() : true);
+    });
+
+    if (selection.empty()) {
+        throw std::runtime_error("No available hosts found in list");
+    }
+
+    struct {
+        bool operator()(const HostInfo& a, const HostInfo& b) const {
+            return a.GetHost() < b.GetHost();
+        }
+    } host_name_sort;
+    std::sort(selection.begin(), selection.end(), host_name_sort);
+
+    create_cache_entries(selection, properties);
+    std::string cluster_id_key = selection.at(0).GetHost();
+    std::shared_ptr<round_robin_property::RoundRobinClusterInfo> cluster_info = round_robin_cache.Get(cluster_id_key);
+
+    std::shared_ptr<HostInfo> last_host = cluster_info->last_host;
+    int last_host_idx = NO_HOST_IDX;
+    if (last_host) {
+        for (int i = 0; i < selection.size(); i++) {
+            if (selection.at(i).GetHost() == last_host->GetHost()) {
+                last_host_idx = i;
+            }
+        }
+    }
+
+    int target_host_idx;
+    if (cluster_info->weight_counter > 0 && last_host_idx != NO_HOST_IDX) {
+        target_host_idx = last_host_idx;
+    } else {
+        if (last_host_idx != NO_HOST_IDX && last_host_idx != selection.size() - 1) {
+            target_host_idx = last_host_idx + 1;
+        } else {
+            target_host_idx = 0;
+        }
+        int weight = cluster_info->default_weight;
+        if (auto itr = cluster_info->cluster_weight_map.find(selection.at(target_host_idx).GetHost()); itr != cluster_info->cluster_weight_map.end()) {
+            weight = itr->second;
+        }
+        cluster_info->weight_counter = weight;
+    }
+
+    cluster_info->weight_counter--;
+    cluster_info->last_host = std::make_shared<HostInfo>(selection.at(target_host_idx));
+
+    return selection.at(target_host_idx);
+}
+
+/**
+ * This function is created to convert strings to integers.
+ * An issue with using std::stoi() is that it will also parse floats/doubles
+ * up until the decimal point, e.g. std::stoi("1.1") = 1
+ * and is not a desirable case for our use
+ */
+int RoundRobinHostSelector::convert_to_int(const std::string& str) {
+    std::istringstream stream(str);
+    char c;
+    int result;
+    if (stream >> result) {
+        if (stream.get(c)) {
+            throw std::runtime_error("String is not a pure integer.");
+        }
+        return result;
+    }
+    throw std::runtime_error("Could not convert string to a pure integer.");
+}
+
+bool RoundRobinHostSelector::check_prop_change(const std::string& value, const std::string& prop_name,
+    const std::unordered_map<std::string, std::string>& props) {
+
+    if (!props.contains(prop_name)) {
+        return false;
+    }
+    const std::string& prop_value = props.at(prop_name);
+    return value != prop_value;
+}
+
+void RoundRobinHostSelector::create_cache_entries(const std::vector<HostInfo>& hosts,
+    const std::unordered_map<std::string, std::string>& props) {
+
+    std::vector<HostInfo> hosts_with_cached_entry;
+    hosts_with_cached_entry.reserve(round_robin_cache.Size());
+    std::copy_if(hosts.begin(), hosts.end(), std::back_inserter(hosts_with_cached_entry), [this](const HostInfo& host) {
+        return RoundRobinHostSelector::round_robin_cache.Find(host.GetHost());
+    });
+
+    // Update cache entries, else create new cache
+    if (hosts_with_cached_entry.empty()) {
+        std::shared_ptr<round_robin_property::RoundRobinClusterInfo> cluster_info = std::make_shared<round_robin_property::RoundRobinClusterInfo>();
+        update_props_default_weight(cluster_info, props);
+        update_props_host_weight(cluster_info, props);
+        update_cache(hosts, cluster_info);
+    } else {
+        std::string cluster_id_key = hosts_with_cached_entry.at(0).GetHost();
+        std::shared_ptr<round_robin_property::RoundRobinClusterInfo> cluster_info = round_robin_cache.Get(cluster_id_key);
+        if (check_prop_change(cluster_info->last_default_weight_str, round_robin_property::DEFAULT_WEIGHT_KEY, props)) {
+            cluster_info->default_weight = 1;
+            update_props_default_weight(cluster_info, props);
+        }
+        if (check_prop_change(cluster_info->last_host_weight_str, round_robin_property::HOST_WEIGHT_KEY, props)) {
+            cluster_info->last_host = nullptr;
+            cluster_info->weight_counter = 0;
+            update_props_host_weight(cluster_info, props);
+        }
+        update_cache(hosts, cluster_info);
+    }
+};
+
+void RoundRobinHostSelector::update_cache(const std::vector<HostInfo>& hosts,
+    const std::shared_ptr<round_robin_property::RoundRobinClusterInfo>& cluster_info) {
+
+    for (const HostInfo& host : hosts) {
+        round_robin_cache.Put(
+            host.GetHost(),
+            cluster_info
+        );
+    }
+}
+
+void RoundRobinHostSelector::update_props_default_weight(
+    const std::shared_ptr<round_robin_property::RoundRobinClusterInfo>& info,
+    const std::unordered_map<std::string, std::string>& props) {
+
+    int set_weight = DEFAULT_WEIGHT;
+    if (auto itr = props.find(round_robin_property::DEFAULT_WEIGHT_KEY); itr != props.end()) {
+        try {
+            set_weight = convert_to_int(itr->second);
+            if (set_weight < DEFAULT_WEIGHT) {
+                throw std::runtime_error("Invalid default host weight.");
+            }
+        } catch (const std::exception& e) {
+            throw std::runtime_error("Default host weight not parsable as an integer.");
+        }
+        info->last_default_weight_str = itr->first;
+    }
+    info->default_weight = set_weight;
+}
+
+void RoundRobinHostSelector::update_props_host_weight(
+    const std::shared_ptr<round_robin_property::RoundRobinClusterInfo>& info,
+    const std::unordered_map<std::string, std::string>& props) {
+
+    if (auto itr = props.find(round_robin_property::HOST_WEIGHT_KEY); itr != props.end()) {
+        std::string host_weigths_str = itr->second;
+        if (host_weigths_str.empty()) {
+            info->cluster_weight_map.clear();
+            info->last_host_weight_str = "";
+            return;
+        }
+        std::istringstream stream(host_weigths_str);
+        std::string token;
+        std::vector<std::string> host_weight_groups;
+        while (std::getline(stream, token, ',')) {
+            host_weight_groups.push_back(token);
+        }
+
+        for (const std::string& host_weight_pair : host_weight_groups) {
+            std::istringstream stream(host_weight_pair);
+            std::string token;
+            std::vector<std::string> host_weight_split;
+            while (std::getline(stream, token, ':')) {
+                host_weight_split.push_back(token);
+            }
+            if (host_weight_split.size() != 2) {
+                throw std::runtime_error("Invalid format for host weight pair.");
+            }
+
+            std::string host_name = host_weight_split.at(0);
+            std::string host_weight = host_weight_split.at(1);
+            if (host_name.empty() || host_weight.empty()) {
+                throw std::runtime_error("Host Name and/or host weight missing.");
+            }
+
+            try {
+                int set_weight = convert_to_int(host_weight);
+                if (set_weight < DEFAULT_WEIGHT) {
+                    throw std::runtime_error("Invalid host weight.");
+                }
+                info->cluster_weight_map[host_name] = set_weight;
+                info->last_host_weight_str = host_weigths_str;
+            } catch (const std::exception& e) {
+                throw std::runtime_error("Host weight not parsable as an integer.");
+            }
+        }
+    }
+}

--- a/driver/host_selector/round_robin_host_selector.h
+++ b/driver/host_selector/round_robin_host_selector.h
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROUND_ROBIN_HOST_SELECTOR_H_
+#define ROUND_ROBIN_HOST_SELECTOR_H_
+
+#include <mutex>
+#include <vector>
+
+#include "../host_info.h"
+#include "../util/sliding_cache_map.h"
+#include "host_selector.h"
+#include "round_robin_property.h"
+
+class RoundRobinHostSelector: public HostSelector {
+public:
+    HostInfo GetHost(std::vector<HostInfo> hosts, bool is_writer,
+        std::unordered_map<std::string, std::string> properties) override;
+    static void SetRoundRobinWeight(std::vector<HostInfo> hosts,
+        std::unordered_map<std::string, std::string>& properties);
+    static void ClearCache();
+
+private:
+    const int DEFAULT_WEIGHT = 1;
+    const int NO_HOST_IDX = -1;
+
+    static std::mutex cache_mutex;
+    static SlidingCacheMap<std::string, std::shared_ptr<round_robin_property::RoundRobinClusterInfo>> round_robin_cache;
+
+    virtual int convert_to_int(const std::string& str);
+
+    virtual bool check_prop_change(const std::string& value, const std::string& prop_name,
+        const std::unordered_map<std::string, std::string>& props);
+    virtual void create_cache_entries(const std::vector<HostInfo>& hosts,
+        const std::unordered_map<std::string, std::string>& props);
+    virtual void update_cache(const std::vector<HostInfo>& hosts,
+        const std::shared_ptr<round_robin_property::RoundRobinClusterInfo>& cluster_info);
+    virtual void update_props_default_weight(
+        const std::shared_ptr<round_robin_property::RoundRobinClusterInfo>& info,
+        const std::unordered_map<std::string, std::string>& props);
+    virtual void update_props_host_weight(
+        const std::shared_ptr<round_robin_property::RoundRobinClusterInfo>& info,
+        const std::unordered_map<std::string, std::string>& props);
+};
+
+#endif // ROUND_ROBIN_HOST_SELECTOR_H_

--- a/driver/host_selector/round_robin_property.h
+++ b/driver/host_selector/round_robin_property.h
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROUND_ROBIN_PROPERTY_H
+#define ROUND_ROBIN_PROPERTY_H
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "../host_info.h"
+
+namespace round_robin_property {
+    const std::string HOST_WEIGHT_KEY = "round_robin_host_weight_pairs";
+    const std::string DEFAULT_WEIGHT_KEY = "round_robin_default_weight";
+
+    using RoundRobinClusterInfo = struct RoundRobinClusterInfo {
+        std::shared_ptr<HostInfo> last_host;
+        std::unordered_map<std::string, int> cluster_weight_map;
+        int default_weight = 1;
+        int weight_counter = 0;
+        std::string last_default_weight_str;
+        std::string last_host_weight_str;
+    };
+};
+
+#endif // ROUND_ROBIN_PROPERTY_H

--- a/driver/util/sliding_cache_map.cpp
+++ b/driver/util/sliding_cache_map.cpp
@@ -1,0 +1,118 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "sliding_cache_map.h"
+
+#include <chrono>
+#include <mutex>
+#include <unordered_map>
+
+#include "../host_selector/round_robin_host_selector.h"
+#include "../host_info.h"
+
+template <typename K, typename V>
+void SlidingCacheMap<K, V>::Put(const K& key, const V& value) {
+    Put(key, value, DEFAULT_EXPIRATION_MS);
+}
+
+template <typename K, typename V>
+void SlidingCacheMap<K, V>::Put(const K& key, const V& value, std::chrono::milliseconds ms_ttl) {
+    std::lock_guard<std::mutex> lock(cache_lock);
+    std::chrono::steady_clock::time_point expiry_time =
+        std::chrono::steady_clock::now() + ms_ttl;
+    cache[key] = CacheEntry{value, expiry_time, ms_ttl};
+}
+
+template <typename K, typename V>
+void SlidingCacheMap<K, V>::PutIfAbsent(const K &key, const V &value) {
+    PutIfAbsent(key, value, DEFAULT_EXPIRATION_MS);
+}
+
+template <typename K, typename V>
+void SlidingCacheMap<K, V>::PutIfAbsent(const K &key, const V &value, std::chrono::milliseconds ms_ttl) {
+    std::lock_guard<std::mutex> lock(cache_lock);
+    std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+    if (auto itr = cache.find(key); itr != cache.end()) {
+        CacheEntry& entry = itr->second;
+        // Already in cache & is not expired
+        if (entry.expiry > now) {
+            // Update TTL & Return value
+            entry.expiry = now + entry.time_to_expire_ms;
+            return;
+        }
+    }
+    // Either not in cache or is expired, put new into cache
+    std::chrono::steady_clock::time_point expiry_time =
+        std::chrono::steady_clock::now() + ms_ttl;
+    cache[key] = CacheEntry{value, expiry_time, ms_ttl};
+}
+
+template <typename K, typename V>
+V SlidingCacheMap<K, V>::Get(const K& key) {
+    std::lock_guard<std::mutex> lock(cache_lock);
+    std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+    if (auto itr = cache.find(key); itr != cache.end()) {
+        CacheEntry& entry = itr->second;
+        if (entry.expiry > now) {
+            // Update TTL & Return value
+            entry.expiry = now + entry.time_to_expire_ms;
+            return entry.value;
+        }
+        // Expired, remove from cache
+        cache.erase(itr);
+    }
+    return {};
+}
+
+template <typename K, typename V>
+bool SlidingCacheMap<K, V>::Find(const K& key) {
+    std::lock_guard<std::mutex> lock(cache_lock);
+    std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+    if (auto itr = cache.find(key); itr != cache.end()) {
+        CacheEntry& entry = itr->second;
+        if (entry.expiry > now) {
+            // Update TTL & Return found
+            entry.expiry = now + entry.time_to_expire_ms;
+            return true;
+        }
+        // Expired, remove from cache
+        cache.erase(itr);
+    }
+    return false;
+}
+
+template <typename K, typename V>
+unsigned int SlidingCacheMap<K, V>::Size() {
+    std::lock_guard<std::mutex> lock(cache_lock);
+    std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+    for (auto itr = cache.begin(); itr != cache.end();) {
+        if (itr->second.expiry < now) {
+            itr = cache.erase(itr);
+        } else {
+            itr++;
+        }
+    }
+    return cache.size();
+}
+
+template <typename K, typename V>
+void SlidingCacheMap<K, V>::Clear() {
+    std::lock_guard<std::mutex> lock(cache_lock);
+    cache.clear();
+}
+
+// Explicit Template Instantiations
+template class SlidingCacheMap<std::string, std::shared_ptr<round_robin_property::RoundRobinClusterInfo>>;
+template class SlidingCacheMap<std::string, std::string>;
+template class SlidingCacheMap<std::string, std::vector<HostInfo>>;

--- a/driver/util/sliding_cache_map.h
+++ b/driver/util/sliding_cache_map.h
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SLIDING_CACHE_MAP_H_
+#define SLIDING_CACHE_MAP_H_
+
+#include <chrono>
+#include <mutex>
+#include <unordered_map>
+
+template <typename K, typename V>
+class SlidingCacheMap {
+public:
+    SlidingCacheMap() = default;
+
+    void Put(const K& key, const V& value);
+    void Put(const K& key, const V& value, std::chrono::milliseconds ms_ttl);
+    void PutIfAbsent(const K& key, const V& value);
+    void PutIfAbsent(const K& key, const V& value, std::chrono::milliseconds ms_ttl);
+    V Get(const K& key);
+    bool Find(const K& key);
+    unsigned int Size();
+    void Clear();
+
+private:
+    struct CacheEntry {
+        V value;
+        std::chrono::steady_clock::time_point expiry;
+        std::chrono::milliseconds time_to_expire_ms;
+    };
+    static inline const std::chrono::milliseconds
+        DEFAULT_EXPIRATION_MS = std::chrono::minutes(15);
+    std::unordered_map<K, CacheEntry> cache;
+    std::mutex cache_lock;
+};
+
+#endif // SLIDING_CACHE_MAP_H_

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -28,10 +28,15 @@ set(TEST_SUITE
     ${CMAKE_CURRENT_SOURCE_DIR}/adfs_saml_util_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/auth_provider_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/connection_string_helper_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/highest_weight_host_selector_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/iam_auth_plugin_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/mock_objects.h
     ${CMAKE_CURRENT_SOURCE_DIR}/okta_auth_plugin_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/okta_saml_util_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/random_host_selector_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/round_robin_host_selector_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/secrets_manager_plugin_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sliding_cache_map_test.cpp
 )
 
 set(TEST_RUNNER

--- a/test/unit_test/highest_weight_host_selector_test.cpp
+++ b/test/unit_test/highest_weight_host_selector_test.cpp
@@ -1,0 +1,124 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../../driver/host_selector/highest_weight_host_selector.h"
+
+#include "../../driver/host_info.h"
+
+#include <unordered_map>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace {
+    constexpr int base_port = 1234;
+    HostInfo reader_host_info_a("reader_a", base_port, UP, false, HostInfo::DEFAULT_WEIGHT - 2);
+    HostInfo reader_host_info_b("reader_b", base_port, UP, false, HostInfo::DEFAULT_WEIGHT - 1);
+    HostInfo reader_host_info_c("reader_c", base_port, UP, false, HostInfo::DEFAULT_WEIGHT - 1);
+    HostInfo reader_host_info_down_a("reader_down_a", base_port, DOWN, false, HostInfo::DEFAULT_WEIGHT);
+    HostInfo reader_host_info_down_b("reader_down_b", base_port, DOWN, false, HostInfo::DEFAULT_WEIGHT + 1);
+    HostInfo writer_host_info_a("writer_a", base_port, UP, true, HostInfo::DEFAULT_WEIGHT - 2);
+    HostInfo writer_host_info_b("writer_b", base_port, UP, true, HostInfo::DEFAULT_WEIGHT - 1);
+    HostInfo writer_host_info_c("writer_c", base_port, UP, true, HostInfo::DEFAULT_WEIGHT - 1);
+    HostInfo writer_host_info_down_a("writer_down_a", base_port, DOWN, true, HostInfo::DEFAULT_WEIGHT);
+    HostInfo writer_host_info_down_b("writer_down_b", base_port, DOWN, true, HostInfo::DEFAULT_WEIGHT + 1);
+    std::vector<HostInfo> all_hosts = {
+        reader_host_info_a,
+        reader_host_info_b,
+        reader_host_info_c,
+        reader_host_info_down_a,
+        reader_host_info_down_b,
+        writer_host_info_a,
+        writer_host_info_b,
+        writer_host_info_c,
+        writer_host_info_down_a,
+        writer_host_info_down_b
+    };
+    std::unordered_map<std::string, std::string> empty_map;
+}
+
+class HighestWeightHostSelectorTest : public testing::Test {
+protected:
+    // Runs once per suite
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+    // Runs per test case
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(HighestWeightHostSelectorTest, get_highest_reader) {
+    HighestWeightHostSelector host_selector;
+    HostInfo host_info = host_selector.GetHost(all_hosts, false, empty_map);
+    EXPECT_EQ(reader_host_info_b.GetHost(), host_info.GetHost());
+}
+
+TEST_F(HighestWeightHostSelectorTest, get_highest_writer) {
+    HighestWeightHostSelector host_selector;
+    HostInfo host_info = host_selector.GetHost(all_hosts, true, empty_map);
+    EXPECT_EQ(writer_host_info_b.GetHost(), host_info.GetHost());
+}
+
+TEST_F(HighestWeightHostSelectorTest, get_reader_fail_all_writers) {
+    HighestWeightHostSelector host_selector;
+    std::vector<HostInfo> hosts = {
+        writer_host_info_a,
+        writer_host_info_b,
+        writer_host_info_c,
+        writer_host_info_down_a
+    };
+    EXPECT_THROW(host_selector.GetHost(hosts, false, empty_map), std::runtime_error);
+}
+
+TEST_F(HighestWeightHostSelectorTest, get_writer_fail_all_readers) {
+    HighestWeightHostSelector host_selector;
+    std::vector<HostInfo> hosts = {
+        reader_host_info_a,
+        reader_host_info_b,
+        reader_host_info_c,
+        reader_host_info_down_a
+    };
+    EXPECT_THROW(host_selector.GetHost(hosts, true, empty_map), std::runtime_error);
+}
+
+TEST_F(HighestWeightHostSelectorTest, get_reader_all_down) {
+    HighestWeightHostSelector host_selector;
+    std::vector<HostInfo> hosts = {
+        reader_host_info_down_a,
+        reader_host_info_down_b
+    };
+    EXPECT_THROW(host_selector.GetHost(hosts, false, empty_map), std::runtime_error);
+}
+
+TEST_F(HighestWeightHostSelectorTest, get_writer_all_down) {
+    HighestWeightHostSelector host_selector;
+    std::vector<HostInfo> hosts = {
+        writer_host_info_down_a,
+        writer_host_info_down_b
+    };
+    EXPECT_THROW(host_selector.GetHost(hosts, true, empty_map), std::runtime_error);
+}
+
+TEST_F(HighestWeightHostSelectorTest, get_reader_no_hosts) {
+    HighestWeightHostSelector host_selector;
+    std::vector<HostInfo> hosts = {};
+    EXPECT_THROW(host_selector.GetHost(hosts, false, empty_map), std::runtime_error);
+}
+
+TEST_F(HighestWeightHostSelectorTest, get_writer_no_hosts) {
+    HighestWeightHostSelector host_selector;
+    std::vector<HostInfo> hosts = {};
+    EXPECT_THROW(host_selector.GetHost(hosts, true, empty_map), std::runtime_error);
+}

--- a/test/unit_test/random_host_selector_test.cpp
+++ b/test/unit_test/random_host_selector_test.cpp
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../../driver/host_selector/random_host_selector.h"
+
+#include "../../driver/host_info.h"
+
+#include <unordered_map>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace {
+    constexpr int base_port = 1234;
+    HostInfo writer_host_info_a("writer_a", base_port, UP, true);
+    HostInfo writer_host_info_b("writer_b", base_port, UP, true);
+    HostInfo writer_host_info_down("writer_down", base_port, DOWN, true);
+    HostInfo reader_host_info_a("reader_a", base_port, UP, false);
+    HostInfo reader_host_info_b("reader_b", base_port, UP, false);
+    HostInfo reader_host_info_down("reader_down", base_port, DOWN, false);
+    std::unordered_map<std::string, std::string> empty_map;
+}
+
+class RandomHostSelectorTest : public testing::Test {
+  protected:
+    // Runs once per suite
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+    // Runs per test case
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(RandomHostSelectorTest, GetWriter) {
+    RandomHostSelector host_selector;
+    std::vector<HostInfo> hosts = {writer_host_info_a, reader_host_info_a, reader_host_info_b};
+    HostInfo host_info = host_selector.GetHost(hosts, true, empty_map);
+    EXPECT_EQ(writer_host_info_a.GetHost(), host_info.GetHost());
+}
+
+TEST_F(RandomHostSelectorTest, get_live_writer) {
+    RandomHostSelector host_selector;
+    std::vector<HostInfo> hosts = {writer_host_info_a, writer_host_info_down};
+    HostInfo host_info = host_selector.GetHost(hosts, true, empty_map);
+    EXPECT_EQ(writer_host_info_a.GetHost(), host_info.GetHost());
+}
+
+TEST_F(RandomHostSelectorTest, get_writer_from_many) {
+    RandomHostSelector host_selector;
+    std::vector<HostInfo> hosts = {writer_host_info_a, writer_host_info_b, writer_host_info_down,
+        reader_host_info_a, reader_host_info_b, reader_host_info_down};
+    HostInfo host_info = host_selector.GetHost(hosts, true, empty_map);
+    EXPECT_TRUE(host_info.IsHostWriter());
+    EXPECT_TRUE(host_info.IsHostUp());
+}
+
+TEST_F(RandomHostSelectorTest, get_writer_fail_all_readers) {
+    RandomHostSelector host_selector;
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+    EXPECT_THROW(host_selector.GetHost(hosts, true, empty_map), std::runtime_error);
+}
+
+TEST_F(RandomHostSelectorTest, get_reader_one_down) {
+    RandomHostSelector host_selector;
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_down};
+    HostInfo host_info = host_selector.GetHost(hosts, false, empty_map);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+}
+
+TEST_F(RandomHostSelectorTest, no_hosts) {
+    RandomHostSelector host_selector;
+    std::vector<HostInfo> hosts = {};
+    EXPECT_THROW(host_selector.GetHost(hosts, false, empty_map), std::runtime_error);
+}

--- a/test/unit_test/round_robin_host_selector_test.cpp
+++ b/test/unit_test/round_robin_host_selector_test.cpp
@@ -1,0 +1,296 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../../driver/host_selector/round_robin_host_selector.h"
+
+#include "../../driver/host_info.h"
+
+#include <unordered_map>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace {
+    const int base_port = 1234;
+    HostInfo writer_host_info_a("writer", base_port, HOST_STATE::UP, true, 1);
+    HostInfo reader_host_info_a("reader_a", base_port, HOST_STATE::UP, false, 1);
+    HostInfo reader_host_info_b("reader_b", base_port, HOST_STATE::UP, false, 1);
+    HostInfo reader_host_info_c("reader_c", base_port, HOST_STATE::UP, false, 1);
+    HostInfo reader_host_info_down("reader_down", base_port, HOST_STATE::DOWN, false, 1);
+}
+
+class RoundRobinHostSelectorTest : public testing::Test {
+  protected:
+    // Runs once per suite
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+    // Runs per test case
+    void SetUp() override {
+        RoundRobinHostSelector::ClearCache();
+    }
+    void TearDown() override {}
+};
+
+TEST_F(RoundRobinHostSelectorTest, GetWriter) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    std::vector<HostInfo> hosts = {writer_host_info_a, reader_host_info_a, reader_host_info_b};
+    HostInfo host_info = host_selector.GetHost(hosts, true, props);
+    EXPECT_EQ(writer_host_info_a.GetHost(), host_info.GetHost());
+}
+
+TEST_F(RoundRobinHostSelectorTest, get_writer_fail_all_readers) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+    EXPECT_THROW(host_selector.GetHost(hosts, true, props), std::runtime_error);
+}
+
+TEST_F(RoundRobinHostSelectorTest, get_reader_one_down) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    std::vector<HostInfo> hosts = {reader_host_info_down, reader_host_info_a};
+    HostInfo host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+}
+
+TEST_F(RoundRobinHostSelectorTest, no_hosts) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    std::vector<HostInfo> hosts = {};
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
+}
+
+TEST_F(RoundRobinHostSelectorTest, get_first_reader) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b, reader_host_info_c};
+    HostInfo host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+}
+
+TEST_F(RoundRobinHostSelectorTest, get_first_reader_unsorted_input) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    std::vector<HostInfo> hosts = {reader_host_info_c, reader_host_info_a, reader_host_info_b};
+    HostInfo host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+}
+
+TEST_F(RoundRobinHostSelectorTest, get_round_robin_readers_default) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+
+    HostInfo host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_b.GetHost(), host_info.GetHost());
+
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+}
+
+TEST_F(RoundRobinHostSelectorTest, get_round_robin_readers_weighted) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
+        reader_host_info_a.GetHost() + ":2"
+         + "," + reader_host_info_b.GetHost() + ":1"
+    );
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+
+    HostInfo host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_b.GetHost(), host_info.GetHost());
+
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+}
+
+TEST_F(RoundRobinHostSelectorTest, get_round_robin_readers_weighted_change) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
+        reader_host_info_a.GetHost() + ":2"
+         + "," + reader_host_info_b.GetHost() + ":1"
+    );
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+
+    HostInfo host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_b.GetHost(), host_info.GetHost());
+
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+
+    std::unordered_map<std::string, std::string> updated_props;
+    updated_props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
+        reader_host_info_a.GetHost() + ":1"
+         + "," + reader_host_info_b.GetHost() + ":2"
+    );
+
+    host_info = host_selector.GetHost(hosts, false, updated_props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+
+    host_info = host_selector.GetHost(hosts, false, updated_props);
+    EXPECT_EQ(reader_host_info_b.GetHost(), host_info.GetHost());
+    host_info = host_selector.GetHost(hosts, false, updated_props);
+    EXPECT_EQ(reader_host_info_b.GetHost(), host_info.GetHost());
+
+    host_info = host_selector.GetHost(hosts, false, updated_props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+}
+
+TEST_F(RoundRobinHostSelectorTest, set_round_robin_weight) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    std::string expected_weight_prop(
+        reader_host_info_a.GetHost() + ":" + std::to_string(reader_host_info_a.GetWeight())
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
+    );
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+    RoundRobinHostSelector::SetRoundRobinWeight(hosts, props);
+
+    std::string weight_prop = props.at(round_robin_property::HOST_WEIGHT_KEY);
+    EXPECT_STREQ(expected_weight_prop.c_str(), weight_prop.c_str());
+
+    HostInfo host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_b.GetHost(), host_info.GetHost());
+
+    host_info = host_selector.GetHost(hosts, false, props);
+    EXPECT_EQ(reader_host_info_a.GetHost(), host_info.GetHost());
+}
+
+TEST_F(RoundRobinHostSelectorTest, invalid_host_weight_empty_host) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
+        ":" + std::to_string(reader_host_info_a.GetWeight())
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
+    );
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
+}
+
+TEST_F(RoundRobinHostSelectorTest, invalid_host_weight_empty_weight) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
+        reader_host_info_a.GetHost() + ":"
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
+    );
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
+}
+
+TEST_F(RoundRobinHostSelectorTest, invalid_host_weight_zero_weight) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
+        reader_host_info_a.GetHost() + ":0"
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
+    );
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
+}
+
+TEST_F(RoundRobinHostSelectorTest, invalid_host_weight_negative_weight) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
+        reader_host_info_a.GetHost() + ":-1"
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
+    );
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
+}
+
+TEST_F(RoundRobinHostSelectorTest, invalid_host_weight_float_weight) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
+        reader_host_info_a.GetHost() + ":1.1"
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
+    );
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
+}
+
+TEST_F(RoundRobinHostSelectorTest, invalid_host_weight_non_int_weight) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
+        reader_host_info_a.GetHost() + ":one"
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
+    );
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
+}
+
+TEST_F(RoundRobinHostSelectorTest, invalid_host_weight_format) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    props[round_robin_property::HOST_WEIGHT_KEY] = std::string(
+        reader_host_info_a.GetHost() + ":111:" + std::to_string(reader_host_info_a.GetWeight())
+         + "," + reader_host_info_b.GetHost() + ":" + std::to_string(reader_host_info_b.GetWeight())
+    );
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
+}
+
+TEST_F(RoundRobinHostSelectorTest, invalid_default_zero) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    props[round_robin_property::DEFAULT_WEIGHT_KEY] = std::string("0");
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
+}
+
+TEST_F(RoundRobinHostSelectorTest, invalid_default_negative) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    props[round_robin_property::DEFAULT_WEIGHT_KEY] = std::string("-100");
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
+}
+
+TEST_F(RoundRobinHostSelectorTest, invalid_default_float) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    props[round_robin_property::DEFAULT_WEIGHT_KEY] = std::string("1.1");
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
+}
+
+TEST_F(RoundRobinHostSelectorTest, invalid_default_non_int) {
+    RoundRobinHostSelector host_selector;
+    std::unordered_map<std::string, std::string> props;
+    props[round_robin_property::DEFAULT_WEIGHT_KEY] = std::string("one");
+    std::vector<HostInfo> hosts = {reader_host_info_a, reader_host_info_b};
+    EXPECT_THROW(host_selector.GetHost(hosts, false, props), std::runtime_error);
+}

--- a/test/unit_test/sliding_cache_map_test.cpp
+++ b/test/unit_test/sliding_cache_map_test.cpp
@@ -1,0 +1,159 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../../driver/util/sliding_cache_map.h"
+
+#include <string>
+#include <thread>
+#include <chrono>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace {
+    const std::string cache_key_a("key_a");
+    const std::string cache_key_b("key_b");
+    const std::string cache_val_a("val_a");
+    const std::string cache_val_b("val_b");
+    const std::string cache_empty("");
+    const std::chrono::milliseconds cache_exp_short(std::chrono::seconds(3));
+    const std::chrono::milliseconds cache_exp_mid(std::chrono::seconds(5));
+    const std::chrono::milliseconds cache_exp_long(std::chrono::seconds(6000));
+}
+
+class SlidingCacheMapTest : public testing::Test {
+  protected:
+    // Runs once per suite
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+    // Runs per test case
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(SlidingCacheMapTest, put_cache) {
+    SlidingCacheMap<std::string, std::string> cache;
+    cache.Put(cache_key_a, cache_val_a);
+    cache.Put(cache_key_b, cache_val_b, cache_exp_long);
+    EXPECT_STREQ(cache_val_a.c_str(), cache.Get(cache_key_a).c_str());
+    EXPECT_STREQ(cache_val_b.c_str(), cache.Get(cache_key_b).c_str());
+}
+
+TEST_F(SlidingCacheMapTest, put_cache_update) {
+    SlidingCacheMap<std::string, std::string> cache;
+    EXPECT_EQ(0, cache.Size());
+    cache.Put(cache_key_a, cache_val_a);
+    cache.Put(cache_key_b, cache_val_b, cache_exp_short);
+    EXPECT_EQ(2, cache.Size());
+    EXPECT_STREQ(cache_val_b.c_str(), cache.Get(cache_key_b).c_str());
+
+    cache.Put(cache_key_b, cache_val_b, cache_exp_long);
+    std::this_thread::sleep_for(cache_exp_mid);
+    EXPECT_EQ(2, cache.Size());
+    EXPECT_STREQ(cache_val_b.c_str(), cache.Get(cache_key_b).c_str());
+}
+
+TEST_F(SlidingCacheMapTest, get_cache_hit) {
+    SlidingCacheMap<std::string, std::string> cache;
+    cache.Put(cache_key_a, cache_val_a);
+    EXPECT_STREQ(cache_val_a.c_str(), cache.Get(cache_key_a).c_str());
+}
+
+TEST_F(SlidingCacheMapTest, get_cache_miss) {
+    SlidingCacheMap<std::string, std::string> cache;
+    EXPECT_STREQ(cache_empty.c_str(), cache.Get(cache_key_a).c_str());
+}
+
+TEST_F(SlidingCacheMapTest, get_cache_expire) {
+    SlidingCacheMap<std::string, std::string> cache;
+    cache.Put(cache_key_a, cache_val_a, cache_exp_short);
+    std::this_thread::sleep_for(cache_exp_mid);
+    EXPECT_STREQ(cache_empty.c_str(), cache.Get(cache_key_a).c_str());
+}
+
+TEST_F(SlidingCacheMapTest, find_cache_miss) {
+    SlidingCacheMap<std::string, std::string> cache;
+    EXPECT_FALSE(cache.Find("Missing"));
+}
+
+TEST_F(SlidingCacheMapTest, find_cache_hit) {
+    SlidingCacheMap<std::string, std::string> cache;
+    cache.Put(cache_key_a, cache_val_a);
+    EXPECT_TRUE(cache.Find(cache_key_a));
+}
+
+TEST_F(SlidingCacheMapTest, cache_size) {
+    SlidingCacheMap<std::string, std::string> cache;
+    EXPECT_EQ(0, cache.Size());
+    cache.Put(cache_key_a, cache_val_a);
+    cache.Put(cache_key_b, cache_val_b);
+    EXPECT_EQ(2, cache.Size());
+}
+
+TEST_F(SlidingCacheMapTest, cache_size_expire) {
+    SlidingCacheMap<std::string, std::string> cache;
+    EXPECT_EQ(0, cache.Size());
+    cache.Put(cache_key_a, cache_val_a, cache_exp_short);
+    cache.Put(cache_key_b, cache_val_b, cache_exp_short);
+    EXPECT_EQ(2, cache.Size());
+    std::this_thread::sleep_for(cache_exp_mid);
+    EXPECT_EQ(0, cache.Size());
+}
+
+TEST_F(SlidingCacheMapTest, cache_clear) {
+    SlidingCacheMap<std::string, std::string> cache;
+    cache.Put(cache_key_a, cache_val_a);
+    cache.Put(cache_key_b, cache_val_b);
+    EXPECT_EQ(2, cache.Size());
+    cache.Clear();
+    EXPECT_EQ(0, cache.Size());
+}
+
+TEST_F(SlidingCacheMapTest, ttl_update_find) {
+    SlidingCacheMap<std::string, std::string> cache;
+    EXPECT_EQ(0, cache.Size());
+    cache.Put(cache_key_a, cache_val_a, cache_exp_mid);
+    EXPECT_EQ(1, cache.Size());
+
+    std::this_thread::sleep_for(cache_exp_short);
+
+    // Touch to refresh TTL
+    EXPECT_TRUE(cache.Find(cache_key_a));
+
+    // Sleep again combined with previous to expire original put
+    std::this_thread::sleep_for(cache_exp_short);
+
+    // Should be valid due to earlier `find()` updates TTL
+    EXPECT_EQ(1, cache.Size());
+    EXPECT_STREQ(cache_val_a.c_str(), cache.Get(cache_key_a).c_str());
+}
+
+TEST_F(SlidingCacheMapTest, ttl_update_get) {
+    SlidingCacheMap<std::string, std::string> cache;
+    EXPECT_EQ(0, cache.Size());
+    cache.Put(cache_key_a, cache_val_a, cache_exp_mid);
+    EXPECT_EQ(1, cache.Size());
+
+    std::this_thread::sleep_for(cache_exp_short);
+
+    // Touch to refresh TTL
+    EXPECT_STREQ(cache_val_a.c_str(), cache.Get(cache_key_a).c_str());
+
+    // Sleep again combined with previous to expire original put
+    std::this_thread::sleep_for(cache_exp_short);
+
+    // Should be valid due to earlier `get()` updates TTL
+    EXPECT_EQ(1, cache.Size());
+    EXPECT_STREQ(cache_val_a.c_str(), cache.Get(cache_key_a).c_str());
+}


### PR DESCRIPTION
### Summary

Adds Host Selector Strategies

### Description

- Added Host Info
- Added Sliding Expiration Cache
- Added Host Selector Strategy for
  - Random
  - Highest Weight
  - and Round Robin
- Included Dialect for Aurora PostgreSQL 

### Testing

- Additional unit tests added for new files

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
