### PR TITLE
fix: unixodbc sqlerror

### DIFF
--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -763,19 +763,21 @@ SQLRETURN RDS_SQLError(
 
     // Take in order of lowest to high
     //  Stmt > Dbc > Env
-    // SQLError is deprecated, if called directly, return the first error
+    // SQLError is deprecated, if called directly,
+    //  return the first error only once
+    //  UnixODBC will enter an infinite loop otherwise
     if (StatementHandle) {
-        ret = RDS_SQLGetDiagRec(SQL_HANDLE_STMT, StatementHandle, 1,
+        ret = RDS_SQLGetDiagRec(SQL_HANDLE_STMT, StatementHandle, NEXT_STMT_ERROR(StatementHandle),
             SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
         );
     }
     else if (ConnectionHandle) {
-        ret = RDS_SQLGetDiagRec(SQL_HANDLE_DBC, ConnectionHandle, 1,
+        ret = RDS_SQLGetDiagRec(SQL_HANDLE_DBC, ConnectionHandle, NEXT_DBC_ERROR(ConnectionHandle),
             SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
         );
     }
     else if (EnvironmentHandle) {
-        ret = RDS_SQLGetDiagRec(SQL_HANDLE_ENV, EnvironmentHandle, 1,
+        ret = RDS_SQLGetDiagRec(SQL_HANDLE_ENV, EnvironmentHandle, NEXT_ENV_ERROR(EnvironmentHandle),
             SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
         );
     }


### PR DESCRIPTION
### Summary

Fixes the infinite loop caused by SQLError when using unixODBC

### Description

When using `iusql`, a shell tool for connecting using unixODBC, original code will loop infinitely getting the same error. Changed to return the error at most one time when calling deprecated function SQLError

### Testing

Ran iusql with invalid connection string, no base driver.

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
