### PR TITLE
feat: add IAM_HOST parameter to iam, adfs and okta plugins

### DIFF
--- a/driver/plugin/federated/okta_auth_plugin.cpp
+++ b/driver/plugin/federated/okta_auth_plugin.cpp
@@ -65,6 +65,8 @@ SQLRETURN OktaAuthPlugin::Connect(
 
     std::string server = dbc->conn_attr.contains(KEY_SERVER) ?
         ToStr(dbc->conn_attr.at(KEY_SERVER)) : "";
+    std::string iam_host = dbc->conn_attr.contains(KEY_IAM_HOST) ?
+        ToStr(dbc->conn_attr.at(KEY_IAM_HOST)) : server;
     // TODO - Helper to parse from URL
     std::string region = dbc->conn_attr.contains(KEY_REGION) ?
         ToStr(dbc->conn_attr.at(KEY_REGION)) : Aws::Region::US_EAST_1;
@@ -78,7 +80,7 @@ SQLRETURN OktaAuthPlugin::Connect(
         dbc->conn_attr.at(KEY_EXTRA_URL_ENCODE) == VALUE_BOOL_TRUE : false;
 
     // TODO - Proper error handling for missing parameters
-    std::pair<std::string, bool> token = auth_provider->GetToken(server, region, port, username, true, extra_url_encode, token_expiration);
+    std::pair<std::string, bool> token = auth_provider->GetToken(iam_host, region, port, username, true, extra_url_encode, token_expiration);
 
     SQLRETURN ret = SQL_ERROR;
 
@@ -93,7 +95,7 @@ SQLRETURN OktaAuthPlugin::Connect(
         Aws::Auth::AWSCredentials credentials = saml_util->GetAwsCredentials(saml_assertion);
         auth_provider->UpdateAwsCredential(credentials);
         //  and retry without cache
-        token = auth_provider->GetToken(server, region, port, username, false, extra_url_encode, token_expiration);
+        token = auth_provider->GetToken(iam_host, region, port, username, false, extra_url_encode, token_expiration);
         dbc->conn_attr.insert_or_assign(KEY_DB_PASSWORD, ToRdsStr(token.first));
         ret = next_plugin->Connect(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
     }

--- a/test/unit_test/adfs_auth_plugin_test.cpp
+++ b/test/unit_test/adfs_auth_plugin_test.cpp
@@ -84,6 +84,27 @@ TEST_F(AdfsAuthPluginTest, Connect_Success) {
     EXPECT_STREQ(token_info.first.c_str(), ToStr(dbc->conn_attr.at(KEY_DB_PASSWORD)).c_str());
 }
 
+TEST_F(AdfsAuthPluginTest, Connect_Success_IAM_Host) {
+    std::string test_iam_host = "test-host";
+    std::pair<std::string, bool> token_info("cached_token", true);
+    EXPECT_CALL(
+        *mock_auth_provider,
+        GetToken(test_iam_host, testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillRepeatedly(testing::Return(token_info));
+    EXPECT_CALL(
+        *mock_base_plugin,
+        Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillOnce(testing::Return(SQL_SUCCESS));
+
+    dbc->conn_attr.insert_or_assign(KEY_IAM_HOST, ToStr(test_iam_host));
+    AdfsAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider);
+    SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_SUCCESS, ret);
+    EXPECT_STREQ(token_info.first.c_str(), ToStr(dbc->conn_attr.at(KEY_DB_PASSWORD)).c_str());
+}
+
 TEST_F(AdfsAuthPluginTest, Connect_Success_CacheExpire) {
     std::pair<std::string, bool> expired_token_info("expired_cached_token", true);
     std::pair<std::string, bool> valid_token_info("fresh_token", false);

--- a/test/unit_test/iam_auth_plugin_test.cpp
+++ b/test/unit_test/iam_auth_plugin_test.cpp
@@ -88,6 +88,27 @@ TEST_F(IamAuthPluginTest, Connect_Success) {
     EXPECT_STREQ(token_info.first.c_str(), ToStr(dbc->conn_attr.at(KEY_DB_PASSWORD)).c_str());
 }
 
+TEST_F(IamAuthPluginTest, Connect_Success_IAM_HOST) {
+    std::string test_iam_host = "test-host";
+    std::pair<std::string, bool> token_info("cached_token", true);
+    EXPECT_CALL(
+        *mock_auth_provider,
+        GetToken(test_iam_host, testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillRepeatedly(testing::Return(token_info));
+    EXPECT_CALL(
+        *mock_base_plugin,
+        Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillOnce(testing::Return(SQL_SUCCESS));
+
+    dbc->conn_attr.insert_or_assign(KEY_IAM_HOST, ToStr(test_iam_host));
+    IamAuthPlugin plugin(dbc, mock_base_plugin, mock_auth_provider);
+    SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_SUCCESS, ret);
+    EXPECT_STREQ(token_info.first.c_str(), ToStr(dbc->conn_attr.at(KEY_DB_PASSWORD)).c_str());
+}
+
 TEST_F(IamAuthPluginTest, Connect_Success_CacheExpire) {
     std::pair<std::string, bool> expired_token_info("expired_cached_token", true);
     std::pair<std::string, bool> valid_token_info("fresh_token", false);

--- a/test/unit_test/okta_auth_plugin_test.cpp
+++ b/test/unit_test/okta_auth_plugin_test.cpp
@@ -84,6 +84,27 @@ TEST_F(OktaAuthPluginTest, Connect_Success) {
     EXPECT_STREQ(token_info.first.c_str(), ToStr(dbc->conn_attr.at(KEY_DB_PASSWORD)).c_str());
 }
 
+TEST_F(OktaAuthPluginTest, Connect_Success_IAM_HOST) {
+    std::string test_iam_host = "test-host";
+    std::pair<std::string, bool> token_info("cached_token", true);
+    EXPECT_CALL(
+        *mock_auth_provider,
+        GetToken(test_iam_host, testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillRepeatedly(testing::Return(token_info));
+    EXPECT_CALL(
+        *mock_base_plugin,
+        Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillOnce(testing::Return(SQL_SUCCESS));
+
+    dbc->conn_attr.insert_or_assign(KEY_IAM_HOST, ToStr(test_iam_host));
+    OktaAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider);
+    SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_SUCCESS, ret);
+    EXPECT_STREQ(token_info.first.c_str(), ToStr(dbc->conn_attr.at(KEY_DB_PASSWORD)).c_str());
+}
+
 TEST_F(OktaAuthPluginTest, Connect_Success_CacheExpire) {
     std::pair<std::string, bool> expired_token_info("expired_cached_token", true);
     std::pair<std::string, bool> valid_token_info("fresh_token", false);


### PR DESCRIPTION
### Summary

Add IAM_HOST parameter to IAM, ADFS and Okta plugins

### Description

Checks for the existence of the IAM_HOST key in the IAM, ADFS and Okta plugins and uses it to generate tokens. The plugins default to the server if it does not exist.

### Testing

Unit tests added for the plugins, manual testing for IAM, Okta

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
