### PR TITLE
chore: fix macos-15 GitHub Actions build

### DIFF
--- a/.github/workflows/compatibility_test.yaml
+++ b/.github/workflows/compatibility_test.yaml
@@ -43,7 +43,7 @@ jobs:
 
   build-macos-psqlodbc:
     name: MacOS - Build psqlODBC
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
@@ -198,7 +198,7 @@ jobs:
   test-macos-compat:
     name: MacOS - Compatibility Test
     needs: [build-macos-psqlodbc]
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
         uses: actions/checkout@v4
@@ -213,12 +213,11 @@ jobs:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}
       - name: Build AWS SDK for C++
-        if: ${{steps.cache-aws-sdk.outputs.cache-hit != 'true'}}
         run: |
-          ./scripts/compile_aws_sdk_unix.sh ${{env.BUILD_CONFIG}}
+          ./scripts/compile_aws_sdk_unix.sh ${{env.BUILD_CONFIG}} "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
       - name: Build aws-advanced-odbc-wrapper
         run: |
-          cmake -S . -B build -DBUILD_UNICODE=OFF -DBUILD_UNIT_TEST=OFF
+          cmake -S . -B build -DBUILD_UNICODE=OFF -DBUILD_UNIT_TEST=OFF -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/
           cmake --build build
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -57,7 +57,7 @@ jobs:
 
   test-macos-unit:
     name: MacOS - Unit Test
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
         uses: actions/checkout@v4
@@ -72,12 +72,11 @@ jobs:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}
       - name: Build AWS SDK for C++
-        if: ${{steps.cache-aws-sdk-cpp.outputs.cache-hit != 'true'}}
         run: |
-          ./scripts/compile_aws_sdk_unix.sh Release
+          ./scripts/compile_aws_sdk_unix.sh Release "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
       - name: Build aws-advanced-odbc-wrapper
         run: |
-          cmake -S . -B build -DBUILD_UNICODE=OFF -DBUILD_UNIT_TEST=ON
+          cmake -S . -B build -DBUILD_UNICODE=OFF -DBUILD_UNIT_TEST=ON -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/
           cmake --build build
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/scripts/compile_aws_sdk_unix.sh
+++ b/scripts/compile_aws_sdk_unix.sh
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 CONFIGURATION=$1    # Debug/Release
+PLATFORM_SDK=$2
 
 export ROOT_REPO_PATH=$(cd "$(dirname "$0")/.."; pwd -P)
 
@@ -36,7 +37,8 @@ cmake -S ${SRC_DIR} \
     -D ENABLE_TESTING="OFF" \
     -D CPP_STANDARD="20" \
     -D BUILD_SHARED_LIBS="OFF" \
-    -D FORCE_SHARED_CRT="ON"
+    -D FORCE_SHARED_CRT="ON" \
+    -D CMAKE_OSX_SYSROOT=${PLATFORM_SDK}
 
 cmake --build . --config=${CONFIGURATION}
 cmake --install . --config=${CONFIGURATION}


### PR DESCRIPTION
### Summary

Fix GitHub actions failing mac builds on macos-15

### Description

- Uses the `CMAKE_OSX_SYSROOT` flag to specify the platform sdk

### Testing

<!-- What did you test and how did you test it -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
