### PR TITLE
fix: parse region from host

### DIFF
--- a/driver/plugin/federated/adfs_auth_plugin.cpp
+++ b/driver/plugin/federated/adfs_auth_plugin.cpp
@@ -21,6 +21,7 @@
 #include "../../util/aws_sdk_helper.h"
 #include "../../util/connection_string_keys.h"
 #include "../../util/logger_wrapper.h"
+#include "../../util/rds_utils.h"
 #include "saml_util.h"
 
 AdfsAuthPlugin::AdfsAuthPlugin(DBC *dbc) : AdfsAuthPlugin(dbc, nullptr) {}
@@ -41,7 +42,10 @@ AdfsAuthPlugin::AdfsAuthPlugin(DBC *dbc, BasePlugin *next_plugin, std::shared_pt
         this->auth_provider = auth_provider;
     } else {
         std::string region = dbc->conn_attr.contains(KEY_REGION) ?
-            ToStr(dbc->conn_attr.at(KEY_REGION)) : Aws::Region::US_EAST_1;
+            ToStr(dbc->conn_attr.at(KEY_REGION)) :
+            dbc->conn_attr.contains(KEY_SERVER) ?
+                RdsUtils::GetRdsRegion(ToStr(dbc->conn_attr.at(KEY_SERVER))) :
+                Aws::Region::US_EAST_1;
         std::string saml_assertion = this->saml_util->GetSamlAssertion();
         this->auth_provider = std::make_shared<AuthProvider>(region, this->saml_util->GetAwsCredentials(saml_assertion));
     }
