### PR TITLE
bug: sql error always empty

### DIFF
--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -652,18 +652,19 @@ SQLRETURN RDS_SQLError(
 
     // Take in order of lowest to high
     //  Stmt > Dbc > Env
+    // SQLError is deprecated, if called directly, return the first error
     if (StatementHandle) {
-        ret = RDS_SQLGetDiagRec(SQL_HANDLE_STMT, StatementHandle, 0,
+        ret = RDS_SQLGetDiagRec(SQL_HANDLE_STMT, StatementHandle, 1,
             SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
         );
     }
     else if (ConnectionHandle) {
-        ret = RDS_SQLGetDiagRec(SQL_HANDLE_DBC, ConnectionHandle, 0,
+        ret = RDS_SQLGetDiagRec(SQL_HANDLE_DBC, ConnectionHandle, 1,
             SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
         );
     }
     else if (EnvironmentHandle) {
-        ret = RDS_SQLGetDiagRec(SQL_HANDLE_ENV, EnvironmentHandle, 0,
+        ret = RDS_SQLGetDiagRec(SQL_HANDLE_ENV, EnvironmentHandle, 1,
             SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
         );
     }


### PR DESCRIPTION
### Summary

SQLError to use RecNumber 1

### Description

Changes the way SQLError calls SQLGetDiagRec to use RecNumber 1. Previously at 0, this would always return SQL_NO_DATA. 

### Testing

Manual testing
- Calling directly (RDS_SQLError) before any other calls
- Calling directly (RDS_SQLError) after any expected errors (e.g. connection bad password)
- For both, call single and multiple times (without any changes, e.g. no additional calls). Expected to have the same results

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
