### PR TITLE
chore: add ConcurrentStack

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -69,6 +69,7 @@ set(INC
     ${CMAKE_CURRENT_SOURCE_DIR}/util/aws_sdk_helper.h
     ${CMAKE_CURRENT_SOURCE_DIR}/util/cluster_helper.h
     ${CMAKE_CURRENT_SOURCE_DIR}/util/concurrent_map.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/util/concurrent_stack.h
     ${CMAKE_CURRENT_SOURCE_DIR}/util/connection_string_helper.h
     ${CMAKE_CURRENT_SOURCE_DIR}/util/connection_string_keys.h
     ${CMAKE_CURRENT_SOURCE_DIR}/util/init_plugin_helper.h

--- a/driver/util/concurrent_stack.h
+++ b/driver/util/concurrent_stack.h
@@ -1,0 +1,84 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+
+#ifndef CONCURRENT_STACK_H
+#define CONCURRENT_STACK_H
+
+#include <functional>
+#include <mutex>
+#include <vector>
+
+template <typename Value>
+class ConcurrentStack {
+public:
+    ConcurrentStack() = default;
+    ~ConcurrentStack() = default;
+
+    Value Back() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return stack_.back();
+    }
+
+    void PushBack(const Value& value) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return stack_.push_back(value);
+    }
+
+    void PopBack() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stack_.pop_back();
+    }
+
+    Value PopAndGetBack() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        Value v = stack_.back();
+        stack_.pop_back();
+        return v;
+    }
+
+    size_t Size() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return stack_.size();
+    }
+
+    bool Empty() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return stack_.empty();
+    }
+
+    void Clear() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stack_.clear();
+    }
+
+    void ForEach(std::function<void(Value)> fn) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (const auto& val : stack_) {
+            fn(val);
+        }
+    }
+
+    void RemoveIf(std::function<bool(Value)> fn) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stack_.erase(std::remove_if(stack_.begin(), stack_.end(), fn), stack_.end());
+    }
+
+private:
+    std::vector<Value> stack_;
+    mutable std::mutex mutex_;
+};
+
+#endif  // CONCURRENT_STACK_H

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -35,6 +35,7 @@ set(TEST_SUITE
     ${CMAKE_CURRENT_SOURCE_DIR}/aurora_initial_connection_strategy_plugin_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/auth_provider_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/concurrent_map_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/concurrent_stack_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/connection_string_helper_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_endpoint_plugin_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/failover_plugin_test.cpp

--- a/test/unit_test/concurrent_stack_test.cpp
+++ b/test/unit_test/concurrent_stack_test.cpp
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../../driver/util/concurrent_stack.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <string>
+
+namespace {
+    const std::string one = "one";
+    const std::string two = "two";
+    const std::string three = "three";
+    const std::string four = "four";
+    const std::string five = "five";
+}
+
+class ConcurrentStackTest : public testing::Test {
+
+protected:
+    // Runs once per suite
+    static void SetUpTestSuite() {}
+    static void TearDownTestSuite() {}
+    // Runs per test case
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(ConcurrentStackTest, Test_Push_And_Pop) {
+    ConcurrentStack<std::string> stack;
+
+    EXPECT_EQ(0, stack.Size());
+    EXPECT_TRUE(stack.Empty());
+
+    stack.PushBack(one);
+    stack.PushBack(two);
+    stack.PushBack(three);
+    stack.PushBack(four);
+    stack.PushBack(five);
+    EXPECT_EQ(5, stack.Size());
+    EXPECT_FALSE(stack.Empty());
+    EXPECT_EQ(five, stack.Back());
+
+    stack.PopBack();
+    EXPECT_EQ(4, stack.Size());
+    EXPECT_EQ(four, stack.Back());
+
+    stack.PopBack();
+    EXPECT_EQ(3, stack.Size());
+    EXPECT_EQ(three, stack.Back());
+
+    stack.Clear();
+
+    EXPECT_EQ(0, stack.Size());
+    EXPECT_TRUE(stack.Empty());
+}
+
+TEST_F(ConcurrentStackTest, Test_RemoveIf) {
+    ConcurrentStack<std::string> stack;
+    stack.PushBack(one);
+    stack.PushBack(two);
+    stack.PushBack(three);
+    stack.PushBack(four);
+    stack.PushBack(five);
+
+    EXPECT_EQ(5, stack.Size());
+
+    std::function<bool(std::string)> isThree = [](std::string value) { return value == three; };
+    stack.RemoveIf(isThree);
+
+    EXPECT_EQ(4, stack.Size());
+
+    EXPECT_EQ(five, stack.Back());
+
+    stack.PopBack();
+    EXPECT_EQ(four, stack.Back());
+
+    stack.PopBack();
+    EXPECT_EQ(two, stack.Back());
+
+    stack.PopBack();
+    EXPECT_EQ(one, stack.Back());
+}
+
+TEST_F(ConcurrentStackTest, Test_ForEach) {
+    ConcurrentStack<std::string> stack;
+    stack.PushBack(one);
+    stack.PushBack(two);
+    stack.PushBack(three);
+    stack.PushBack(four);
+    stack.PushBack(five);
+
+    std::string expectedString = one + two + three + four + five;
+
+    std::string actualString = "";
+
+    std::function<void(std::string)> appendToActualString = [&actualString](std::string value) {actualString = actualString + value; };
+    stack.ForEach(appendToActualString);
+
+    EXPECT_EQ(expectedString, actualString);
+}


### PR DESCRIPTION
### Summary

Add new ConcurrentStack class.

### Description

Add new ConcurrentStack class that wraps `std::vector` with mutexes for thread safety. 

It exposes a subset of `std::vector` methods that are essential for stack operations. 

`ForEach` method also added for QoL. 

### Testing

Unit tests

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