@@ -67,9 +71,11 @@ SQLRETURN AdfsAuthPlugin::Connect(
         ToStr(dbc->conn_attr.at(KEY_SERVER)) : "";
     std::string iam_host = dbc->conn_attr.contains(KEY_IAM_HOST) ?
         ToStr(dbc->conn_attr.at(KEY_IAM_HOST)) : server;
-    // TODO - Helper to parse from URL
     std::string region = dbc->conn_attr.contains(KEY_REGION) ?
-        ToStr(dbc->conn_attr.at(KEY_REGION)) : Aws::Region::US_EAST_1;
+        ToStr(dbc->conn_attr.at(KEY_REGION)) :
+        dbc->conn_attr.contains(KEY_SERVER) ?
+            RdsUtils::GetRdsRegion(ToStr(dbc->conn_attr.at(KEY_SERVER))) :
+            Aws::Region::US_EAST_1;
     std::string port = dbc->conn_attr.contains(KEY_PORT) ?
         ToStr(dbc->conn_attr.at(KEY_PORT)) : "";
     std::string username = dbc->conn_attr.contains(KEY_DB_USERNAME) ?

--- a/driver/plugin/federated/saml_util.cpp
+++ b/driver/plugin/federated/saml_util.cpp
@@ -20,6 +20,7 @@
 #include "../../util/connection_string_keys.h"
 #include "../../util/logger_wrapper.h"
 #include "../../util/rds_strings.h"
+#include "../../util/rds_utils.h"
 
 SamlUtil::SamlUtil(std::map<RDS_STR, RDS_STR> connection_attributes)
     : SamlUtil(connection_attributes, nullptr, nullptr) {}
@@ -54,7 +55,10 @@ SamlUtil::SamlUtil(
         this->sts_client = sts_client;
     } else {
         std::string region = connection_attributes.contains(KEY_REGION) ?
-            ToStr(connection_attributes.at(KEY_REGION)) : Aws::Region::US_EAST_1;
+            ToStr(connection_attributes.at(KEY_REGION)) :
+            connection_attributes.contains(KEY_SERVER) ?
+                RdsUtils::GetRdsRegion(ToStr(connection_attributes.at(KEY_SERVER))) :
+                Aws::Region::US_EAST_1;
         Aws::STS::STSClientConfiguration sts_client_config;
         sts_client_config.region = region;
         this->sts_client = std::make_shared<Aws::STS::STSClient>(sts_client_config);

--- a/test/unit_test/adfs_auth_plugin_test.cpp
+++ b/test/unit_test/adfs_auth_plugin_test.cpp
@@ -105,6 +105,27 @@ TEST_F(AdfsAuthPluginTest, Connect_Success_IAM_Host) {
     EXPECT_STREQ(token_info.first.c_str(), ToStr(dbc->conn_attr.at(KEY_DB_PASSWORD)).c_str());
 }
 
+TEST_F(AdfsAuthPluginTest, Connect_Success_Empty_Region) {
+    dbc->conn_attr.insert_or_assign(KEY_SERVER, "mydbname.cluster-xyz.us-east-2.rds.amazonaws.com");
+    dbc->conn_attr.erase(KEY_REGION);
+    std::pair<std::string, bool> token_info("cached_token", true);
+    EXPECT_CALL(
+        *mock_auth_provider,
+        GetToken(testing::_, "us-east-2", testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillRepeatedly(testing::Return(token_info));
+    EXPECT_CALL(
+        *mock_base_plugin,
+        Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillOnce(testing::Return(SQL_SUCCESS));
+
+    AdfsAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider);
+    SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_SUCCESS, ret);
+    EXPECT_STREQ(token_info.first.c_str(), ToStr(dbc->conn_attr.at(KEY_DB_PASSWORD)).c_str());
+}
+
 TEST_F(AdfsAuthPluginTest, Connect_Success_CacheExpire) {
     std::pair<std::string, bool> expired_token_info("expired_cached_token", true);
     std::pair<std::string, bool> valid_token_info("fresh_token", false);

--- a/test/unit_test/iam_auth_plugin_test.cpp
+++ b/test/unit_test/iam_auth_plugin_test.cpp
@@ -88,6 +88,27 @@ TEST_F(IamAuthPluginTest, Connect_Success) {
     EXPECT_STREQ(token_info.first.c_str(), ToStr(dbc->conn_attr.at(KEY_DB_PASSWORD)).c_str());
 }
 
+TEST_F(IamAuthPluginTest, Connect_Success_Empty_Region) {
+    dbc->conn_attr.insert_or_assign(KEY_SERVER, "mydbname.cluster-xyz.us-east-2.rds.amazonaws.com");
+    dbc->conn_attr.erase(KEY_REGION);
+    std::pair<std::string, bool> token_info("cached_token", true);
+    EXPECT_CALL(
+        *mock_auth_provider,
+        GetToken(testing::_, "us-east-2", testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillRepeatedly(testing::Return(token_info));
+    EXPECT_CALL(
+        *mock_base_plugin,
+        Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillOnce(testing::Return(SQL_SUCCESS));
+
+    IamAuthPlugin plugin(dbc, mock_base_plugin, mock_auth_provider);
+    SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_SUCCESS, ret);
+    EXPECT_STREQ(token_info.first.c_str(), ToStr(dbc->conn_attr.at(KEY_DB_PASSWORD)).c_str());
+}
+
 TEST_F(IamAuthPluginTest, Connect_Success_IAM_HOST) {
     std::string test_iam_host = "test-host";
     std::pair<std::string, bool> token_info("cached_token", true);

--- a/test/unit_test/okta_auth_plugin_test.cpp
+++ b/test/unit_test/okta_auth_plugin_test.cpp
@@ -84,6 +84,27 @@ TEST_F(OktaAuthPluginTest, Connect_Success) {
     EXPECT_STREQ(token_info.first.c_str(), ToStr(dbc->conn_attr.at(KEY_DB_PASSWORD)).c_str());
 }
 
+TEST_F(OktaAuthPluginTest, Connect_Success_Empty_Region) {
+    dbc->conn_attr.insert_or_assign(KEY_SERVER, "mydbname.cluster-xyz.us-east-2.rds.amazonaws.com");
+    dbc->conn_attr.erase(KEY_REGION);
+    std::pair<std::string, bool> token_info("cached_token", true);
+    EXPECT_CALL(
+        *mock_auth_provider,
+        GetToken(testing::_, "us-east-2", testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillRepeatedly(testing::Return(token_info));
+    EXPECT_CALL(
+        *mock_base_plugin,
+        Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillOnce(testing::Return(SQL_SUCCESS));
+
+    OktaAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider);
+    SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_SUCCESS, ret);
+    EXPECT_STREQ(token_info.first.c_str(), ToStr(dbc->conn_attr.at(KEY_DB_PASSWORD)).c_str());
+}
+
 TEST_F(OktaAuthPluginTest, Connect_Success_IAM_HOST) {
     std::string test_iam_host = "test-host";
     std::pair<std::string, bool> token_info("cached_token", true);


### PR DESCRIPTION
### Summary

Detect region from host

### Description

- Changes the default region if the region key is not provided to be detected from the server. If the server key value is also not present, the region `us-east-1` will be used

### Testing

Unit tests added

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
