### PR TITLE
fix: ensure SQLDriverConnect conforms to ODBC standards

### DIFF
--- a/driver/gui/setup.cpp
+++ b/driver/gui/setup.cpp
@@ -159,6 +159,7 @@ std::string driver;
 std::string current_dsn;
 std::string connection_str;
 std::string out_connection_str;
+bool dialog_box_cancelled = false;
 bool driver_connect = false;
 bool disable_optional = false;
 
@@ -739,6 +740,7 @@ void HandleGuiInteraction(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify)
             ChooseFile(main_win, IDC_BASE_DRIVER);
             break;
         case IDCANCEL:
+            dialog_box_cancelled = true;
             if (codeNotify == BN_CLICKED) {
                 if (driver_connect) {
                     connection_str = GetDsn(true);
@@ -877,7 +879,7 @@ void GetDriverFromConnectionString(std::string conn_str, HWND hwndParent) {
     }
 }
 
-std::pair<std::string, std::string> StartDialogForSqlDriverConnect(HWND hwnd, SQLTCHAR* InConnectionString, SQLTCHAR* OutConnectionString, bool complete_required) {
+std::tuple<std::string, std::string, bool> StartDialogForSqlDriverConnect(HWND hwnd, SQLTCHAR* InConnectionString, SQLTCHAR* OutConnectionString, bool complete_required) {
     connection_str = "";
     out_connection_str = "";
     driver_connect = true;
@@ -892,7 +894,7 @@ std::pair<std::string, std::string> StartDialogForSqlDriverConnect(HWND hwnd, SQ
         // Check for DSN and DRIVER from the connection string.
         GetDsnFromConnectionString(converted_str, hwnd);
         if (!current_dsn.empty() || !driver.empty()) {
-            return { converted_str, converted_str };
+            return { converted_str, converted_str, false };
         }
     }
 
@@ -901,7 +903,7 @@ std::pair<std::string, std::string> StartDialogForSqlDriverConnect(HWND hwnd, SQ
 
     driver_connect = false;
     disable_optional = false;
-    return { connection_str, out_connection_str };
+    return { connection_str, out_connection_str, dialog_box_cancelled };
 }
 #endif
 

--- a/driver/gui/setup.h
+++ b/driver/gui/setup.h
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-std::pair<std::string, std::string> StartDialogForSqlDriverConnect(HWND hwnd, SQLTCHAR* InConnectionString, SQLTCHAR* OutConnectionString, bool complete_required);
+std::tuple<std::string, std::string, bool> StartDialogForSqlDriverConnect(HWND hwnd, SQLTCHAR* InConnectionString, SQLTCHAR* OutConnectionString, bool complete_required);

--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -668,7 +668,7 @@ SQLRETURN RDS_SQLDriverConnect(
     if (DriverCompletion && WindowHandle) {
 #if !defined(UNICODE) && defined(_WIN32)
         bool complete_required = true;
-        std::pair<std::string, std::string> dialog_result;
+        std::tuple<std::string, std::string, bool> dialog_result; // conn_str, out_conn_str, dialog_box_cancelled
 
         switch (DriverCompletion) {
             case SQL_DRIVER_PROMPT:
@@ -676,13 +676,19 @@ SQLRETURN RDS_SQLDriverConnect(
                 complete_required = false;
             case SQL_DRIVER_COMPLETE_REQUIRED:
                 dialog_result = StartDialogForSqlDriverConnect(WindowHandle, InConnectionString, OutConnectionString, complete_required);
-                RDS_sprintf(conn_str, sizeof(conn_str), RDS_CHAR_FORMAT, dialog_result.first.c_str());
-                RDS_sprintf(out_conn_str, sizeof(out_conn_str), RDS_CHAR_FORMAT, dialog_result.second.c_str());
+                RDS_sprintf(conn_str, sizeof(conn_str), RDS_CHAR_FORMAT, std::get<0>(dialog_result).c_str());
+                RDS_sprintf(out_conn_str, sizeof(out_conn_str), RDS_CHAR_FORMAT, std::get<1>(dialog_result).c_str());
                 break;
             case SQL_DRIVER_NOPROMPT:
             default:
                 break;
         }
+
+        if (std::get<2>(dialog_result)) {
+            // If a dialog box was opened but cancelled mid-operation, do not continue with the connection attempt.
+            return SQL_NO_DATA_FOUND;
+        }
+
 #endif
     } else {
         RDS_sprintf((RDS_CHAR*)conn_str, MAX_KEY_SIZE, RDS_CHAR_FORMAT, (RDS_CHAR*)InConnectionString);


### PR DESCRIPTION
### Summary

Ensure the way wrapper handles DriverCompletion conforms to ODBC standards:
https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldriverconnect-function?view=sql-server-ver17#driver-manager-guidelines

> The action of the Driver Manager is based on the value of the DriverCompletion argument:
> 
> SQL_DRIVER_PROMPT: If the connection string does not contain either the DRIVER, DSN, or FILEDSN keyword, the Driver Manager displays the Data Sources dialog box. It constructs a connection string from the data source name returned by the dialog box and any other keywords passed to it by the application. If the data source name returned by the dialog box is empty, the Driver Manager specifies the keyword-value pair DSN=Default. (This dialog box will not display a data source with the name "Default".)
> 
> SQL_DRIVER_COMPLETE or SQL_DRIVER_COMPLETE_REQUIRED: If the connection string specified by the application includes the DSN keyword, the Driver Manager copies the connection string specified by the application. Otherwise, it takes the same actions as it does when DriverCompletion is SQL_DRIVER_PROMPT.
> 
> SQL_DRIVER_NOPROMPT: The Driver Manager copies the connection string specified by the application.

### Description

<!--- Details of what you changed -->

### Testing

<!-- What did you test and how did you test it -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
