### PR TITLE
chore: refactor federated plugins to use a base saml plugin for connection and do not retry connection on network errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,6 +24,8 @@ Checks: ">
   -modernize-use-ranges,
   -modernize-use-scoped-lock,
   -modernize-use-trailing-return-type,
+  -modernize-pass-by-value,
+  -llvm-include-order,
   -optin.cplusplus.VirtualCall,
   -performance-no-int-to-ptr,
   -performance-unnecessary-value-param,

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -68,6 +68,7 @@ set(INC
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin/failover/failover_plugin.h
     ## Federated
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin/federated/adfs_auth_plugin.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/plugin/federated/base_saml_auth_plugin.h
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin/federated/html_util.h
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin/federated/okta_auth_plugin.h
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin/federated/saml_util.h
@@ -168,6 +169,7 @@ set(SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin/failover/failover_plugin.cpp
     ## Federated Auth
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin/federated/adfs_auth_plugin.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/plugin/federated/base_saml_auth_plugin.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin/federated/html_util.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin/federated/okta_auth_plugin.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/plugin/federated/saml_util.cpp

--- a/driver/dialect/dialect.h
+++ b/driver/dialect/dialect.h
@@ -42,6 +42,9 @@ public:
     virtual std::string GetIsReaderQuery() { return ""; };
 
     virtual bool IsSqlStateAccessError(const char* sql_state) { return false; };
+    virtual bool IsSqlStateAccessError(const char* sql_state, const std::string& error_message) {
+        return IsSqlStateAccessError(sql_state);
+    };
     virtual bool IsSqlStateNetworkError(const char* sql_state) { return false; };
 
     virtual DatabaseDialectType GetDialectType() { return DatabaseDialectType::UNKNOWN_DIALECT; };

--- a/driver/dialect/dialect_aurora_postgres.h
+++ b/driver/dialect/dialect_aurora_postgres.h
@@ -39,6 +39,21 @@ public:
         });
     };
 
+    bool IsSqlStateAccessError(const char* sql_state, const std::string& error_message) override {
+        if (IsSqlStateAccessError(sql_state)) {
+            return true;
+        }
+        // psqlODBC wraps PAM authentication failures in 08001 (connection exception)
+        // instead of 28P01/28000. Check the error message for auth-related keywords.
+        if (!error_message.empty()
+            && (error_message.find("PAM authentication failed") != std::string::npos
+                || error_message.find("password authentication failed") != std::string::npos))
+        {
+            return true;
+        }
+        return false;
+    };
+
     bool IsSqlStateNetworkError(const char* sql_state) override {
         std::string state(sql_state);
         return std::ranges::any_of(NETWORK_ERRORS, [&state](const std::string &prefix) {

--- a/driver/host_list_providers/cluster_topology_monitor.cpp
+++ b/driver/host_list_providers/cluster_topology_monitor.cpp
@@ -46,10 +46,10 @@ ClusterTopologyMonitor::ClusterTopologyMonitor(
     HostInfo template_host)
     : plugin_service_{ plugin_service },
       topology_util_{ topology_util },
-      connection_attributes_{ conn_attr },
-      cluster_id_{ cluster_id },
-      initial_host_{ initial_host },
-      template_host_{ template_host },
+      connection_attributes_{ std::move(conn_attr) },
+      cluster_id_{ std::move(cluster_id) },
+      initial_host_{ std::move(initial_host) },
+      template_host_{ std::move(template_host) },
       dialect_{ plugin_service->GetDialect() },
       odbc_helper_{ plugin_service->GetOdbcHelper() }
 {

--- a/driver/host_list_providers/cluster_topology_monitor.cpp
+++ b/driver/host_list_providers/cluster_topology_monitor.cpp
@@ -172,8 +172,7 @@ void ClusterTopologyMonitor::Run() {
 }
 
 std::vector<HostInfo> ClusterTopologyMonitor::WaitForTopologyUpdate(std::chrono::milliseconds timeout_ms) {
-    std::vector<HostInfo> curr_hosts = plugin_service_->GetHosts();
-    std::vector<HostInfo> new_hosts = curr_hosts;
+    uint64_t version_before = topology_version_.load();
     {
         const std::lock_guard<std::mutex> lock(request_update_topology_mutex_);
         request_update_topology_.store(true);
@@ -181,6 +180,7 @@ std::vector<HostInfo> ClusterTopologyMonitor::WaitForTopologyUpdate(std::chrono:
     request_update_topology_cv_.notify_all();
 
     if (timeout_ms.count() <= 0) {
+        std::vector<HostInfo> curr_hosts = plugin_service_->GetHosts();
         LOG(INFO) << "A topology refresh was requested, but the given timeout for the request was 0ms. Returning cached hosts";
         TopologyUtil::LogTopology(curr_hosts);
         return curr_hosts;
@@ -189,20 +189,18 @@ std::vector<HostInfo> ClusterTopologyMonitor::WaitForTopologyUpdate(std::chrono:
     const std::chrono::steady_clock::time_point end = curr_time + timeout_ms;
 
     std::unique_lock<std::mutex> topology_lock(topology_updated_mutex_);
-    // TODO(karezche): refactor the code to compare references instead of values
-    // Current implementation does not support comparing curr_hosts and new_hosts by their references.
-    while (curr_time < end && curr_hosts == new_hosts) {
+    while (curr_time < end && topology_version_.load() == version_before) {
         topology_updated_.wait_for(topology_lock, TOPOLOGY_UPDATE_WAIT_MS);
-        new_hosts = plugin_service_->GetHosts();
         curr_time = std::chrono::steady_clock::now();
     }
+    topology_lock.unlock();
     LOG(INFO) << "New hosts have been updated";
 
     if (curr_time >= end) {
         LOG(ERROR) << "Cluster Monitor topology did not update within the maximum time: " << std::to_string(timeout_ms.count()) << "ms for cluster ID: " << cluster_id_;
     }
 
-    return new_hosts;
+    return plugin_service_->GetHosts();
 }
 
 void ClusterTopologyMonitor::DelayMainThread(bool use_high_refresh_rate) {
@@ -249,6 +247,7 @@ void ClusterTopologyMonitor::UpdateTopologyCache(const std::vector<HostInfo>& ho
     // Update topology and notify threads
     plugin_service_->SetHosts(hosts);
     request_update_topology_.store(false);
+    topology_version_.fetch_add(1);
     topology_updated_.notify_all();
     request_update_topology_cv_.notify_one();
 }

--- a/driver/host_list_providers/cluster_topology_monitor.h
+++ b/driver/host_list_providers/cluster_topology_monitor.h
@@ -107,6 +107,7 @@ private:
     std::mutex topology_updated_mutex_;
     std::condition_variable topology_updated_;
     const std::chrono::milliseconds TOPOLOGY_UPDATE_WAIT_MS = std::chrono::milliseconds(1000);
+    std::atomic<uint64_t> topology_version_{0};
 
     std::atomic<std::chrono::steady_clock::time_point> ignore_topology_request_end_ms_;
     std::chrono::milliseconds ignore_topology_request_ms_ = std::chrono::seconds(30);

--- a/driver/host_list_providers/rds_host_list_provider.cpp
+++ b/driver/host_list_providers/rds_host_list_provider.cpp
@@ -28,16 +28,16 @@ RdsHostListProvider::RdsHostListProvider(
     std::string cluster_id)
     : topology_util_{ topology_util },
       plugin_service_{ plugin_service },
-      conn_attr_{ conn_attr },
-    HostListProvider(cluster_id)
+      conn_attr_{ std::move(conn_attr) },
+    HostListProvider(std::move(cluster_id))
 {
     this->initial_host_info_ = HostInfo(
-        conn_attr.contains(KEY_SERVER) ?
-            conn_attr.at(KEY_SERVER) : "",
-        conn_attr.contains(KEY_PORT) ?
-            static_cast<int>(std::strtol(conn_attr.at(KEY_PORT).c_str(), nullptr, 0)) : HostInfo::NO_PORT
+        conn_attr_.contains(KEY_SERVER) ?
+            conn_attr_.at(KEY_SERVER) : "",
+        conn_attr_.contains(KEY_PORT) ?
+            static_cast<int>(std::strtol(conn_attr_.at(KEY_PORT).c_str(), nullptr, 0)) : HostInfo::NO_PORT
     );
-    this->template_host_info_= HostInfo(
+    this->template_host_info_ = HostInfo(
         RdsUtils::GetRdsInstanceHostPattern(this->initial_host_info_.GetHost()),
         this->initial_host_info_.GetPort()
     );

--- a/driver/plugin/base_plugin.cpp
+++ b/driver/plugin/base_plugin.cpp
@@ -22,9 +22,7 @@ BasePlugin::BasePlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin) :
     next_plugin(next_plugin),
     plugin_name("BasePlugin") {}
 
-BasePlugin::~BasePlugin() {
-    next_plugin = nullptr;
-}
+BasePlugin::~BasePlugin() = default;
 
 // codechecker_suppress [misc-no-recursion]
 SQLRETURN BasePlugin::Connect(

--- a/driver/plugin/blue_green/blue_green_monitor.cpp
+++ b/driver/plugin/blue_green/blue_green_monitor.cpp
@@ -390,6 +390,25 @@ void BlueGreenMonitor::CollectStatus() {
     std::vector<StatusInfo> status_entries;
 
     res = this->odbc_helper_->ExecDirect(&stmt, this->dialect_blue_green_->GetBlueGreenStatusQuery());
+    if (!SQL_SUCCEEDED(res.fn_result)) {
+        // Check if this is the expected metadata removal error after switchover completes.
+        // The PG blue/green metadata table is removed post-switchover, causing this specific error.
+        std::string error_msg = (stmt != SQL_NULL_HANDLE) ? this->odbc_helper_->GetStmtErrorMessage(stmt) : "";
+        if (error_msg.find("An error occurred while retrieving the blue/green fast switchover metadata") != std::string::npos) {
+            this->current_phase_ = BlueGreenPhase::NOT_CREATED;
+        } else if (!this->odbc_helper_->IsClosed(this->hdbc_)) {
+            this->current_phase_ = BlueGreenPhase::NOT_CREATED;
+        } else {
+            this->odbc_helper_->DisconnectAndFree(&(this->hdbc_));
+            this->hdbc_ = SQL_NULL_HDBC;
+            this->current_phase_ = BlueGreenPhase::UNKNOWN;
+            this->in_panic_mode_.store(true);
+        }
+        if (stmt != SQL_NULL_HANDLE) {
+            this->odbc_helper_->BaseFreeStmt(&stmt);
+        }
+        return;
+    }
 
     SQLLEN len = 0;
     SQLTCHAR version[BUFFER_SIZE] = {0};
@@ -407,11 +426,14 @@ void BlueGreenMonitor::CollectStatus() {
     while (SQL_SUCCEEDED(res.fn_result)) {
         std::string version_str = AS_UTF8_CSTR(version);
         std::string endpoint_str = AS_UTF8_CSTR(endpoint);
+        std::string role_str = AS_UTF8_CSTR(role);
+        std::string status_str = AS_UTF8_CSTR(status);
         int port_ = static_cast<int>(port);
-        BlueGreenRole role_ = BlueGreenRole::ParseRole(AS_UTF8_CSTR(role), version_str);
-        BlueGreenPhase phase_ = BlueGreenPhase::ParsePhase(AS_UTF8_CSTR(status), version_str);
+        BlueGreenRole role_ = BlueGreenRole::ParseRole(role_str, version_str);
+        BlueGreenPhase phase_ = BlueGreenPhase::ParsePhase(status_str, version_str);
 
         if (this->current_role_ == role_) {
+            status_entries.push_back({version_str, endpoint_str, port_, phase_, role_});
             status_entries.push_back({version_str, endpoint_str, port_, phase_, role_});
         }
         res = this->odbc_helper_->Fetch(&stmt);

--- a/driver/plugin/blue_green/blue_green_monitor.cpp
+++ b/driver/plugin/blue_green/blue_green_monitor.cpp
@@ -374,6 +374,7 @@ void BlueGreenMonitor::CollectStatus() {
         res = this->odbc_helper_->ExecDirect(&stmt, this->dialect_blue_green_->GetBlueGreenStatusAvailableQuery());
         if (!SQL_SUCCEEDED(res.fn_result)) {
             this->odbc_helper_->BaseFreeStmt(&stmt);
+            stmt = SQL_NULL_HANDLE;
             if (!this->odbc_helper_->IsClosed(this->hdbc_)) {
                 this->current_phase_ = BlueGreenPhase::NOT_CREATED;
             } else {
@@ -394,6 +395,11 @@ void BlueGreenMonitor::CollectStatus() {
         // Check if this is the expected metadata removal error after switchover completes.
         // The PG blue/green metadata table is removed post-switchover, causing this specific error.
         std::string error_msg = (stmt != SQL_NULL_HANDLE) ? this->odbc_helper_->GetStmtErrorMessage(stmt) : "";
+        if (stmt != SQL_NULL_HANDLE) {
+            this->odbc_helper_->BaseFreeStmt(&stmt);
+            stmt = SQL_NULL_HANDLE;
+        }
+
         if (error_msg.find("An error occurred while retrieving the blue/green fast switchover metadata") != std::string::npos) {
             this->current_phase_ = BlueGreenPhase::NOT_CREATED;
         } else if (!this->odbc_helper_->IsClosed(this->hdbc_)) {
@@ -403,9 +409,6 @@ void BlueGreenMonitor::CollectStatus() {
             this->hdbc_ = SQL_NULL_HDBC;
             this->current_phase_ = BlueGreenPhase::UNKNOWN;
             this->in_panic_mode_.store(true);
-        }
-        if (stmt != SQL_NULL_HANDLE) {
-            this->odbc_helper_->BaseFreeStmt(&stmt);
         }
         return;
     }
@@ -433,7 +436,6 @@ void BlueGreenMonitor::CollectStatus() {
         BlueGreenPhase phase_ = BlueGreenPhase::ParsePhase(status_str, version_str);
 
         if (this->current_role_ == role_) {
-            status_entries.push_back({version_str, endpoint_str, port_, phase_, role_});
             status_entries.push_back({version_str, endpoint_str, port_, phase_, role_});
         }
         res = this->odbc_helper_->Fetch(&stmt);

--- a/driver/plugin/blue_green/blue_green_plugin.cpp
+++ b/driver/plugin/blue_green/blue_green_plugin.cpp
@@ -98,11 +98,14 @@ SQLRETURN BlueGreenPlugin::Connect(
         return InitConnection(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
     }
 
+    const std::map<std::string, std::string> original_conn_attr = dbc->conn_attr;
+
     SQLRETURN rc = SQL_ERROR;
     this->start_time_ = std::chrono::steady_clock::now();
     try {
+        std::string last_failed_route;
         while (route_itr != connect_routes.end() && !SQL_SUCCEEDED(rc)) {
-            LOG(INFO) << "Using connect route: " << (*route_itr)->ToString();
+            std::string current_route = (*route_itr)->ToString();
             rc = (*route_itr)->Connect(dbc, HostInfo(conn_host), this->odbc_helper_, this->status_map_);
             LOG(INFO) << "Connection route returned: " << std::to_string(rc);
             if (!SQL_SUCCEEDED(rc)) {
@@ -110,6 +113,7 @@ SQLRETURN BlueGreenPlugin::Connect(
                 if (this->blue_green_status_.GetCurrentPhase().GetPhase() == BlueGreenPhase::UNKNOWN) {
                     this->end_time_ = std::chrono::steady_clock::now();
                     LOG(WARNING) << "Default connection, statuses reset, routes cleared for role: " << host_role.ToString() << ", host: " << conn_host;
+                    dbc->conn_attr = original_conn_attr;
                     return InitConnection(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
                 }
 
@@ -118,13 +122,22 @@ SQLRETURN BlueGreenPlugin::Connect(
                     [&conn_host, &host_role](const std::shared_ptr<BaseConnectRouting>& route) {
                         return route->IsMatch(conn_host, host_role);
                     });
+
+                if (route_itr != connect_routes.end() && (*route_itr)->ToString() == last_failed_route) {
+                    route_itr = connect_routes.end();
+                }
+                last_failed_route = current_route;
             }
         }
         if (!SQL_SUCCEEDED(rc)) {
             LOG(WARNING) << "Default connection, alternative routes unsuccessful for role: " << host_role.ToString() << ", host: " << conn_host;
+            dbc->conn_attr = original_conn_attr;
             return InitConnection(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
         }
+        // Restore conn_attr even on success — the routing modified SERVER/IAM_HOST/PORT
+        dbc->conn_attr = original_conn_attr;
     } catch (const std::exception& ex) {
+        dbc->conn_attr = original_conn_attr;
         CLEAR_DBC_ERROR(dbc);
         std::string error_message("Blue/Green Connect route failed: ");
         error_message += ex.what();
@@ -178,8 +191,9 @@ SQLRETURN BlueGreenPlugin::Execute(
     SQLRETURN rc = SQL_ERROR;
     this->start_time_ = std::chrono::steady_clock::now();
     try {
+        std::string last_failed_route;
         while (route_itr != execute_routes.end() && !SQL_SUCCEEDED(rc)) {
-            LOG(INFO) << "Using execute route: " << (*route_itr)->ToString();
+            std::string current_route = (*route_itr)->ToString();
             rc = (*route_itr)->Execute(stmt, this->odbc_helper_, this->status_map_);
             LOG(INFO) << "Execute route returned: " << std::to_string(rc);
             if (!SQL_SUCCEEDED(rc)) {
@@ -195,7 +209,15 @@ SQLRETURN BlueGreenPlugin::Execute(
                     [&conn_host, &host_role](const std::shared_ptr<BaseExecuteRouting> route) {
                         return route->IsMatch(conn_host, host_role);
                     });
+
+                if (route_itr != execute_routes.end() && (*route_itr)->ToString() == last_failed_route) {
+                    route_itr = execute_routes.end();
+                }
+                last_failed_route = current_route;
             }
+        }
+        if (SQL_SUCCEEDED(rc)) {
+            return rc;
         }
 
         LOG(WARNING) << "Default execution, out of routes: " << host_role.ToString() << ", host: " << conn_host;
@@ -239,6 +261,9 @@ SQLRETURN BlueGreenPlugin::InitConnection(
 
     if (SQL_SUCCEEDED(rc)) {
         this->InitProvider();
+    } else {
+        DBC* dbc = static_cast<DBC*>(ConnectionHandle);
+        std::string sql_state = this->odbc_helper_->GetSqlStateAndLogMessage(dbc);
     }
 
     return rc;

--- a/driver/plugin/blue_green/blue_green_plugin.cpp
+++ b/driver/plugin/blue_green/blue_green_plugin.cpp
@@ -46,6 +46,7 @@ BlueGreenPlugin::~BlueGreenPlugin() {
         std::pair<unsigned int, std::shared_ptr<BlueGreenStatusProvider>>& pair = itr->second;
         if (pair.first == 1) {
             status_providers_map_.erase(this->blue_green_id_);
+            status_map_->Erase(this->blue_green_id_);
             LOG(INFO) << "Shut down Blue Green Status Provider: " << this->blue_green_id_;
         } else {
             pair.first--;
@@ -63,6 +64,7 @@ SQLRETURN BlueGreenPlugin::Connect(
     SQLUSMALLINT   DriverCompletion)
 {
     LOG(INFO) << "Entering Connect";
+    this->InitProvider();
     DBC* dbc = static_cast<DBC*>(ConnectionHandle);
     if (dbc->conn_attr.contains(KEY_MONITORING_CONN_UUID)) {
         return next_plugin->Connect(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);

--- a/driver/plugin/blue_green/blue_green_plugin.cpp
+++ b/driver/plugin/blue_green/blue_green_plugin.cpp
@@ -261,9 +261,6 @@ SQLRETURN BlueGreenPlugin::InitConnection(
 
     if (SQL_SUCCEEDED(rc)) {
         this->InitProvider();
-    } else {
-        DBC* dbc = static_cast<DBC*>(ConnectionHandle);
-        std::string sql_state = this->odbc_helper_->GetSqlStateAndLogMessage(dbc);
     }
 
     return rc;

--- a/driver/plugin/blue_green/blue_green_status_provider.cpp
+++ b/driver/plugin/blue_green/blue_green_status_provider.cpp
@@ -892,6 +892,7 @@ void BlueGreenStatusProvider::ResetContext() {
         source_monitor = this->monitors_[BlueGreenRole::SOURCE];
         target_monitor = this->monitors_[BlueGreenRole::TARGET];
     }
+
     if (source_monitor != nullptr && target_monitor != nullptr) {
         while (pending_restart_ && !(source_monitor->IsStop() && target_monitor->IsStop())) {
             std::this_thread::sleep_for(RESET_CHECK_RATE);
@@ -900,8 +901,8 @@ void BlueGreenStatusProvider::ResetContext() {
         this->monitors_[BlueGreenRole::SOURCE] = nullptr;
         this->monitors_[BlueGreenRole::TARGET] = nullptr;
         LOG(INFO) << "Previous monitors closed.";
-    } else {
     }
+
     if (!pending_restart_) {
         LOG(INFO) << "No longer pending a monitor restart, no need to restart";
         return;

--- a/driver/plugin/blue_green/blue_green_status_provider.cpp
+++ b/driver/plugin/blue_green/blue_green_status_provider.cpp
@@ -606,12 +606,16 @@ void BlueGreenStatusProvider::CreatePostRouting(std::vector<std::shared_ptr<Base
 
                 // Check if green ghost connected with blue (non-prefixed) IAM host name
                 std::vector<HostInfo> iam_hosts;
-                HostInfo iam_blue_host_info = HostInfo(RdsUtils::RemoveGreenInstancePrefix(green_host_ip), green_host_info.GetPort(),
+                HostInfo iam_blue_host_info = HostInfo(RdsUtils::RemoveGreenInstancePrefix(green_host), green_host_info.GetPort(),
                                                        green_host_info.GetHostState(), green_host_info.GetHostRole());
-                if (!this->IsAlreadySuccessfullyConnected(green_host, iam_blue_host_info.GetHost())) {
+                if (this->IsAlreadySuccessfullyConnected(green_host, iam_blue_host_info.GetHost())) {
+                    // Green node already accepted the blue hostname token — only use blue.
+                    iam_hosts.push_back(iam_blue_host_info);
+                } else {
+                    // Green node isn't yet changed its name, so we need to try both possible IAM host options.
                     iam_hosts.push_back(green_host_info);
+                    iam_hosts.push_back(iam_blue_host_info);
                 }
-                iam_hosts.push_back(iam_blue_host_info);
 
                 connect_routing.push_back(std::make_shared<SubstituteConnectRouting>(
                     blue_host, role, green_ip_host_info, iam_hosts,
@@ -646,10 +650,13 @@ void BlueGreenStatusProvider::CreatePostRouting(std::vector<std::shared_ptr<Base
             HostInfo green_ip_host_info = HostInfo(this->host_ip_map_->Get(green_host), interim_status.port_);
 
             std::vector<HostInfo> iam_hosts;
-            if (!this->IsAlreadySuccessfullyConnected(green_host, blue_host)) {
+            if (this->IsAlreadySuccessfullyConnected(green_host, blue_host)) {
+                iam_hosts.push_back(blue_host_info);
+            } else {
+                // Green node has not changed its name, so we need to try both possible IAM host options.
                 iam_hosts.push_back(green_host_info);
+                iam_hosts.push_back(blue_host_info);
             }
-            iam_hosts.push_back(blue_host_info);
 
             connect_routing.push_back(std::make_shared<SubstituteConnectRouting>(
                 green_host, role, green_ip_host_info, iam_hosts,
@@ -692,6 +699,9 @@ BlueGreenStatus BlueGreenStatusProvider::GetStatusOfCompleted() {
 }
 
 void BlueGreenStatusProvider::RegisterIamHost(std::string connect_host, std::string iam_host) {
+    if (!this->iam_host_success_connects_map_) {
+        return;
+    }
     bool different_node_name = !connect_host.empty() && connect_host != iam_host;
     if (different_node_name) {
         if (!this->IsAlreadySuccessfullyConnected(connect_host, iam_host)) {
@@ -726,6 +736,9 @@ void BlueGreenStatusProvider::RegisterIamHost(std::string connect_host, std::str
 }
 
 bool BlueGreenStatusProvider::IsAlreadySuccessfullyConnected(std::string connect_host, std::string iam_host) {
+    if (!this->iam_host_success_connects_map_) {
+        return false;
+    }
     return this->iam_host_success_connects_map_->Get(connect_host).contains(iam_host);
 }
 
@@ -887,6 +900,7 @@ void BlueGreenStatusProvider::ResetContext() {
         this->monitors_[BlueGreenRole::SOURCE] = nullptr;
         this->monitors_[BlueGreenRole::TARGET] = nullptr;
         LOG(INFO) << "Previous monitors closed.";
+    } else {
     }
     if (!pending_restart_) {
         LOG(INFO) << "No longer pending a monitor restart, no need to restart";

--- a/driver/plugin/blue_green/routing/connect/substitute_connect_routing.cpp
+++ b/driver/plugin/blue_green/routing/connect/substitute_connect_routing.cpp
@@ -33,8 +33,8 @@ SQLRETURN SubstituteConnectRouting::Connect(
     odbc_helper->Disconnect(dbc);
 
     std::string substitute_host = this->substitute_info_.GetHost();
-    bool using_ip_host = RdsUtils::IsIpv4(substitute_host);
-    bool using_iam = dbc->conn_attr.contains(KEY_AUTH_TYPE) && dbc->conn_attr.at(KEY_AUTH_TYPE) == VALUE_AUTH_IAM;
+    bool const using_ip_host = RdsUtils::IsIpv4(substitute_host);
+    bool const using_iam = dbc->conn_attr.contains(KEY_AUTH_TYPE) && dbc->conn_attr.at(KEY_AUTH_TYPE) == VALUE_AUTH_IAM;
 
     // Substitute connections
     dbc->conn_attr.insert_or_assign(KEY_SERVER, substitute_host);
@@ -44,7 +44,19 @@ SQLRETURN SubstituteConnectRouting::Connect(
 
     // Connect as usual if not using IAM
     if (!using_ip_host || !using_iam) {
-        return plugin_head_->Connect(dbc, nullptr, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+        SQLRETURN const rt = plugin_head_->Connect(dbc, nullptr, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+        if (!SQL_SUCCEEDED(rt)) {
+            dbc->sql_error_called = 0;
+            const std::shared_ptr<Dialect> dialect = dbc->plugin_service->GetDialect();
+            std::string error_message;
+            const std::string sql_state = odbc_helper->GetSqlStateAndLogMessage(dbc, &error_message);
+            if (dialect && dialect->IsSqlStateAccessError(sql_state.c_str(), error_message)) {
+                // Login error - let another routing try
+                odbc_helper->Disconnect(dbc);
+                return SQL_ERROR;
+            }
+        }
+        return rt;
     }
 
     // IAM Host needed to generate token when connecting with IP
@@ -52,30 +64,35 @@ SQLRETURN SubstituteConnectRouting::Connect(
         throw std::runtime_error("Connecting with IP address when IAM authentication is enabled requires an 'IAM_HOST' parameter.");
     }
 
-    for (HostInfo iam_info : this->iam_hosts_) {
+    for (const HostInfo& iam_info : this->iam_hosts_) {
         dbc->conn_attr.insert_or_assign(KEY_IAM_HOST, iam_info.GetHost());
         if (iam_info.GetPort() != HostInfo::NO_PORT) {
             dbc->conn_attr.insert_or_assign(KEY_IAM_PORT, std::to_string(iam_info.GetPort()));
         };
         dbc->conn_attr.insert_or_assign(KEY_MONITORING_CONN_UUID, VALUE_BOOL_TRUE);
-        SQLRETURN rt = plugin_head_->Connect(dbc, nullptr, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
+        const SQLRETURN rt = plugin_head_->Connect(dbc, nullptr, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
         dbc->conn_attr.erase(KEY_MONITORING_CONN_UUID);
+        // Reset the diagnostic counter so we can read the SQL state from the underlying driver.
+        // The IAM plugin may have already consumed the diagnostic record during its retry logic.
+        dbc->sql_error_called = 0;
         const std::shared_ptr<Dialect> dialect = dbc->plugin_service->GetDialect();
-        const std::string sql_state = odbc_helper->GetSqlStateAndLogMessage(dbc);
-        if (dialect->IsSqlStateAccessError(sql_state.c_str())) {
-            std::string err("Encountered access error, SQL State: ");
-            err += sql_state;
-            throw std::runtime_error(err);
+        std::string error_message;
+        const std::string sql_state = odbc_helper->GetSqlStateAndLogMessage(dbc, &error_message);
+        if (dialect && dialect->IsSqlStateAccessError(sql_state.c_str(), error_message)) {
+            // Login/access error with this IAM host - try next IAM host
+            odbc_helper->Disconnect(dbc);
+            continue;
         }
         if (!SQL_SUCCEEDED(rt)) {
-            odbc_helper->Disconnect(dbc);
-        } else {
-            if (iam_connect_notify_) {
-                iam_connect_notify_(iam_info.GetHost());
-            }
-            return rt;
+            // Non-login error (network, DNS, etc.) - propagate
+            throw std::runtime_error("Encountered non-login error, SQL State: " + sql_state);
         }
+        if (iam_connect_notify_) {
+            iam_connect_notify_(iam_info.GetHost());
+        }
+        return rt;
     }
 
-    throw std::runtime_error("Blue/Green Deployment switchover is in progress. Can't establish connection.");
+    // All IAM hosts exhausted with login errors - return SQL_ERROR to let next routing try
+    return SQL_ERROR;
 }

--- a/driver/plugin/blue_green/routing/connect/substitute_connect_routing.cpp
+++ b/driver/plugin/blue_green/routing/connect/substitute_connect_routing.cpp
@@ -49,7 +49,7 @@ SQLRETURN SubstituteConnectRouting::Connect(
             dbc->sql_error_called = 0;
             const std::shared_ptr<Dialect> dialect = dbc->plugin_service->GetDialect();
             std::string error_message;
-            const std::string sql_state = odbc_helper->GetSqlStateAndLogMessage(dbc, &error_message);
+            const std::string sql_state = odbc_helper->GetSqlStateAndLogMessage(dbc, error_message);
             if (dialect && dialect->IsSqlStateAccessError(sql_state.c_str(), error_message)) {
                 // Login error - let another routing try
                 odbc_helper->Disconnect(dbc);
@@ -77,7 +77,7 @@ SQLRETURN SubstituteConnectRouting::Connect(
         dbc->sql_error_called = 0;
         const std::shared_ptr<Dialect> dialect = dbc->plugin_service->GetDialect();
         std::string error_message;
-        const std::string sql_state = odbc_helper->GetSqlStateAndLogMessage(dbc, &error_message);
+        const std::string sql_state = odbc_helper->GetSqlStateAndLogMessage(dbc, error_message);
         if (dialect && dialect->IsSqlStateAccessError(sql_state.c_str(), error_message)) {
             // Login/access error with this IAM host - try next IAM host
             odbc_helper->Disconnect(dbc);
@@ -93,6 +93,6 @@ SQLRETURN SubstituteConnectRouting::Connect(
         return rt;
     }
 
-    // All IAM hosts exhausted with login errors - return SQL_ERROR to let next routing try
-    return SQL_ERROR;
+    // All IAM hosts exhausted with login errors
+    throw std::runtime_error("Unable to open a connection to " + substitute_host + ". All IAM hosts exhausted with login errors.");
 }

--- a/driver/plugin/default_plugin.cpp
+++ b/driver/plugin/default_plugin.cpp
@@ -52,6 +52,16 @@ SQLRETURN DefaultPlugin::Connect(
         );
     }
 
+    // Apply pre-connect attributes to the wrapped DBC before SQLDriverConnect.
+    // Attributes like SQL_ATTR_LOGIN_TIMEOUT must be set before connecting to take effect.
+    for (auto const& [key, val] : dbc->attr_map) {
+        if (key == SQL_ATTR_LOGIN_TIMEOUT || key == SQL_ATTR_CONNECTION_TIMEOUT) {
+            NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLSetConnectAttr, RDS_STR_SQLSetConnectAttr,
+                dbc->wrapped_dbc, key, val.first, val.second
+            );
+        }
+    }
+
     // DSN should be read from the original input
     // and a new connection string should be built without DSN & Driver
     const std::string conn_in = ConnectionStringHelper::BuildMinimumConnectionString(dbc->conn_attr);

--- a/driver/plugin/federated/adfs_auth_plugin.cpp
+++ b/driver/plugin/federated/adfs_auth_plugin.cpp
@@ -29,93 +29,48 @@ AdfsAuthPlugin::AdfsAuthPlugin(DBC *dbc) : AdfsAuthPlugin(dbc, nullptr) {}
 
 AdfsAuthPlugin::AdfsAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin) : AdfsAuthPlugin(dbc, next_plugin, nullptr, nullptr) {}
 
-AdfsAuthPlugin::AdfsAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin, const std::shared_ptr<SamlUtil> &saml_util, const std::shared_ptr<AuthProvider> &auth_provider) : BasePlugin(dbc, next_plugin)
-{
-    this->plugin_name = "ADFS";
-
-    if (saml_util) {
-        this->saml_util = saml_util;
-    } else {
-        this->saml_util = std::make_shared<AdfsSamlUtil>(dbc->conn_attr);
+namespace {
+    std::shared_ptr<SamlUtil> CreateAdfsSamlUtil(
+        DBC* dbc,
+        const std::shared_ptr<SamlUtil>& saml_util)
+    {
+        if (saml_util) {
+            return saml_util;
+        }
+        return std::make_shared<AdfsSamlUtil>(dbc->conn_attr);
     }
 
-    if (auth_provider) {
-        this->auth_provider = auth_provider;
-    } else {
+    std::shared_ptr<AuthProvider> CreateAdfsAuthProvider(
+        DBC* dbc,
+        const std::shared_ptr<SamlUtil>& resolved_saml,
+        const std::shared_ptr<AuthProvider>& auth_provider)
+    {
+        if (auth_provider) {
+            return auth_provider;
+        }
         std::string region = MapUtils::GetStringValue(dbc->conn_attr, KEY_REGION, "");
         if (region.empty()) {
             region = dbc->conn_attr.contains(KEY_SERVER) ?
                 RdsUtils::GetRdsRegion(dbc->conn_attr.at(KEY_SERVER))
                 : Aws::Region::US_EAST_1;
         }
-        const std::string saml_assertion = this->saml_util->GetSamlAssertion();
-        this->auth_provider = std::make_shared<AuthProvider>(region, this->saml_util->GetAwsCredentials(saml_assertion));
+        const std::string assertion = resolved_saml->GetSamlAssertion();
+        return std::make_shared<AuthProvider>(region, resolved_saml->GetAwsCredentials(assertion));
     }
-}
+}  // namespace
 
-AdfsAuthPlugin::~AdfsAuthPlugin()
+AdfsAuthPlugin::AdfsAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin, const std::shared_ptr<SamlUtil> &saml_util, const std::shared_ptr<AuthProvider> &auth_provider)
+    : AdfsAuthPlugin(dbc, next_plugin, saml_util, auth_provider, nullptr, nullptr) {}
+
+AdfsAuthPlugin::AdfsAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin,
+                               const std::shared_ptr<SamlUtil> &saml_util, const std::shared_ptr<AuthProvider> &auth_provider,
+                               std::shared_ptr<Dialect> dialect, std::shared_ptr<OdbcHelper> odbc_helper)
+    : BaseSamlAuthPlugin(dbc, next_plugin,
+        CreateAdfsSamlUtil(dbc, saml_util),
+        CreateAdfsAuthProvider(dbc, CreateAdfsSamlUtil(dbc, saml_util), auth_provider),
+        dialect, odbc_helper)
 {
-    if (auth_provider) {
-        auth_provider = nullptr;
-    }
-    if (saml_util) {
-        saml_util = nullptr;
-    }
-}
-
-SQLRETURN AdfsAuthPlugin::Connect(
-    SQLHDBC        ConnectionHandle,
-    SQLHWND        WindowHandle,
-    SQLTCHAR *     OutConnectionString,
-    SQLSMALLINT    BufferLength,
-    SQLSMALLINT *  StringLengthPtr,
-    SQLUSMALLINT   DriverCompletion)
-{
-    LOG(INFO) << "Entering Connect";
-    DBC* dbc = static_cast<DBC*>(ConnectionHandle);
-
-    const std::string server = MapUtils::GetStringValue(dbc->conn_attr, KEY_SERVER, "");
-    const std::string iam_host = MapUtils::GetStringValue(dbc->conn_attr, KEY_IAM_HOST, server);
-    std::string region = MapUtils::GetStringValue(dbc->conn_attr, KEY_REGION, "");
-    if (region.empty()) {
-        region = dbc->conn_attr.contains(KEY_SERVER) ?
-            RdsUtils::GetRdsRegion(dbc->conn_attr.at(KEY_SERVER))
-            : Aws::Region::US_EAST_1;
-    }
-    const std::string port = AuthProvider::GetPort(dbc);
-    const std::string username = MapUtils::GetStringValue(dbc->conn_attr, KEY_DB_USERNAME, "");
-    const std::chrono::milliseconds token_expiration = dbc->conn_attr.contains(KEY_TOKEN_EXPIRATION) ?
-        std::chrono::seconds(std::strtol(dbc->conn_attr.at(KEY_TOKEN_EXPIRATION).c_str(), nullptr, 0)) : AuthProvider::DEFAULT_EXPIRATION_MS;
-    const bool extra_url_encode = MapUtils::GetBooleanValue(dbc->conn_attr, KEY_EXTRA_URL_ENCODE, false);
-
-    if (iam_host.empty() || region.empty() || port.empty() || username.empty()) {
-        LOG(ERROR) << "Missing required parameters for ADFS Authentication";
-        CLEAR_DBC_ERROR(dbc);
-        dbc->err = new ERR_INFO("Missing required parameters for ADFS Authentication", ERR_CLIENT_UNABLE_TO_ESTABLISH_CONNECTION);
-        return SQL_ERROR;
-    }
-    std::pair<std::string, bool> token = auth_provider->GetToken(iam_host, region, port, username, true, extra_url_encode, token_expiration);
-
-    SQLRETURN ret = SQL_ERROR;
-
-    dbc->conn_attr.insert_or_assign(KEY_DB_PASSWORD, token.first);
-    ret = next_plugin->Connect(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
-
-    // Unsuccessful connection using cached token
-    // Skip cache and generate a new token to retry
-    if (!SQL_SUCCEEDED(ret) && token.second) {
-        LOG(WARNING) << "Cached token failed to connect. Retrying with fresh token";
-        // Update AWS Credentials
-        const std::string saml_assertion = saml_util->GetSamlAssertion();
-        const Aws::Auth::AWSCredentials credentials = saml_util->GetAwsCredentials(saml_assertion);
-        auth_provider->UpdateAwsCredential(credentials);
-        // and retry without cache
-        token = auth_provider->GetToken(iam_host, region, port, username, false, extra_url_encode, token_expiration);
-        dbc->conn_attr.insert_or_assign(KEY_DB_PASSWORD, token.first);
-        ret = next_plugin->Connect(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
-    }
-
-    return ret;
+    this->plugin_name = "ADFS";
 }
 
 AdfsSamlUtil::AdfsSamlUtil(const std::map<std::string, std::string> &connection_attributes)

--- a/driver/plugin/federated/adfs_auth_plugin.h
+++ b/driver/plugin/federated/adfs_auth_plugin.h
@@ -17,7 +17,7 @@
 
 #include "../../util/auth_provider.h"
 
-#include "../base_plugin.h"
+#include "base_saml_auth_plugin.h"
 
 #include "saml_util.h"
 
@@ -43,24 +43,14 @@ private:
     static inline const std::regex URL_PATTERN = std::regex("^(https)://[-a-zA-Z0-9+&@#/%?=~_!:,.']*[-a-zA-Z0-9+&@#/%=~_']");
 };
 
-class AdfsAuthPlugin : public BasePlugin {
+class AdfsAuthPlugin : public BaseSamlAuthPlugin {
 public:
     AdfsAuthPlugin(DBC* dbc);
     AdfsAuthPlugin(DBC* dbc, std::shared_ptr<BasePlugin> next_plugin);
     AdfsAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin, const std::shared_ptr<SamlUtil> &saml_util, const std::shared_ptr<AuthProvider> &auth_provider);
-    ~AdfsAuthPlugin() override;
-
-    SQLRETURN Connect(
-        SQLHDBC        ConnectionHandle,
-        SQLHWND        WindowHandle,
-        SQLTCHAR *     OutConnectionString,
-        SQLSMALLINT    BufferLength,
-        SQLSMALLINT *  StringLengthPtr,
-        SQLUSMALLINT   DriverCompletion) override;
-
-private:
-    std::shared_ptr<AuthProvider> auth_provider;
-    std::shared_ptr<SamlUtil> saml_util;
+    AdfsAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin,
+                   const std::shared_ptr<SamlUtil> &saml_util, const std::shared_ptr<AuthProvider> &auth_provider,
+                   std::shared_ptr<Dialect> dialect, std::shared_ptr<OdbcHelper> odbc_helper);
 };
 
 #endif // ADFS_AUTH_PLUGIN_H_

--- a/driver/plugin/federated/base_saml_auth_plugin.cpp
+++ b/driver/plugin/federated/base_saml_auth_plugin.cpp
@@ -103,11 +103,12 @@ SQLRETURN BaseSamlAuthPlugin::Connect(
 
     // Check if the failure is a login/access error
     std::string sql_state;
+    std::string error_message;
     if (odbc_helper_) {
-        sql_state = odbc_helper_->GetSqlStateAndLogMessage(dbc);
+        sql_state = odbc_helper_->GetSqlStateAndLogMessage(dbc, &error_message);
     }
     const bool is_access_error = dialect_ && !sql_state.empty()
-        && dialect_->IsSqlStateAccessError(sql_state.c_str());
+        && dialect_->IsSqlStateAccessError(sql_state.c_str(), error_message);
 
     // Only retry with a fresh token if the token was from cache AND the error is an access/login error.
     // Non-access errors (network, DNS, etc.) are not token-related and should not trigger a retry.

--- a/driver/plugin/federated/base_saml_auth_plugin.cpp
+++ b/driver/plugin/federated/base_saml_auth_plugin.cpp
@@ -105,7 +105,7 @@ SQLRETURN BaseSamlAuthPlugin::Connect(
     std::string sql_state;
     std::string error_message;
     if (odbc_helper_) {
-        sql_state = odbc_helper_->GetSqlStateAndLogMessage(dbc, &error_message);
+        sql_state = odbc_helper_->GetSqlStateAndLogMessage(dbc, error_message);
     }
     const bool is_access_error = dialect_ && !sql_state.empty()
         && dialect_->IsSqlStateAccessError(sql_state.c_str(), error_message);

--- a/driver/plugin/federated/base_saml_auth_plugin.cpp
+++ b/driver/plugin/federated/base_saml_auth_plugin.cpp
@@ -1,0 +1,133 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "base_saml_auth_plugin.h"
+
+#include "../../util/connection_string_keys.h"
+#include "../../util/logger_wrapper.h"
+#include "../../util/map_utils.h"
+#include "../../util/plugin_service.h"
+#include "../../util/rds_utils.h"
+
+BaseSamlAuthPlugin::BaseSamlAuthPlugin(
+    DBC* dbc,
+    std::shared_ptr<BasePlugin> next_plugin,
+    const std::shared_ptr<SamlUtil>& saml_util,
+    const std::shared_ptr<AuthProvider>& auth_provider,
+    std::shared_ptr<Dialect> dialect,
+    std::shared_ptr<OdbcHelper> odbc_helper)
+    : BasePlugin(dbc, next_plugin)
+{
+    this->saml_util = saml_util;
+    this->auth_provider = auth_provider;
+
+    if (dialect) {
+        this->dialect_ = dialect;
+    } else if (dbc->plugin_service) {
+        this->dialect_ = dbc->plugin_service->GetDialect();
+    }
+
+    if (odbc_helper) {
+        this->odbc_helper_ = odbc_helper;
+    } else if (dbc->plugin_service) {
+        this->odbc_helper_ = dbc->plugin_service->GetOdbcHelper();
+    }
+}
+
+BaseSamlAuthPlugin::~BaseSamlAuthPlugin()
+{
+    if (auth_provider) {
+        auth_provider.reset();
+    }
+    if (saml_util) {
+        saml_util.reset();
+    }
+}
+
+SQLRETURN BaseSamlAuthPlugin::Connect(
+    SQLHDBC        ConnectionHandle,
+    SQLHWND        WindowHandle,
+    SQLTCHAR *     OutConnectionString,
+    SQLSMALLINT    BufferLength,
+    SQLSMALLINT *  StringLengthPtr,
+    SQLUSMALLINT   DriverCompletion)
+{
+    LOG(INFO) << "[" << plugin_name << "] Entering Connect";
+    DBC* dbc = static_cast<DBC*>(ConnectionHandle);
+
+    const std::string server = MapUtils::GetStringValue(dbc->conn_attr, KEY_SERVER, "");
+    const std::string iam_host = MapUtils::GetStringValue(dbc->conn_attr, KEY_IAM_HOST, server);
+    std::string region = MapUtils::GetStringValue(dbc->conn_attr, KEY_REGION, "");
+    if (region.empty()) {
+        region = dbc->conn_attr.contains(KEY_SERVER) ?
+            RdsUtils::GetRdsRegion(dbc->conn_attr.at(KEY_SERVER))
+            : Aws::Region::US_EAST_1;
+    }
+    const std::string port = AuthProvider::GetPort(dbc);
+    const std::string username = MapUtils::GetStringValue(dbc->conn_attr, KEY_DB_USERNAME, "");
+    const std::chrono::milliseconds token_expiration = dbc->conn_attr.contains(KEY_TOKEN_EXPIRATION) ?
+        std::chrono::seconds(std::strtol(dbc->conn_attr.at(KEY_TOKEN_EXPIRATION).c_str(), nullptr, 0))
+        : AuthProvider::DEFAULT_EXPIRATION_MS;
+    const bool extra_url_encode = MapUtils::GetBooleanValue(dbc->conn_attr, KEY_EXTRA_URL_ENCODE, false);
+
+    if (iam_host.empty() || region.empty() || port.empty() || username.empty()) {
+        LOG(ERROR) << "Missing required parameters for " << plugin_name << " Authentication";
+        CLEAR_DBC_ERROR(dbc);
+        std::string err_msg = "Missing required parameters for " + plugin_name + " Authentication";
+        dbc->err = new ERR_INFO(err_msg.c_str(), ERR_CLIENT_UNABLE_TO_ESTABLISH_CONNECTION);
+        return SQL_ERROR;
+    }
+
+    std::pair<std::string, bool> token = auth_provider->GetToken(
+        iam_host, region, port, username, true, extra_url_encode, token_expiration);
+    const bool is_cached_token = token.second;
+
+    dbc->conn_attr.insert_or_assign(KEY_DB_PASSWORD, token.first);
+    SQLRETURN ret = next_plugin->Connect(
+        ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
+
+    if (SQL_SUCCEEDED(ret)) {
+        return ret;
+    }
+
+    // Check if the failure is a login/access error
+    std::string sql_state;
+    if (odbc_helper_) {
+        sql_state = odbc_helper_->GetSqlStateAndLogMessage(dbc);
+    }
+    const bool is_access_error = dialect_ && !sql_state.empty()
+        && dialect_->IsSqlStateAccessError(sql_state.c_str());
+
+    // Only retry with a fresh token if the token was from cache AND the error is an access/login error.
+    // Non-access errors (network, DNS, etc.) are not token-related and should not trigger a retry.
+    if (!is_cached_token || !is_access_error) {
+        return ret;
+    }
+
+    LOG(WARNING) << "[" << plugin_name << "] Cached token failed to connect with access error (sql_state="
+                 << sql_state << "). Retrying with fresh SAML credentials and token";
+
+    // Refresh SAML credentials before generating a new token
+    const std::string saml_assertion = saml_util->GetSamlAssertion();
+    const Aws::Auth::AWSCredentials credentials = saml_util->GetAwsCredentials(saml_assertion);
+    auth_provider->UpdateAwsCredential(credentials);
+
+    token = auth_provider->GetToken(
+        iam_host, region, port, username, false, extra_url_encode, token_expiration);
+    dbc->conn_attr.insert_or_assign(KEY_DB_PASSWORD, token.first);
+    ret = next_plugin->Connect(
+        ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
+
+    return ret;
+}

--- a/driver/plugin/federated/base_saml_auth_plugin.h
+++ b/driver/plugin/federated/base_saml_auth_plugin.h
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BASE_SAML_AUTH_PLUGIN_H_
+#define BASE_SAML_AUTH_PLUGIN_H_
+
+#include "../../util/auth_provider.h"
+#include "../../dialect/dialect.h"
+#include "../../util/odbc_helper.h"
+
+#include "saml_util.h"
+#include "../base_plugin.h"
+#include "../../driver.h"
+
+#include <memory>
+
+class BaseSamlAuthPlugin : public BasePlugin {
+public:
+    BaseSamlAuthPlugin(DBC* dbc, std::shared_ptr<BasePlugin> next_plugin,
+                       const std::shared_ptr<SamlUtil>& saml_util,
+                       const std::shared_ptr<AuthProvider>& auth_provider,
+                       std::shared_ptr<Dialect> dialect = nullptr,
+                       std::shared_ptr<OdbcHelper> odbc_helper = nullptr);
+    ~BaseSamlAuthPlugin() override;
+
+    SQLRETURN Connect(
+        SQLHDBC        ConnectionHandle,
+        SQLHWND        WindowHandle,
+        SQLTCHAR *     OutConnectionString,
+        SQLSMALLINT    BufferLength,
+        SQLSMALLINT *  StringLengthPtr,
+        SQLUSMALLINT   DriverCompletion) override;
+
+protected:
+    std::shared_ptr<AuthProvider> auth_provider;
+    std::shared_ptr<SamlUtil> saml_util;
+    std::shared_ptr<Dialect> dialect_;
+    std::shared_ptr<OdbcHelper> odbc_helper_;
+};
+
+#endif // BASE_SAML_AUTH_PLUGIN_H_

--- a/driver/plugin/federated/okta_auth_plugin.cpp
+++ b/driver/plugin/federated/okta_auth_plugin.cpp
@@ -35,95 +35,48 @@ OktaAuthPlugin::OktaAuthPlugin(DBC *dbc) : OktaAuthPlugin(dbc, nullptr) {}
 
 OktaAuthPlugin::OktaAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin) : OktaAuthPlugin(dbc, next_plugin, nullptr, nullptr) {}
 
-OktaAuthPlugin::OktaAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin, const std::shared_ptr<SamlUtil> &saml_util, const std::shared_ptr<AuthProvider> &auth_provider) : BasePlugin(dbc, next_plugin)
-{
-    this->plugin_name = "OKTA";
-
-    if (saml_util) {
-        this->saml_util = saml_util;
-    } else {
-        this->saml_util = std::make_shared<OktaSamlUtil>(dbc->conn_attr);
+namespace {
+    std::shared_ptr<SamlUtil> CreateOktaSamlUtil(
+        DBC* dbc,
+        const std::shared_ptr<SamlUtil>& saml_util)
+    {
+        if (saml_util) {
+            return saml_util;
+        }
+        return std::make_shared<OktaSamlUtil>(dbc->conn_attr);
     }
 
-    if (auth_provider) {
-        this->auth_provider = auth_provider;
-    } else {
+    std::shared_ptr<AuthProvider> CreateOktaAuthProvider(
+        DBC* dbc,
+        const std::shared_ptr<SamlUtil>& resolved_saml,
+        const std::shared_ptr<AuthProvider>& auth_provider)
+    {
+        if (auth_provider) {
+            return auth_provider;
+        }
         std::string region = MapUtils::GetStringValue(dbc->conn_attr, KEY_REGION, "");
-
         if (region.empty()) {
             region = dbc->conn_attr.contains(KEY_SERVER) ?
                 RdsUtils::GetRdsRegion(dbc->conn_attr.at(KEY_SERVER))
                 : Aws::Region::US_EAST_1;
         }
-        const std::string saml_assertion = this->saml_util->GetSamlAssertion();
-        this->auth_provider = std::make_shared<AuthProvider>(region, this->saml_util->GetAwsCredentials(saml_assertion));
+        const std::string assertion = resolved_saml->GetSamlAssertion();
+        return std::make_shared<AuthProvider>(region, resolved_saml->GetAwsCredentials(assertion));
     }
-}
+}  // namespace
 
-OktaAuthPlugin::~OktaAuthPlugin()
+OktaAuthPlugin::OktaAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin, const std::shared_ptr<SamlUtil> &saml_util, const std::shared_ptr<AuthProvider> &auth_provider)
+    : OktaAuthPlugin(dbc, next_plugin, saml_util, auth_provider, nullptr, nullptr) {}
+
+OktaAuthPlugin::OktaAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin,
+                               const std::shared_ptr<SamlUtil> &saml_util, const std::shared_ptr<AuthProvider> &auth_provider,
+                               std::shared_ptr<Dialect> dialect, std::shared_ptr<OdbcHelper> odbc_helper)
+    : BaseSamlAuthPlugin(dbc, next_plugin,
+        CreateOktaSamlUtil(dbc, saml_util),
+        CreateOktaAuthProvider(dbc, CreateOktaSamlUtil(dbc, saml_util), auth_provider),
+        dialect, odbc_helper)
 {
-    if (auth_provider) {
-        auth_provider = nullptr;
-    }
-    if (saml_util) {
-        saml_util = nullptr;
-    }
-}
-
-SQLRETURN OktaAuthPlugin::Connect(
-    SQLHDBC        ConnectionHandle,
-    SQLHWND        WindowHandle,
-    SQLTCHAR *     OutConnectionString,
-    SQLSMALLINT    BufferLength,
-    SQLSMALLINT *  StringLengthPtr,
-    SQLUSMALLINT   DriverCompletion)
-{
-    LOG(INFO) << "Entering Connect";
-    DBC* dbc = static_cast<DBC*>(ConnectionHandle);
-
-    const std::string server = MapUtils::GetStringValue(dbc->conn_attr, KEY_SERVER, "");
-    const std::string iam_host = MapUtils::GetStringValue(dbc->conn_attr, KEY_IAM_HOST, server);
-    std::string region = MapUtils::GetStringValue(dbc->conn_attr, KEY_REGION, "");
-    if (region.empty()) {
-        region = dbc->conn_attr.contains(KEY_SERVER) ?
-            RdsUtils::GetRdsRegion(dbc->conn_attr.at(KEY_SERVER))
-            : Aws::Region::US_EAST_1;
-    }
-    const std::string port = AuthProvider::GetPort(dbc);
-    const std::string username = MapUtils::GetStringValue(dbc->conn_attr, KEY_DB_USERNAME, "");
-    const std::chrono::milliseconds token_expiration = dbc->conn_attr.contains(KEY_TOKEN_EXPIRATION) ?
-        std::chrono::seconds(std::strtol(dbc->conn_attr.at(KEY_TOKEN_EXPIRATION).c_str(), nullptr, 0))
-        : AuthProvider::DEFAULT_EXPIRATION_MS;
-    const bool extra_url_encode = MapUtils::GetBooleanValue(dbc->conn_attr, KEY_EXTRA_URL_ENCODE, false);
-
-    if (iam_host.empty() || region.empty() || port.empty() || username.empty()) {
-        LOG(ERROR) << "Missing required parameters for Okta Authentication";
-        CLEAR_DBC_ERROR(dbc);
-        dbc->err = new ERR_INFO("Missing required parameters for Okta Authentication", ERR_CLIENT_UNABLE_TO_ESTABLISH_CONNECTION);
-        return SQL_ERROR;
-    }
-    std::pair<std::string, bool> token = auth_provider->GetToken(iam_host, region, port, username, true, extra_url_encode, token_expiration);
-
-    SQLRETURN ret = SQL_ERROR;
-
-    dbc->conn_attr.insert_or_assign(KEY_DB_PASSWORD, token.first);
-    ret = next_plugin->Connect(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
-
-    // Unsuccessful connection using cached token
-    // Skip cache and generate a new token to retry
-    if (!SQL_SUCCEEDED(ret) && token.second) {
-        LOG(WARNING) << "Cached token failed to connect. Retrying with fresh token";
-        // Update AWS Credentials
-        const std::string saml_assertion = saml_util->GetSamlAssertion();
-        const Aws::Auth::AWSCredentials credentials = saml_util->GetAwsCredentials(saml_assertion);
-        auth_provider->UpdateAwsCredential(credentials);
-        //  and retry without cache
-        token = auth_provider->GetToken(iam_host, region, port, username, false, extra_url_encode, token_expiration);
-        dbc->conn_attr.insert_or_assign(KEY_DB_PASSWORD, token.first);
-        ret = next_plugin->Connect(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
-    }
-
-    return ret;
+    this->plugin_name = "OKTA";
 }
 
 OktaSamlUtil::OktaSamlUtil(const std::map<std::string, std::string> &connection_attributes)

--- a/driver/plugin/federated/okta_auth_plugin.h
+++ b/driver/plugin/federated/okta_auth_plugin.h
@@ -18,7 +18,7 @@
 #include "../../util/auth_provider.h"
 
 #include "saml_util.h"
-#include "../base_plugin.h"
+#include "base_saml_auth_plugin.h"
 #include "../../driver.h"
 
 typedef enum {
@@ -59,24 +59,14 @@ private:
     static inline const std::regex SAML_RESPONSE_PATTERN = std::regex("<input name=\"SAMLResponse\".+value=\"(.+)\"/\\>");
 };
 
-class OktaAuthPlugin : public BasePlugin {
+class OktaAuthPlugin : public BaseSamlAuthPlugin {
 public:
     OktaAuthPlugin(DBC* dbc);
     OktaAuthPlugin(DBC* dbc, std::shared_ptr<BasePlugin> next_plugin);
     OktaAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin, const std::shared_ptr<SamlUtil> &saml_util, const std::shared_ptr<AuthProvider> &auth_provider);
-    ~OktaAuthPlugin() override;
-
-    SQLRETURN Connect(
-        SQLHDBC        ConnectionHandle,
-        SQLHWND        WindowHandle,
-        SQLTCHAR *     OutConnectionString,
-        SQLSMALLINT    BufferLength,
-        SQLSMALLINT *  StringLengthPtr,
-        SQLUSMALLINT   DriverCompletion) override;
-
-private:
-    std::shared_ptr<AuthProvider> auth_provider;
-    std::shared_ptr<SamlUtil> saml_util;
+    OktaAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin,
+                   const std::shared_ptr<SamlUtil> &saml_util, const std::shared_ptr<AuthProvider> &auth_provider,
+                   std::shared_ptr<Dialect> dialect, std::shared_ptr<OdbcHelper> odbc_helper);
 };
 
 #endif // OKTA_AUTH_PLUGIN_H_

--- a/driver/plugin/iam/iam_auth_plugin.cpp
+++ b/driver/plugin/iam/iam_auth_plugin.cpp
@@ -113,7 +113,7 @@ SQLRETURN IamAuthPlugin::Connect(
     std::string sql_state;
     std::string error_message;
     if (odbc_helper_) {
-        sql_state = odbc_helper_->GetSqlStateAndLogMessage(dbc, &error_message);
+        sql_state = odbc_helper_->GetSqlStateAndLogMessage(dbc, error_message);
     }
 
     // Only retry with a fresh token if the token was from cache AND the error is an access/login error.

--- a/driver/plugin/iam/iam_auth_plugin.cpp
+++ b/driver/plugin/iam/iam_auth_plugin.cpp
@@ -111,14 +111,15 @@ SQLRETURN IamAuthPlugin::Connect(
 
     // Check if the failure is a login/access error
     std::string sql_state;
+    std::string error_message;
     if (odbc_helper_) {
-        sql_state = odbc_helper_->GetSqlStateAndLogMessage(dbc);
+        sql_state = odbc_helper_->GetSqlStateAndLogMessage(dbc, &error_message);
     }
-    const bool is_access_error = dialect_ && !sql_state.empty() && dialect_->IsSqlStateAccessError(sql_state.c_str());
 
     // Only retry with a fresh token if the token was from cache AND the error is an access/login error.
     // Non-access errors (network, DNS, etc.) are not token-related and should not trigger a retry.
-    if (!is_cached_token || !is_access_error) {
+    if (const bool is_access_error = dialect_ && !sql_state.empty() && dialect_->IsSqlStateAccessError(sql_state.c_str(), error_message);
+        !is_cached_token || !is_access_error) {
         return ret;
     }
 

--- a/driver/plugin/iam/iam_auth_plugin.cpp
+++ b/driver/plugin/iam/iam_auth_plugin.cpp
@@ -20,15 +20,34 @@
 #include "../../util/aws_sdk_helper.h"
 #include "../../util/connection_string_keys.h"
 #include "../../util/map_utils.h"
+#include "../../util/plugin_service.h"
 #include "../../util/rds_utils.h"
 
 IamAuthPlugin::IamAuthPlugin(DBC *dbc) : IamAuthPlugin(dbc, nullptr) {}
 
-IamAuthPlugin::IamAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin) : IamAuthPlugin(dbc, next_plugin, nullptr) {}
+IamAuthPlugin::IamAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin) : IamAuthPlugin(dbc, next_plugin, nullptr, nullptr, nullptr) {}
 
-IamAuthPlugin::IamAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin, const std::shared_ptr<AuthProvider>& auth_provider) : BasePlugin(dbc, next_plugin)
+IamAuthPlugin::IamAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin, const std::shared_ptr<AuthProvider>& auth_provider)
+    : IamAuthPlugin(dbc, next_plugin, auth_provider, nullptr, nullptr) {}
+
+IamAuthPlugin::IamAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin,
+                             const std::shared_ptr<AuthProvider>& auth_provider,
+                             std::shared_ptr<Dialect> dialect,
+                             std::shared_ptr<OdbcHelper> odbc_helper) : BasePlugin(dbc, next_plugin)
 {
     this->plugin_name = "IAM";
+
+    if (dialect) {
+        this->dialect_ = dialect;
+    } else if (dbc->plugin_service) {
+        this->dialect_ = dbc->plugin_service->GetDialect();
+    }
+
+    if (odbc_helper) {
+        this->odbc_helper_ = odbc_helper;
+    } else if (dbc->plugin_service) {
+        this->odbc_helper_ = dbc->plugin_service->GetOdbcHelper();
+    }
 
     if (auth_provider) {
         this->auth_provider = auth_provider;
@@ -47,7 +66,7 @@ IamAuthPlugin::IamAuthPlugin(DBC *dbc, std::shared_ptr<BasePlugin> next_plugin, 
 IamAuthPlugin::~IamAuthPlugin()
 {
     if (auth_provider) {
-        auth_provider = nullptr;
+        auth_provider.reset();
     }
 }
 
@@ -81,20 +100,32 @@ SQLRETURN IamAuthPlugin::Connect(
     }
 
     std::pair<std::string, bool> token = auth_provider->GetToken(iam_host, region, port, username, true, extra_url_encode, token_expiration);
-
-    SQLRETURN ret = SQL_ERROR;
+    const bool is_cached_token = token.second;
 
     dbc->conn_attr.insert_or_assign(KEY_DB_PASSWORD, token.first);
-    ret = next_plugin->Connect(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
+    SQLRETURN ret = next_plugin->Connect(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
 
-    // Unsuccessful connection using cached token
-    // Skip cache and generate a new token to retry
-    if (!SQL_SUCCEEDED(ret) && token.second) {
-        LOG(WARNING) << "Cached token failed to connect. Retrying with fresh token";
-        token = auth_provider->GetToken(iam_host, region, port, username, false, extra_url_encode, token_expiration);
-        dbc->conn_attr.insert_or_assign(KEY_DB_PASSWORD, token.first);
-        ret = next_plugin->Connect(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
+    if (SQL_SUCCEEDED(ret)) {
+        return ret;
     }
+
+    // Check if the failure is a login/access error
+    std::string sql_state;
+    if (odbc_helper_) {
+        sql_state = odbc_helper_->GetSqlStateAndLogMessage(dbc);
+    }
+    const bool is_access_error = dialect_ && !sql_state.empty() && dialect_->IsSqlStateAccessError(sql_state.c_str());
+
+    // Only retry with a fresh token if the token was from cache AND the error is an access/login error.
+    // Non-access errors (network, DNS, etc.) are not token-related and should not trigger a retry.
+    if (!is_cached_token || !is_access_error) {
+        return ret;
+    }
+
+    LOG(WARNING) << "Cached token failed to connect with access error (sql_state=" << sql_state << "). Retrying with fresh token";
+    token = auth_provider->GetToken(iam_host, region, port, username, false, extra_url_encode, token_expiration);
+    dbc->conn_attr.insert_or_assign(KEY_DB_PASSWORD, token.first);
+    ret = next_plugin->Connect(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
 
     return ret;
 }

--- a/driver/plugin/iam/iam_auth_plugin.h
+++ b/driver/plugin/iam/iam_auth_plugin.h
@@ -19,6 +19,8 @@
 
 #include "../base_plugin.h"
 #include "../../driver.h"
+#include "../../dialect/dialect.h"
+#include "../../util/odbc_helper.h"
 
 #include <memory>
 
@@ -27,6 +29,10 @@ public:
     IamAuthPlugin(DBC* dbc);
     IamAuthPlugin(DBC* dbc, std::shared_ptr<BasePlugin> next_plugin);
     IamAuthPlugin(DBC* dbc, std::shared_ptr<BasePlugin> next_plugin, const std::shared_ptr<AuthProvider>& auth_provider);
+    IamAuthPlugin(DBC* dbc, std::shared_ptr<BasePlugin> next_plugin,
+                  const std::shared_ptr<AuthProvider>& auth_provider,
+                  std::shared_ptr<Dialect> dialect,
+                  std::shared_ptr<OdbcHelper> odbc_helper);
     ~IamAuthPlugin() override;
 
     SQLRETURN Connect(
@@ -39,6 +45,8 @@ public:
 
 private:
     std::shared_ptr<AuthProvider> auth_provider;
+    std::shared_ptr<Dialect> dialect_;
+    std::shared_ptr<OdbcHelper> odbc_helper_;
 
     static bool ValidateRequiredParams(DBC* dbc, const std::string& iam_host, const std::string& region,
                                 const std::string& port, const std::string& username);

--- a/driver/plugin/limitless/limitless_router_service.cpp
+++ b/driver/plugin/limitless/limitless_router_service.cpp
@@ -211,7 +211,7 @@ SQLRETURN LimitlessRouterService::EstablishConnection(std::shared_ptr<BasePlugin
 
 void LimitlessRouterService::StartMonitoring(DBC* dbc, const std::shared_ptr<DialectLimitless> &dialect)
 {
-    std::shared_ptr<BasePlugin> plugin_head = dbc->plugin_service->GetPluginChain();
+    const std::shared_ptr<BasePlugin> plugin_head = dbc->plugin_service->GetPluginChain();
     const std::map<std::string, std::string> conn_attr = dbc->conn_attr;
     const std::string host = conn_attr.at(KEY_SERVER);
     router_monitor_key_ = host;

--- a/driver/util/odbc_helper.cpp
+++ b/driver/util/odbc_helper.cpp
@@ -200,11 +200,30 @@ void OdbcHelper::SetUse4BytesUserApp(const bool use_4_bytes) {
 }
 
 std::string OdbcHelper::GetSqlStateAndLogMessage(DBC* dbc) {
+    return GetSqlStateAndLogMessage(dbc, nullptr);
+}
+
+std::string OdbcHelper::GetSqlStateAndLogMessage(DBC* dbc, std::string* out_message) {
     SQLSMALLINT stmt_length;
     SQLINTEGER native_error;
     SQLTCHAR sql_state[MAX_SQL_STATE_LEN] = { 0 };
     SQLTCHAR message[MAX_MSG_LEN] = { 0 };
     RDS_SQLError(nullptr, static_cast<SQLHDBC>(dbc), nullptr, sql_state, &native_error, message, MAX_MSG_LEN, &stmt_length, true);
     LOG(WARNING) << "SQL State: " << AS_UTF8_CSTR(sql_state) << ". Message: " << AS_UTF8_CSTR(message);
+    if (out_message) {
+        *out_message = AS_UTF8_CSTR(message);
+    }
     return AS_UTF8_CSTR(sql_state);
+}
+std::string OdbcHelper::GetStmtErrorMessage(SQLHSTMT stmt) {
+    SQLTCHAR sql_state[MAX_SQL_STATE_LEN] = { 0 };
+    SQLTCHAR message[MAX_MSG_LEN] = { 0 };
+    SQLINTEGER native_error = 0;
+    SQLSMALLINT text_length = 0;
+    RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(lib_loader_, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
+        SQL_HANDLE_STMT, stmt, 1, sql_state, &native_error, message, MAX_MSG_LEN, &text_length);
+    if (SQL_SUCCEEDED(res.fn_result)) {
+        return AS_UTF8_CSTR(message);
+    }
+    return "";
 }

--- a/driver/util/odbc_helper.cpp
+++ b/driver/util/odbc_helper.cpp
@@ -200,19 +200,18 @@ void OdbcHelper::SetUse4BytesUserApp(const bool use_4_bytes) {
 }
 
 std::string OdbcHelper::GetSqlStateAndLogMessage(DBC* dbc) {
-    return GetSqlStateAndLogMessage(dbc, nullptr);
+    std::string unused;
+    return GetSqlStateAndLogMessage(dbc, unused);
 }
 
-std::string OdbcHelper::GetSqlStateAndLogMessage(DBC* dbc, std::string* out_message) {
+std::string OdbcHelper::GetSqlStateAndLogMessage(DBC* dbc, std::string& out_message) {
     SQLSMALLINT stmt_length;
     SQLINTEGER native_error;
     SQLTCHAR sql_state[MAX_SQL_STATE_LEN] = { 0 };
     SQLTCHAR message[MAX_MSG_LEN] = { 0 };
     RDS_SQLError(nullptr, static_cast<SQLHDBC>(dbc), nullptr, sql_state, &native_error, message, MAX_MSG_LEN, &stmt_length, true);
     LOG(WARNING) << "SQL State: " << AS_UTF8_CSTR(sql_state) << ". Message: " << AS_UTF8_CSTR(message);
-    if (out_message) {
-        *out_message = AS_UTF8_CSTR(message);
-    }
+    out_message = AS_UTF8_CSTR(message);
     return AS_UTF8_CSTR(sql_state);
 }
 std::string OdbcHelper::GetStmtErrorMessage(SQLHSTMT stmt) {

--- a/driver/util/odbc_helper.h
+++ b/driver/util/odbc_helper.h
@@ -52,6 +52,8 @@ public:
     void SetUse4BytesUserApp(bool use_4_bytes);
 
     virtual std::string GetSqlStateAndLogMessage(DBC *dbc);
+    virtual std::string GetSqlStateAndLogMessage(DBC *dbc, std::string* out_message);
+    virtual std::string GetStmtErrorMessage(SQLHSTMT stmt);
 
 private:
     std::shared_ptr<RdsLibLoader> lib_loader_;

--- a/driver/util/odbc_helper.h
+++ b/driver/util/odbc_helper.h
@@ -52,7 +52,7 @@ public:
     void SetUse4BytesUserApp(bool use_4_bytes);
 
     virtual std::string GetSqlStateAndLogMessage(DBC *dbc);
-    virtual std::string GetSqlStateAndLogMessage(DBC *dbc, std::string* out_message);
+    virtual std::string GetSqlStateAndLogMessage(DBC *dbc, std::string& out_message);
     virtual std::string GetStmtErrorMessage(SQLHSTMT stmt);
 
 private:

--- a/driver/util/plugin_chain_builder.h
+++ b/driver/util/plugin_chain_builder.h
@@ -27,6 +27,6 @@
 
 namespace PluginChainBuilder {
     std::shared_ptr<BasePlugin> MonitoringBuild(std::map<std::string, std::string> conn_attr, std::shared_ptr<PluginService> plugin_service);
-}
+}  // namespace PluginChainBuilder
 
 #endif PLUGIN_CHAIN_BUILDER_H_

--- a/driver/util/plugin_service.cpp
+++ b/driver/util/plugin_service.cpp
@@ -16,6 +16,7 @@
 
 #include "plugin_service.h"
 
+#include "map_utils.h"
 #include "rds_utils.h"
 
 #include "map_utils.h"
@@ -35,9 +36,10 @@
 PluginService::PluginService(const std::shared_ptr<RdsLibLoader>& lib_loader, std::map<std::string, std::string> original_conn_attr)
     : PluginService(lib_loader, original_conn_attr, "") {}
 
-PluginService::PluginService(const std::shared_ptr<RdsLibLoader>& lib_loader, std::map<std::string, std::string> original_conn_attr,
-                             std::string original_conn_str)
-    : original_conn_str_{ std::move(original_conn_str) }, original_conn_attr_{ std::move(original_conn_attr) } {
+PluginService::PluginService(const std::shared_ptr<RdsLibLoader>& lib_loader, std::map<std::string, std::string> original_conn_attr, std::string original_conn_str) :
+    original_conn_str_{ std::move(original_conn_str) },
+    original_conn_attr_{ std::move(original_conn_attr) }
+{
     this->initial_host_ = HostInfo(
         original_conn_attr_.contains(KEY_SERVER) ?
             original_conn_attr_.at(KEY_SERVER) : "",
@@ -192,8 +194,8 @@ void PluginService::InitHostListProvider() {
             monitoring_cluster_id = monitoring_cluster_id + "-monitor";
             monitoring_map.insert_or_assign(KEY_CLUSTER_ID, monitoring_cluster_id);
 
-            std::shared_ptr<PluginService> monitor_plugin_service = std::make_shared<PluginService>(this->odbc_helper_->GetLibLoader(), monitoring_map);
-            std::shared_ptr<BasePlugin> plugin_head = PluginChainBuilder::MonitoringBuild(monitoring_map, monitor_plugin_service);
+            const std::shared_ptr<PluginService> monitor_plugin_service = std::make_shared<PluginService>(this->odbc_helper_->GetLibLoader(), monitoring_map);
+            const std::shared_ptr<BasePlugin> plugin_head = PluginChainBuilder::MonitoringBuild(monitoring_map, monitor_plugin_service);
             monitor_plugin_service->SetPluginChain(plugin_head);
             this->host_list_provider_ = std::make_shared<RdsHostListProvider>(
                 monitor_plugin_service->GetTopologyUtil(),

--- a/driver/util/rds_utils.cpp
+++ b/driver/util/rds_utils.cpp
@@ -116,9 +116,10 @@ std::string RdsUtils::RemoveGreenInstancePrefix(const std::string& host) {
     std::string prefix = match.size() > 1 ? match[1].str() : "";
     std::string converted_host = host;
     if (!prefix.empty()) {
-        size_t begin_idx = host.find(prefix);
+        std::string search = prefix + ".";
+        size_t begin_idx = host.find(search);
         if (begin_idx != std::string::npos) {
-            converted_host = converted_host.replace(begin_idx, begin_idx + prefix.length(), ".");
+            converted_host = converted_host.replace(begin_idx, search.length(), ".");
         }
     }
     return converted_host;

--- a/test/common/test_utils.cpp
+++ b/test/common/test_utils.cpp
@@ -71,8 +71,6 @@ std::string TEST_UTILS::HostToIp(std::string hostname) {
     hints.ai_socktype = SOCK_STREAM;
 
     if ((status = getaddrinfo(hostname.c_str(), NULL, &hints, &servinfo)) != 0) {
-        ADD_FAILURE() << "The IP address of host " << hostname << " could not be determined."
-            << "getaddrinfo error:" << gai_strerror(status);
         return {};
     }
 

--- a/test/integration/base_failover_integration_test.h
+++ b/test/integration/base_failover_integration_test.h
@@ -321,6 +321,7 @@ protected:
                                                  const Aws::String& initial_writer_id, const Aws::String& target_writer_id = "") {
         auto cluster_endpoint = GetDbCluster(client, cluster_id).GetEndpoint();
         std::string initial_writer_ip = TEST_UTILS::HostToIp(cluster_endpoint);
+        ASSERT_FALSE(initial_writer_ip.empty()) << "Failed to resolve IP address for host: " << cluster_endpoint;
 
         FailoverCluster(client, cluster_id, target_writer_id);
 
@@ -337,6 +338,7 @@ protected:
 
         // Failover has finished, wait for DNS to be updated so cluster endpoint resolves to the correct writer instance.
         std::string current_writer_ip = TEST_UTILS::HostToIp(cluster_endpoint);
+        ASSERT_FALSE(current_writer_ip.empty()) << "Failed to resolve IP address for host: " << cluster_endpoint;
         auto start = std::chrono::high_resolution_clock::now();
         while (initial_writer_ip == current_writer_ip) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -345,6 +347,7 @@ protected:
             }
 
             current_writer_ip = TEST_UTILS::HostToIp(cluster_endpoint);
+            ASSERT_FALSE(current_writer_ip.empty()) << "Failed to resolve IP address for host: " << cluster_endpoint;
         }
     }
 

--- a/test/integration/base_failover_integration_test.h
+++ b/test/integration/base_failover_integration_test.h
@@ -209,7 +209,7 @@ protected:
         auto outcome = client.DescribeDBClusters(rds_req);
 
         if (!outcome.IsSuccess()) {
-            std::cerr << "Error with Aurora::GDescribeDBClusters. " << outcome.GetError().GetMessage() << std::endl;
+            std::cerr << "Error with Aurora::DescribeDBClusters. " << outcome.GetError().GetMessage() << std::endl;
             throw std::runtime_error("Unable to get cluster topology using SDK.");
         }
 
@@ -253,7 +253,11 @@ protected:
         Aws::RDS::Model::DescribeDBClusterEndpointsRequest request;
         request.SetDBClusterEndpointIdentifier(endpoint_id);
         const auto response = client.DescribeDBClusterEndpoints(request);
-        return response.GetResult().GetDBClusterEndpoints()[0];
+        const auto& endpoints = response.GetResult().GetDBClusterEndpoints();
+        if (endpoints.empty()) {
+            throw std::runtime_error("DescribeDBClusterEndpoints returned no endpoints for: " + endpoint_id);
+        }
+        return endpoints[0];
     }
 
     static Aws::RDS::Model::DBClusterMember GetDbClusterWriter(const Aws::RDS::RDSClient& client, const Aws::String& cluster_id) {

--- a/test/integration/blue_green_integration_test.cpp
+++ b/test/integration/blue_green_integration_test.cpp
@@ -313,10 +313,6 @@ protected:
             }
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }
-
-        if (!SQL_SUCCEEDED(rc)) {
-            GTEST_FAIL() << "Could not connect: " << conn_str;
-        }
     }
 
     std::string GetDirectConnStr(const std::string& host, const bool& use_iam = true) {
@@ -1107,6 +1103,7 @@ protected:
                 std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
                 SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
             }
+            SQLSetConnectAttr(hdbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER)10, 0);
             OpenConnectionWithRetry(hdbc, conn_str);
 
             // Ready for work, wait for other threads
@@ -1144,6 +1141,7 @@ protected:
                 std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
                 SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
             }
+            SQLSetConnectAttr(hdbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER)10, 0);
             OpenConnectionWithRetry(hdbc, conn_str);
 
             // Ready for work, wait for other threads
@@ -1183,15 +1181,13 @@ protected:
             hstmt = SQL_NULL_HSTMT;
 
             // Phase 2 - Post-Switchover, reconnect and continue executing
-            // Use fresh DBC handles for reconnection (matching Java behavior where
-            // DriverManager.getConnection() creates a brand new Connection with fresh
-            // plugin state). Reusing the same DBC after switchover can carry stale
-            // BG plugin routing state that prevents successful reconnection.
+            // Matches Java behavior: each iteration tries a single connect attempt
+            // with a fresh DBC handle. If connect fails, record the error and try again next iteration
             ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, hdbc, SQL_NULL_HSTMT);
             hdbc = SQL_NULL_HDBC;
 
             while (!ThreadSynchronization::stop_flag) {
-                // Reconnect if needed
+                // Reconnect if needed with fresh DBC
                 if (hdbc == SQL_NULL_HDBC || !ODBC_HELPER::TestSimpleQuery(hdbc)) {
                     ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, SQL_NULL_HDBC, hstmt);
                     hstmt = SQL_NULL_HSTMT;
@@ -1203,7 +1199,16 @@ protected:
                         std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
                         SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
                     }
-                    OpenConnectionWithRetry(hdbc, conn_str);
+                    SQLSetConnectAttr(hdbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER)10, 0);
+                    if (!SQL_SUCCEEDED(ODBC_HELPER::DriverConnect(hdbc, conn_str))) {
+                        std::string err = ODBC_HELPER::PrintHandleError(hdbc, SQL_HANDLE_DBC);
+                        ThreadSynchronization::Print("[WrapperBlueExecutingConnectivityMonitoringThread: " + host_id + "] Phase 2 connect failed at offset "
+                            + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - global_start_time).count()) + "ms: " + err);
+                        ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, hdbc, SQL_NULL_HSTMT);
+                        hdbc = SQL_NULL_HDBC;
+                        std::this_thread::sleep_for(std::chrono::seconds(1));
+                        continue;
+                    }
                     SQLAllocHandle(SQL_HANDLE_STMT, hdbc, &hstmt);
                 }
 
@@ -1218,7 +1223,7 @@ protected:
                 } else {
                     end_time = std::chrono::steady_clock::now();
                     std::string err = ODBC_HELPER::PrintHandleError(hstmt, SQL_HANDLE_STMT);
-                    ThreadSynchronization::Print("[WrapperBlueExecutingConnectivityMonitoringThread: " + host_id + "] Phase 2 failed at offset "
+                    ThreadSynchronization::Print("[WrapperBlueExecutingConnectivityMonitoringThread: " + host_id + "] Phase 2 execute failed at offset "
                         + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(end_time - global_start_time).count()) + "ms: " + err);
                     post_switch_results.push_back(
                         TimeHolder(start_time, end_time, err)
@@ -1248,17 +1253,19 @@ protected:
         return std::thread([&](const std::string& host_id, const std::string& host){
             // Setup
             std::string conn_str = GetBlueGreenEnabledConnStr(host);
-            SQLHDBC hdbc = SQL_NULL_HDBC;
-            {
-                std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
-                SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
-            }
 
             // Ready for work, wait for other threads
             ThreadSynchronization::ReadyAndWait();
 
             // Work
             while (!ThreadSynchronization::stop_flag) {
+                SQLHDBC hdbc = SQL_NULL_HDBC;
+                {
+                    std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
+                    SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+                }
+                SQLSetConnectAttr(hdbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER)10, 0);
+
                 std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
                 std::chrono::steady_clock::time_point end_time = empty_time_point;
 
@@ -1277,12 +1284,9 @@ protected:
                     );
                 }
 
-                SQLDisconnect(hdbc);
+                ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, hdbc, SQL_NULL_HSTMT);
                 std::this_thread::sleep_for(std::chrono::seconds(1));
             }
-
-            // Cleanup
-            ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, hdbc, SQL_NULL_HSTMT);
 
             // Finished
             ThreadSynchronization::ThreadFinished();
@@ -1301,13 +1305,11 @@ protected:
                 std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
                 SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
             }
+            SQLSetConnectAttr(hdbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER)10, 0);
             OpenConnectionWithRetry(hdbc, conn_str);
             const std::string original_ip = GetConnectedServerIp(hdbc);
-            SQLDisconnect(hdbc);
-
-            if (original_ip.empty()) {
-                GTEST_FAIL() << "Unable to fetch original blue IP from initial connection.";
-            }
+            ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, hdbc, SQL_NULL_HSTMT);
+            hdbc = SQL_NULL_HDBC;
 
             ThreadSynchronization::Print("[WrapperBlueHostVerificationThread: " + host_id + "] Original Blue IP: " + original_ip);
 
@@ -1316,6 +1318,12 @@ protected:
 
             // Work
             while (!ThreadSynchronization::stop_flag) {
+                {
+                    std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
+                    SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+                }
+                SQLSetConnectAttr(hdbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER)10, 0);
+
                 std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
                 if (SQL_SUCCEEDED(ODBC_HELPER::DriverConnect(hdbc, conn_str))) {
                     std::string latest_ip = GetConnectedServerIp(hdbc);
@@ -1336,12 +1344,10 @@ protected:
                     );
                 }
 
-                SQLDisconnect(hdbc);
+                ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, hdbc, SQL_NULL_HSTMT);
+                hdbc = SQL_NULL_HDBC;
                 std::this_thread::sleep_for(std::chrono::seconds(1));
             }
-
-            // Cleanup
-            ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, hdbc, SQL_NULL_HSTMT);
 
             // Finished
             ThreadSynchronization::ThreadFinished();
@@ -1493,6 +1499,7 @@ protected:
                 std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
                 SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
             }
+            SQLSetConnectAttr(hdbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER)10, 0);
             OpenConnectionWithRetry(hdbc, conn_str);
 
             // Ready for work, wait for other threads
@@ -1662,9 +1669,6 @@ protected:
 
 TEST_F(BlueGreenIntegrationTest, SwitchoverTest) {
     const std::vector<std::string> topology_instances = GetBlueGreenEndpoints(blue_green_deployment_id);
-    if (topology_instances.empty()) {
-        GTEST_FAIL() << "Unable to describe Blue Green Endpoints for: " << blue_green_deployment_id;
-    }
 
     auto start_time = std::chrono::steady_clock::now();
     global_start_time = start_time;

--- a/test/integration/blue_green_integration_test.cpp
+++ b/test/integration/blue_green_integration_test.cpp
@@ -30,14 +30,20 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
+#include <cmath>
 #include <condition_variable>
 #include <deque>
+#include <iomanip>
 #include <iostream>
+#include <map>
 #include <mutex>
+#include <regex>
 #include <sstream>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
 namespace {
     struct TimeHolder {
@@ -102,6 +108,34 @@ namespace {
     };
 } // namespace
 
+namespace {
+    const std::regex BG_GREEN_HOST_PATTERN(R"#(.*(-green-[0-9a-z]{6})\..*)#", std::regex_constants::icase);
+    const std::regex BG_GREEN_HOSTID_PATTERN(R"#((.*)-green-[0-9a-z]{6})#", std::regex_constants::icase);
+
+    std::string RemoveGreenInstancePrefix(const std::string& host) {
+        if (host.empty()) {
+            return host;
+        }
+        std::smatch match;
+        if (!std::regex_match(host, match, BG_GREEN_HOST_PATTERN)) {
+            std::smatch host_id_match;
+            if (!std::regex_match(host, host_id_match, BG_GREEN_HOSTID_PATTERN)) {
+                return host;
+            }
+            return host_id_match.size() > 1 ? host_id_match[1].str() : host;
+        }
+        std::string prefix = match.size() > 1 ? match[1].str() : "";
+        std::string converted_host = host;
+        if (!prefix.empty()) {
+            size_t begin_idx = host.find(prefix);
+            if (begin_idx != std::string::npos) {
+                converted_host = converted_host.replace(begin_idx, begin_idx + prefix.length(), ".");
+            }
+        }
+        return converted_host;
+    }
+} // namespace
+
 namespace ThreadSynchronization {
     int total_threads = 0;
 
@@ -138,9 +172,11 @@ namespace ThreadSynchronization {
 
     std::mutex cout_mutex;
 
+    std::mutex env_mutex;
+
     void Print(const std::string& message) {
         // std::lock_guard<std::mutex> lock(cout_mutex);
-        // std::cout << message << std::endl;
+        std::cerr << message << std::endl;
     }
 }
 
@@ -153,7 +189,6 @@ protected:
     std::string session_token = TEST_UTILS::GetEnvVar("AWS_SESSION_TOKEN");
     std::string rds_endpoint = TEST_UTILS::GetEnvVar("RDS_ENDPOINT");
     std::string rds_region = TEST_UTILS::GetEnvVar("TEST_REGION", "us-west-1");
-    Aws::RDS::RDSClientConfiguration client_config;
     Aws::RDS::RDSClient rds_client;
 
     std::chrono::steady_clock::time_point empty_time_point{};
@@ -161,6 +196,7 @@ protected:
 
     ConnectionStringBuilder conn_str_builder;
     std::string test_iam_user = TEST_UTILS::GetEnvVar("TEST_IAM_USER", "");
+    std::string test_base_driver = TEST_UTILS::GetEnvVar("TEST_BASE_DRIVER", "");
 
     std::string sleep_query;
     std::string server_ip_query;
@@ -188,6 +224,7 @@ protected:
         Aws::Auth::AWSCredentials credentials =
             session_token.empty() ? Aws::Auth::AWSCredentials(access_key, secret_access_key)
                                   : Aws::Auth::AWSCredentials(access_key, secret_access_key, session_token);
+        Aws::RDS::RDSClientConfiguration client_config;
         client_config.region = rds_region;
         if (!rds_endpoint.empty()) {
             client_config.endpointOverride = rds_endpoint;
@@ -212,7 +249,7 @@ protected:
         conn_str_builder = ConnectionStringBuilder("")
             .withDSN(test_dsn)
             .withPort(test_port)
-            .withSslMode("prefer")
+            .withSslMode("require")
             .withAuthRegion(test_region)
             .withDatabase(test_db)
             .withDatabaseDialect(test_dialect)
@@ -274,7 +311,7 @@ protected:
             if (SQL_SUCCEEDED(rc = ODBC_HELPER::DriverConnect(hdbc, conn_str))) {
                 break;
             }
-            std::this_thread::sleep_for(std::chrono::seconds(5));
+            std::this_thread::sleep_for(std::chrono::seconds(1));
         }
 
         if (!SQL_SUCCEEDED(rc)) {
@@ -287,6 +324,7 @@ protected:
             ? ConnectionStringBuilder(conn_str_builder.getString())
                 .withUID(test_iam_user)
                 .withAuthMode("IAM")
+                .withSslMode("require")
                 .withExtraUrlEncode(true)
                 .withServer(host)
                 .getString()
@@ -303,7 +341,10 @@ protected:
             ? ConnectionStringBuilder(conn_str_builder.getString())
                 .withUID(test_iam_user)
                 .withAuthMode("IAM")
+                .withSslMode("require")
+                .withExtraUrlEncode(true)
                 .withBlueGreenEnabled(true)
+                .withEnableClusterFailover(false)
                 .withExtraUrlEncode(true)
                 .withServer(host)
                 .getString()
@@ -311,12 +352,333 @@ protected:
                 .withUID(test_uid)
                 .withPWD(test_pwd)
                 .withBlueGreenEnabled(true)
+                .withEnableClusterFailover(false)
                 .withServer(host)
                 .getString();
     }
 
-    void PrintMetrics() {
+    std::string FormatTimeOffset(std::chrono::steady_clock::time_point tp, std::chrono::steady_clock::time_point bg_trigger_time) {
+        if (tp == empty_time_point) {
+            return "-";
+        }
+        return std::to_string(GetTimeOffsetMs(tp, bg_trigger_time)) + " ms";
+    }
 
+    std::string TruncateError(const std::optional<std::string>& error, size_t max_len = 100) {
+        if (!error.has_value()) {
+            return "";
+        }
+        std::string e = error.value();
+        // Replace newlines with spaces
+        for (auto& c : e) {
+            if (c == '\n') c = ' ';
+        }
+        if (e.length() > max_len) {
+            e = e.substr(0, max_len) + "...";
+        }
+        return e;
+    }
+
+    long long GetPercentile(const std::deque<TimeHolder>& times, double percentile) {
+        if (times.empty()) {
+            return 0;
+        }
+        std::vector<long long> durations;
+        durations.reserve(times.size());
+        for (const auto& t : times) {
+            durations.push_back(
+                std::chrono::duration_cast<std::chrono::milliseconds>(t.end_time - t.start_time).count());
+        }
+        std::sort(durations.begin(), durations.end());
+        int rank = percentile == 0.0 ? 1 : static_cast<int>(std::ceil(percentile / 100.0 * durations.size()));
+        return durations[rank - 1];
+    }
+
+    // Sort entries: blue instances first, then green, alphabetically within each group
+    std::vector<std::pair<std::string, BlueGreenResults*>> GetSortedEntries() {
+        std::vector<std::pair<std::string, BlueGreenResults*>> entries;
+        for (auto& [host_id, result] : results) {
+            entries.push_back({host_id, &result});
+        }
+        std::sort(entries.begin(), entries.end(), [](const auto& a, const auto& b) {
+            bool a_green = a.first.find("-green-") != std::string::npos;
+            bool b_green = b.first.find("-green-") != std::string::npos;
+            if (a_green != b_green) {
+                return !a_green; // blue first
+            }
+            return RemoveGreenInstancePrefix(a.first) < RemoveGreenInstancePrefix(b.first);
+        });
+        return entries;
+    }
+
+    void PrintNodeStatusTimes(const std::string& node, const BlueGreenResults& result,
+        std::chrono::steady_clock::time_point bg_trigger_time)
+    {
+        // Merge blue and green status maps, sort by time
+        std::map<std::chrono::steady_clock::time_point, std::string> sorted_statuses;
+        for (const auto& [status, tp] : result.blue_status_time) {
+            sorted_statuses[tp] = status;
+        }
+        for (const auto& [status, tp] : result.green_status_time) {
+            sorted_statuses.try_emplace(tp, status);
+        }
+
+        // Collect unique status names in time order
+        std::vector<std::string> ordered_statuses;
+        for (const auto& [_, status] : sorted_statuses) {
+            if (std::find(ordered_statuses.begin(), ordered_statuses.end(), status) == ordered_statuses.end()) {
+                ordered_statuses.push_back(status);
+            }
+        }
+
+        std::ostringstream oss;
+        oss << "\n" << node << ":\n";
+        oss << "+------------------------------+---------------------+---------------------+\n";
+        oss << "| Status                       | SOURCE              | TARGET              |\n";
+        oss << "+------------------------------+---------------------+---------------------+\n";
+
+        for (const auto& status : ordered_statuses) {
+            std::string source_time;
+            auto blue_itr = result.blue_status_time.find(status);
+            if (blue_itr != result.blue_status_time.end()) {
+                source_time = std::to_string(GetTimeOffsetMs(blue_itr->second, bg_trigger_time)) + " ms";
+            }
+
+            std::string target_time;
+            auto green_itr = result.green_status_time.find(status);
+            if (green_itr != result.green_status_time.end()) {
+                target_time = std::to_string(GetTimeOffsetMs(green_itr->second, bg_trigger_time)) + " ms";
+            }
+
+            oss << "| " << std::left << std::setw(29) << status
+                << "| " << std::setw(20) << source_time
+                << "| " << std::setw(20) << target_time << "|\n";
+        }
+        oss << "+------------------------------+---------------------+---------------------+";
+        ThreadSynchronization::Print(oss.str());
+    }
+
+    void PrintDurationTimes(const std::string& node, const std::string& title,
+        const std::deque<TimeHolder>& times, std::chrono::steady_clock::time_point bg_trigger_time)
+    {
+        if (times.empty()) {
+            return;
+        }
+
+        long long p99 = GetPercentile(times, 99.0);
+
+        std::ostringstream oss;
+        oss << "\n" << node << ": " << title << "\n";
+        oss << "+---------------------+------------------------------+----------------------------------------------+\n";
+        oss << "| Connect at (ms)     | Connect time/duration (ms)   | Error                                        |\n";
+        oss << "+---------------------+------------------------------+----------------------------------------------+\n";
+        oss << "| " << std::left << std::setw(20) << "p99"
+            << "| " << std::setw(29) << p99
+            << "| " << std::setw(45) << "" << "|\n";
+        oss << "+---------------------+------------------------------+----------------------------------------------+\n";
+
+        auto print_row = [&](const TimeHolder& th) {
+            long long offset = GetTimeOffsetMs(th.start_time, bg_trigger_time);
+            long long duration = std::chrono::duration_cast<std::chrono::milliseconds>(th.end_time - th.start_time).count();
+            oss << "| " << std::left << std::setw(20) << offset
+                << "| " << std::setw(29) << duration
+                << "| " << std::setw(45) << TruncateError(th.error) << "|\n";
+        };
+
+        // First entry
+        print_row(times.front());
+
+        // Entries exceeding p99
+        for (const auto& th : times) {
+            long long duration = std::chrono::duration_cast<std::chrono::milliseconds>(th.end_time - th.start_time).count();
+            if (duration > p99) {
+                print_row(th);
+            }
+        }
+
+        // Last entry (if different from first)
+        if (times.size() > 1) {
+            print_row(times.back());
+        }
+
+        oss << "+---------------------+------------------------------+----------------------------------------------+";
+        ThreadSynchronization::Print(oss.str());
+    }
+
+    void PrintHostVerificationResults(const std::string& node,
+        const std::deque<HostVerificationResult>& host_results,
+        std::chrono::steady_clock::time_point bg_trigger_time)
+    {
+        long long total_attempts = static_cast<long long>(host_results.size());
+        long long total_successful = 0;
+        long long total_unsuccessful = 0;
+        long long connections_to_blue = 0;
+        long long connections_to_green = 0;
+
+        for (const auto& r : host_results) {
+            if (r.error.empty()) {
+                total_successful++;
+                if (r.connected_to_blue) {
+                    connections_to_blue++;
+                } else {
+                    connections_to_green++;
+                }
+            } else {
+                total_unsuccessful++;
+            }
+        }
+
+        std::chrono::steady_clock::time_point switchover_in_progress_time = GetSwitchoverInProgressTime();
+        long long in_progress_offset = GetTimeOffsetMs(switchover_in_progress_time, bg_trigger_time);
+
+        long long connections_to_blue_after_switchover = 0;
+        for (const auto& r : host_results) {
+            long long offset = GetTimeOffsetMs(r.timestamp, bg_trigger_time);
+            if (offset > in_progress_offset && r.connected_to_blue) {
+                connections_to_blue_after_switchover++;
+            }
+        }
+
+        std::ostringstream oss;
+        oss << "\n" << node << ": Host Verification Results\n";
+        oss << "+------------------------------------------------------------------------+---------------------+\n";
+        oss << "| Metric                                                                 | Value               |\n";
+        oss << "+------------------------------------------------------------------------+---------------------+\n";
+        oss << "| " << std::left << std::setw(71) << "Total verification attempts"
+            << "| " << std::setw(20) << total_attempts << "|\n";
+        oss << "| " << std::setw(71) << "Total successful connection and verification attempts"
+            << "| " << std::setw(20) << total_successful << "|\n";
+        oss << "| " << std::setw(71) << "Total unsuccessful/dropped attempts (expected during switchover)"
+            << "| " << std::setw(20) << total_unsuccessful << "|\n";
+        oss << "| " << std::setw(71) << "Total successful connections to blue"
+            << "| " << std::setw(20) << connections_to_blue << "|\n";
+        oss << "| " << std::setw(71) << "Total successful connections to green"
+            << "| " << std::setw(20) << connections_to_green << "|\n";
+        oss << "| " << std::setw(71) << "Connections to old blue after switchover in progress (ERROR if not 0)"
+            << "| " << std::setw(20) << connections_to_blue_after_switchover << "|\n";
+        oss << "+------------------------------------------------------------------------+---------------------+";
+
+        if (connections_to_blue_after_switchover > 0) {
+            oss << "\n| " << std::left << std::setw(20) << "Time (ms)"
+                << "| Connection to blue after switchover                                    |\n";
+            oss << "+------------------------------------------------------------------------+---------------------+\n";
+            for (const auto& r : host_results) {
+                long long offset = GetTimeOffsetMs(r.timestamp, bg_trigger_time);
+                if (offset > in_progress_offset && r.connected_to_blue) {
+                    oss << "| " << std::left << std::setw(20) << offset
+                        << "| " << std::setw(71)
+                        << (r.connected_host + " (original: " + r.original_blue_ip + ")") << "|\n";
+                }
+            }
+            oss << "+------------------------------------------------------------------------+---------------------+";
+        }
+
+        ThreadSynchronization::Print(oss.str());
+    }
+
+    void PrintMetrics() {
+        std::chrono::steady_clock::time_point bg_trigger_time = GetBgTriggerTime();
+        if (bg_trigger_time == empty_time_point) {
+            ThreadSynchronization::Print("PrintMetrics: No BG trigger time available.");
+            return;
+        }
+
+        auto sorted_entries = GetSortedEntries();
+
+        // Main metrics table
+        {
+            std::ostringstream oss;
+            oss << "\n===================== Blue/Green Switchover Metrics =====================\n";
+            oss << std::left
+                << std::setw(40) << "Instance"
+                << std::setw(14) << "startTime"
+                << std::setw(14) << "threadsSync"
+                << std::setw(16) << "Blue idle drop"
+                << std::setw(16) << "Blue SEL drop"
+                << std::setw(16) << "Wrap idle drop"
+                << std::setw(16) << "Green SEL drop"
+                << std::setw(16) << "Blue DNS"
+                << std::setw(16) << "Green DNS"
+                << std::setw(16) << "Green cert"
+                << "\n";
+
+            for (const auto& [host_id, result] : sorted_entries) {
+                long long start_offset = GetTimeOffsetMs(result->start_time, bg_trigger_time);
+                long long sync_offset = GetTimeOffsetMs(result->threads_sync_time, bg_trigger_time);
+
+                std::chrono::steady_clock::time_point green_node_time =
+                    result->green_node_changed_name_time_first_success != empty_time_point
+                        ? result->green_node_changed_name_time_first_success
+                        : result->green_node_changed_name_time_first_error;
+
+                oss << std::left
+                    << std::setw(40) << host_id
+                    << std::setw(14) << (std::to_string(start_offset) + " ms")
+                    << std::setw(14) << (std::to_string(sync_offset) + " ms")
+                    << std::setw(16) << FormatTimeOffset(result->direct_blue_idle_lost_connection_time, bg_trigger_time)
+                    << std::setw(16) << FormatTimeOffset(result->direct_blue_lost_connection_time, bg_trigger_time)
+                    << std::setw(16) << FormatTimeOffset(result->wrapper_blue_idle_lost_connection_time, bg_trigger_time)
+                    << std::setw(16) << FormatTimeOffset(result->wrapper_green_lost_connection_time, bg_trigger_time)
+                    << std::setw(16) << FormatTimeOffset(result->dns_blue_changed_time, bg_trigger_time)
+                    << std::setw(16) << FormatTimeOffset(result->dns_green_removed_time, bg_trigger_time)
+                    << std::setw(16) << FormatTimeOffset(green_node_time, bg_trigger_time)
+                    << "\n";
+            }
+            oss << "=========================================================================";
+            ThreadSynchronization::Print(oss.str());
+        }
+
+        // Node status times
+        for (const auto& [host_id, result] : sorted_entries) {
+            if (result->blue_status_time.empty() && result->green_status_time.empty()) {
+                continue;
+            }
+            PrintNodeStatusTimes(host_id, *result, bg_trigger_time);
+        }
+
+        // Wrapper connection times to Blue
+        for (const auto& [host_id, result] : sorted_entries) {
+            if (result->blue_wrapper_connect_times.empty()) {
+                continue;
+            }
+            PrintDurationTimes(host_id, "Wrapper connection time (ms) to Blue",
+                result->blue_wrapper_connect_times, bg_trigger_time);
+        }
+
+        // IAM (green token) connection times to Green
+        for (const auto& [host_id, result] : sorted_entries) {
+            if (result->green_direct_iam_ip_with_green_node_connect_times.empty()) {
+                continue;
+            }
+            PrintDurationTimes(host_id, "Wrapper IAM (green token) connection time (ms) to Green",
+                result->green_direct_iam_ip_with_green_node_connect_times, bg_trigger_time);
+        }
+
+        // Wrapper execution times to Blue
+        for (const auto& [host_id, result] : sorted_entries) {
+            if (result->blue_wrapper_pre_switchover_execute_times.empty()) {
+                continue;
+            }
+            PrintDurationTimes(host_id, "Wrapper execution time (ms) to Blue",
+                result->blue_wrapper_pre_switchover_execute_times, bg_trigger_time);
+        }
+
+        // Wrapper execution times to Green
+        for (const auto& [host_id, result] : sorted_entries) {
+            if (result->green_wrapper_execute_times.empty()) {
+                continue;
+            }
+            PrintDurationTimes(host_id, "Wrapper execution time (ms) to Green",
+                result->green_wrapper_execute_times, bg_trigger_time);
+        }
+
+        // Host verification results
+        for (const auto& [host_id, result] : sorted_entries) {
+            if (result->host_verification_results.empty()) {
+                continue;
+            }
+            PrintHostVerificationResults(host_id, result->host_verification_results, bg_trigger_time);
+        }
     }
 
     std::chrono::steady_clock::time_point GetBgTriggerTime() {
@@ -664,7 +1026,11 @@ protected:
             // Setup
             std::string conn_str = GetDirectConnStr(host);
             SQLHDBC hdbc;
-            SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            {
+                std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
+                SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            }
+            SQLSetConnectAttr(hdbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER)10, 0);
             OpenConnectionWithRetry(hdbc, conn_str);
 
             // Ready for work, wait for other threads
@@ -697,7 +1063,11 @@ protected:
             // Setup
             std::string conn_str = GetDirectConnStr(host);
             SQLHDBC hdbc = SQL_NULL_HDBC;
-            SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            {
+                std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
+                SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            }
+            SQLSetConnectAttr(hdbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER)10, 0);
             OpenConnectionWithRetry(hdbc, conn_str);
 
             // Ready for work, wait for other threads
@@ -733,7 +1103,10 @@ protected:
             // Setup
             std::string conn_str = GetBlueGreenEnabledConnStr(host);
             SQLHDBC hdbc = SQL_NULL_HDBC;
-            SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            {
+                std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
+                SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            }
             OpenConnectionWithRetry(hdbc, conn_str);
 
             // Ready for work, wait for other threads
@@ -767,7 +1140,10 @@ protected:
             // Setup
             std::string conn_str = GetBlueGreenEnabledConnStr(host);
             SQLHDBC hdbc = SQL_NULL_HDBC;
-            SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            {
+                std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
+                SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            }
             OpenConnectionWithRetry(hdbc, conn_str);
 
             // Ready for work, wait for other threads
@@ -792,7 +1168,8 @@ protected:
                     end_time = std::chrono::steady_clock::now();
                     SQLCloseCursor(hstmt);
                     std::string err = ODBC_HELPER::PrintHandleError(hstmt, SQL_HANDLE_STMT);
-                    ThreadSynchronization::Print("[WrapperBlueExecutingConnectivityMonitoringThread: " + host_id + "] Failed to connect: " + err);
+                    ThreadSynchronization::Print("[WrapperBlueExecutingConnectivityMonitoringThread: " + host_id + "] Phase 1 failed at offset "
+                        + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(end_time - global_start_time).count()) + "ms: " + err);
                     pre_switch_results.push_back(
                         TimeHolder(start_time, end_time, err)
                     );
@@ -806,12 +1183,26 @@ protected:
             hstmt = SQL_NULL_HSTMT;
 
             // Phase 2 - Post-Switchover, reconnect and continue executing
+            // Use fresh DBC handles for reconnection (matching Java behavior where
+            // DriverManager.getConnection() creates a brand new Connection with fresh
+            // plugin state). Reusing the same DBC after switchover can carry stale
+            // BG plugin routing state that prevents successful reconnection.
+            ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, hdbc, SQL_NULL_HSTMT);
+            hdbc = SQL_NULL_HDBC;
+
             while (!ThreadSynchronization::stop_flag) {
                 // Reconnect if needed
-                if (!ODBC_HELPER::TestSimpleQuery(hdbc)) {
+                if (hdbc == SQL_NULL_HDBC || !ODBC_HELPER::TestSimpleQuery(hdbc)) {
                     ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, SQL_NULL_HDBC, hstmt);
                     hstmt = SQL_NULL_HSTMT;
-                    SQLDisconnect(hdbc);
+                    if (hdbc != SQL_NULL_HDBC) {
+                        ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, hdbc, SQL_NULL_HSTMT);
+                        hdbc = SQL_NULL_HDBC;
+                    }
+                    {
+                        std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
+                        SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+                    }
                     OpenConnectionWithRetry(hdbc, conn_str);
                     SQLAllocHandle(SQL_HANDLE_STMT, hdbc, &hstmt);
                 }
@@ -827,14 +1218,16 @@ protected:
                 } else {
                     end_time = std::chrono::steady_clock::now();
                     std::string err = ODBC_HELPER::PrintHandleError(hstmt, SQL_HANDLE_STMT);
-                    ThreadSynchronization::Print("[WrapperBlueExecutingConnectivityMonitoringThread: " + host_id + "] Failed to connect: " + err);
+                    ThreadSynchronization::Print("[WrapperBlueExecutingConnectivityMonitoringThread: " + host_id + "] Phase 2 failed at offset "
+                        + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(end_time - global_start_time).count()) + "ms: " + err);
                     post_switch_results.push_back(
                         TimeHolder(start_time, end_time, err)
                     );
                     SQLCloseCursor(hstmt);
                     ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, SQL_NULL_HDBC, hstmt);
                     hstmt = SQL_NULL_HSTMT;
-                    SQLDisconnect(hdbc);
+                    ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, hdbc, SQL_NULL_HSTMT);
+                    hdbc = SQL_NULL_HDBC;
                 }
 
                 std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -856,7 +1249,10 @@ protected:
             // Setup
             std::string conn_str = GetBlueGreenEnabledConnStr(host);
             SQLHDBC hdbc = SQL_NULL_HDBC;
-            SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            {
+                std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
+                SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            }
 
             // Ready for work, wait for other threads
             ThreadSynchronization::ReadyAndWait();
@@ -874,7 +1270,8 @@ protected:
                 } else {
                     end_time = std::chrono::steady_clock::now();
                     std::string err = ODBC_HELPER::PrintHandleError(hdbc, SQL_HANDLE_DBC);
-                    ThreadSynchronization::Print("[WrapperBlueNewConnectionMonitoringThread: " + host_id + "] Failed to connect: " + err);
+                    ThreadSynchronization::Print("[WrapperBlueNewConnectionMonitoringThread: " + host_id + "] Failed to connect at offset "
+                        + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(end_time - global_start_time).count()) + "ms: " + err);
                     results.push_back(
                         TimeHolder(start_time, end_time, err)
                     );
@@ -900,7 +1297,10 @@ protected:
             // Setup
             std::string conn_str = GetBlueGreenEnabledConnStr(host);
             SQLHDBC hdbc = SQL_NULL_HDBC;
-            SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            {
+                std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
+                SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            }
             OpenConnectionWithRetry(hdbc, conn_str);
             const std::string original_ip = GetConnectedServerIp(hdbc);
             SQLDisconnect(hdbc);
@@ -928,7 +1328,9 @@ protected:
                     }
                 } else {
                     std::string err = ODBC_HELPER::PrintHandleError(hdbc, SQL_HANDLE_DBC) + " - ERROR";
-                    ThreadSynchronization::Print("[WrapperBlueHostVerificationThread: " + host_id + "] Failed to connect: " + err);
+                    long long offset = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - global_start_time).count();
+                    ThreadSynchronization::Print("[WrapperBlueHostVerificationThread: " + host_id + "] Failed to connect at offset " + std::to_string(offset) + "ms: " + err);
                     results.push_back(
                         HostVerificationResult::Failure(timestamp, original_ip, err)
                     );
@@ -1013,7 +1415,12 @@ protected:
             // Setup
             std::string conn_str = GetDirectConnStr(host);
             SQLHDBC hdbc = SQL_NULL_HDBC;
-            SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            {
+                std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
+                SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            }
+            // Set login timeout to 10 seconds preventing long OS-level TCP timeouts from blocking reconnection during switchover.
+            SQLSetConnectAttr(hdbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER)10, 0);
             OpenConnectionWithRetry(hdbc, conn_str);
             const int BUFFER_SIZE = 512;
 
@@ -1040,7 +1447,7 @@ protected:
                     SQLBindCol(hstmt, 5, SQL_C_TCHAR, &role, BUFFER_SIZE, &len);
                     SQLBindCol(hstmt, 6, SQL_C_TCHAR, &status, BUFFER_SIZE, &len);
 
-                    if (SQL_SUCCEEDED(SQLFetch(hstmt))) {
+                    while (SQL_SUCCEEDED(SQLFetch(hstmt))) {
                         std::string status_str = STRING_HELPER::SqltcharToAnsi(status);
                         bool is_green = STRING_HELPER::SqltcharToAnsi(role) == "BLUE_GREEN_DEPLOYMENT_TARGET";
                         if (is_green) {
@@ -1082,7 +1489,10 @@ protected:
             // Setup
             std::string conn_str = GetBlueGreenEnabledConnStr(host);
             SQLHDBC hdbc = SQL_NULL_HDBC;
-            SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            {
+                std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
+                SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            }
             OpenConnectionWithRetry(hdbc, conn_str);
 
             // Ready for work, wait for other threads
@@ -1128,11 +1538,13 @@ protected:
     {
         return std::thread([&](const std::string& host_id, const std::string& host, const std::string& iam_host, const std::string& thread_prefix) {
             // Setup
-            const std::string green_node_original_ip = TEST_UTILS::HostToIp(host);
-            const std::string green_node_connect_ip = ConnectionStringBuilder(conn_str_builder.getString())
-                .withServer(green_node_original_ip)
+            const std::string green_node_connect_ip = TEST_UTILS::HostToIp(host);
+            ThreadSynchronization::Print("[GreenIamConnectivityMonitoringThread_" + thread_prefix + ": " + host_id + "] resolved IP: " + green_node_connect_ip + " for host: " + host);
+            const std::string iam_conn_str_prefix = ConnectionStringBuilder(conn_str_builder.getString())
+                .withServer(green_node_connect_ip)
                 .withUID(test_iam_user)
                 .getString();
+            ThreadSynchronization::Print("[GreenIamConnectivityMonitoringThread_" + thread_prefix + ": " + host_id + "] iam_host: " + iam_host + " conn_str_prefix: " + iam_conn_str_prefix);
 
             // Ready for work, wait for other threads
             ThreadSynchronization::ReadyAndWait();
@@ -1141,14 +1553,26 @@ protected:
 
             // Work
             SQLHDBC hdbc = SQL_NULL_HDBC;
-            SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            {
+                std::lock_guard<std::mutex> lock(ThreadSynchronization::env_mutex);
+                SQLAllocHandle(SQL_HANDLE_DBC, env, &hdbc);
+            }
+            SQLSetConnectAttr(hdbc, SQL_ATTR_LOGIN_TIMEOUT, (SQLPOINTER)10, 0);
             while (!ThreadSynchronization::stop_flag) {
-                const std::string iam_token = rds_client.GenerateConnectAuthToken(
+                const std::string raw_iam_token = rds_client.GenerateConnectAuthToken(
                     iam_host.c_str(), test_region.c_str(), test_port, test_iam_user.c_str());
-                const std::string conn_str = ConnectionStringBuilder(green_node_connect_ip)
+                // Extra URL encode: replace '%' with '%25'
+                std::string iam_token = raw_iam_token;
+                size_t pos = 0;
+                while ((pos = iam_token.find('%', pos)) != std::string::npos) {
+                    iam_token.replace(pos, 1, "%25");
+                    pos += 3;
+                }
+                const std::string conn_str = ConnectionStringBuilder(iam_conn_str_prefix)
                     .withPWD(iam_token)
                     .getString();
 
+                ThreadSynchronization::Print("[GreenIamConnectivityMonitoringThread_" + thread_prefix + ": " + host_id + "] attempting connection with iam_host: " + iam_host);
                 std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
                 std::chrono::steady_clock::time_point end_time = empty_time_point;
                 if (SQL_SUCCEEDED(ODBC_HELPER::DriverConnect(hdbc, conn_str))) {
@@ -1165,7 +1589,8 @@ protected:
                 } else {
                     end_time = std::chrono::steady_clock::now();
                     std::string err = ODBC_HELPER::PrintHandleError(hdbc, SQL_HANDLE_DBC);
-                    ThreadSynchronization::Print("[GreenIamConnectivityMonitoringThread_" + thread_prefix + ": " + host_id + "] Failed to connect: " + err);
+                    ThreadSynchronization::Print("[GreenIamConnectivityMonitoringThread_" + thread_prefix + ": " + host_id + "] Failed to connect at offset "
+                        + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(end_time - global_start_time).count()) + "ms: " + err);
                     result_queue.push_back(
                         TimeHolder(start_time, end_time, err)
                     );
@@ -1187,6 +1612,7 @@ protected:
             }
 
             // Cleanup
+            SQLDisconnect(hdbc);
             ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, hdbc, SQL_NULL_HSTMT);
 
             // Finished
@@ -1214,9 +1640,12 @@ protected:
             request.WithBlueGreenDeploymentIdentifier(blue_green_deployment_id);
             auto outcome = rds_client.SwitchoverBlueGreenDeployment(request);
             if (!outcome.IsSuccess()) {
-                ThreadSynchronization::Print("Failed to send Blue Green Switchover request: " + outcome.GetError().GetMessage());
+                ThreadSynchronization::Print("Failed to send Blue Green Switchover request at offset "
+                    + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - global_start_time).count()) + "ms: "
+                    + outcome.GetError().GetMessage());
             } else {
-                ThreadSynchronization::Print("Successfully sent Blue Green Switchover request.");
+                ThreadSynchronization::Print("Successfully sent Blue Green Switchover request at offset "
+                    + std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - global_start_time).count()) + "ms.");
             }
 
             std::chrono::steady_clock::time_point trigger_time = std::chrono::steady_clock::now();
@@ -1295,18 +1724,22 @@ TEST_F(BlueGreenIntegrationTest, SwitchoverTest) {
     ThreadSynchronization::total_threads = threads.size();
     ThreadSynchronization::start_flag = true;
     ThreadSynchronization::start_latch.notify_all();
-    ThreadSynchronization::Print("Threads started");
+    ThreadSynchronization::Print("Threads started at offset " + std::to_string(
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - global_start_time).count()) + "ms");
 
     ThreadSynchronization::WaitForFinish(std::chrono::minutes(6));
-    ThreadSynchronization::Print("Threads finished");
+    ThreadSynchronization::Print("Threads finished at offset " + std::to_string(
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - global_start_time).count()) + "ms");
 
     // Stop threads
-    ThreadSynchronization::Print("Stopping threads");
+    ThreadSynchronization::Print("Stopping threads at offset " + std::to_string(
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - global_start_time).count()) + "ms");
     ThreadSynchronization::stop_flag = true;
     // Allow threads to finish immediate work
     std::this_thread::sleep_for(std::chrono::minutes(3));
 
-    ThreadSynchronization::Print("Join threads");
+    ThreadSynchronization::Print("Join threads at offset " + std::to_string(
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - global_start_time).count()) + "ms");
     for (auto& thread : threads) {
         thread.join();
     }

--- a/test/integration/blue_green_integration_test.cpp
+++ b/test/integration/blue_green_integration_test.cpp
@@ -1177,13 +1177,12 @@ protected:
                 }
                 std::this_thread::sleep_for(std::chrono::seconds(1));
             }
-            ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, SQL_NULL_HDBC, hstmt);
-            hstmt = SQL_NULL_HSTMT;
 
             // Phase 2 - Post-Switchover, reconnect and continue executing
             // Matches Java behavior: each iteration tries a single connect attempt
             // with a fresh DBC handle. If connect fails, record the error and try again next iteration
-            ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, hdbc, SQL_NULL_HSTMT);
+            ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, hdbc, hstmt);
+            hstmt = SQL_NULL_HSTMT;
             hdbc = SQL_NULL_HDBC;
 
             while (!ThreadSynchronization::stop_flag) {
@@ -1669,6 +1668,7 @@ protected:
 
 TEST_F(BlueGreenIntegrationTest, SwitchoverTest) {
     const std::vector<std::string> topology_instances = GetBlueGreenEndpoints(blue_green_deployment_id);
+    ASSERT_FALSE(topology_instances.empty());
 
     auto start_time = std::chrono::steady_clock::now();
     global_start_time = start_time;

--- a/test/integration/iam_authentication_integration_test.cpp
+++ b/test/integration/iam_authentication_integration_test.cpp
@@ -79,6 +79,7 @@ TEST_F(IamAuthenticationIntegrationTest, SimpleIamConnection) {
 // when given an IP address instead of a cluster name.
 TEST_F(IamAuthenticationIntegrationTest, ConnectToIpAddress) {
     std::string ip_address = TEST_UTILS::HostToIp(test_server);
+    ASSERT_FALSE(ip_address.empty()) << "Failed to resolve IP address for host: " << test_server;
     conn_str = ConnectionStringBuilder(test_dsn, ip_address, test_port)
         .withUID(test_iam_user)
         .withDatabase(test_db)

--- a/test/unit_test/adfs_auth_plugin_test.cpp
+++ b/test/unit_test/adfs_auth_plugin_test.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include "auth_mock_objects.h"
+#include "common_mock_objects.h"
 
 #include "../../driver/plugin/federated/adfs_auth_plugin.h"
 #include "../../driver/util/aws_sdk_helper.h"
@@ -33,9 +34,11 @@ namespace {
 
 class AdfsAuthPluginTest : public testing::Test {
 protected:
-    MOCK_BASE_PLUGIN* mock_base_plugin;
+    std::shared_ptr<MOCK_BASE_PLUGIN> mock_base_plugin;
     std::shared_ptr<MOCK_AUTH_PROVIDER> mock_auth_provider;
     std::shared_ptr<MOCK_SAML_UTIL> mock_saml_util;
+    std::shared_ptr<MOCK_DIALECT> mock_dialect;
+    std::shared_ptr<MOCK_ODBC_HELPER> mock_odbc_helper;
     DBC* dbc;
 
     // Runs once per suite
@@ -50,7 +53,9 @@ protected:
     void SetUp() override {
         mock_auth_provider = std::make_shared<MOCK_AUTH_PROVIDER>();
         mock_saml_util = std::make_shared<MOCK_SAML_UTIL>();
-        mock_base_plugin = new MOCK_BASE_PLUGIN();
+        mock_base_plugin = std::make_shared<MOCK_BASE_PLUGIN>();
+        mock_dialect = std::make_shared<MOCK_DIALECT>();
+        mock_odbc_helper = std::make_shared<MOCK_ODBC_HELPER>();
         dbc = new DBC();
         dbc->conn_attr.insert_or_assign(KEY_SERVER, server);
         dbc->conn_attr.insert_or_assign(KEY_REGION, region);
@@ -58,7 +63,6 @@ protected:
         dbc->conn_attr.insert_or_assign(KEY_DB_USERNAME, username);
     }
     void TearDown() override {
-        // mock_base_plugin should be cleaned up by plugin chain
         if (dbc) delete dbc;
         if (mock_auth_provider) mock_auth_provider.reset();
         if (mock_saml_util) mock_saml_util.reset();
@@ -155,8 +159,12 @@ TEST_F(AdfsAuthPluginTest, Connect_Success_CacheExpire) {
         .Times(testing::Exactly(2))
         .WillOnce(testing::Return(SQL_ERROR))
         .WillOnce(testing::Return(SQL_SUCCESS));
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+        .WillOnce(testing::Return("28000"));
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+        .WillOnce(testing::Return(true));
 
-    AdfsAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider);
+    AdfsAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider, mock_dialect, mock_odbc_helper);
     SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
     EXPECT_EQ(SQL_SUCCESS, ret);
     EXPECT_EQ(valid_token_info.first, dbc->conn_attr.at(KEY_DB_PASSWORD));
@@ -180,7 +188,7 @@ TEST_F(AdfsAuthPluginTest, Connect_Fail_CacheMiss) {
     EXPECT_EQ(SQL_ERROR, ret);
 }
 
-TEST_F(AdfsAuthPluginTest, Connect_Fail_CacheHit) {
+TEST_F(AdfsAuthPluginTest, Connect_Fail_CacheHit_AccessError) {
     std::pair<std::string, bool> cached_token_info("cached_token", true);
     std::pair<std::string, bool> fresh_token_info("fresh_token", false);
     EXPECT_CALL(
@@ -208,8 +216,34 @@ TEST_F(AdfsAuthPluginTest, Connect_Fail_CacheHit) {
         Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .Times(testing::Exactly(2))
         .WillRepeatedly(testing::Return(SQL_ERROR));
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+        .WillOnce(testing::Return("28P01"));
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+        .WillOnce(testing::Return(true));
 
-    AdfsAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider);
+    AdfsAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider, mock_dialect, mock_odbc_helper);
+    SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_ERROR, ret);
+}
+
+TEST_F(AdfsAuthPluginTest, Connect_Fail_CacheHit_NonAccessError_NoRetry) {
+    std::pair<std::string, bool> cached_token_info("cached_token", true);
+    EXPECT_CALL(
+        *mock_auth_provider,
+        GetToken(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillOnce(testing::Return(cached_token_info));
+    EXPECT_CALL(
+        *mock_base_plugin,
+        Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillOnce(testing::Return(SQL_ERROR));
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+        .WillOnce(testing::Return("08001"));
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+        .WillOnce(testing::Return(false));
+
+    AdfsAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider, mock_dialect, mock_odbc_helper);
     SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
     EXPECT_EQ(SQL_ERROR, ret);
 }

--- a/test/unit_test/adfs_auth_plugin_test.cpp
+++ b/test/unit_test/adfs_auth_plugin_test.cpp
@@ -159,9 +159,9 @@ TEST_F(AdfsAuthPluginTest, Connect_Success_CacheExpire) {
         .Times(testing::Exactly(2))
         .WillOnce(testing::Return(SQL_ERROR))
         .WillOnce(testing::Return(SQL_SUCCESS));
-    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::An<DBC*>(), testing::_))
         .WillOnce(testing::Return("28000"));
-    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_, testing::An<const std::string&>()))
         .WillOnce(testing::Return(true));
 
     AdfsAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider, mock_dialect, mock_odbc_helper);
@@ -216,9 +216,9 @@ TEST_F(AdfsAuthPluginTest, Connect_Fail_CacheHit_AccessError) {
         Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .Times(testing::Exactly(2))
         .WillRepeatedly(testing::Return(SQL_ERROR));
-    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::An<DBC*>(), testing::_))
         .WillOnce(testing::Return("28P01"));
-    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_, testing::An<const std::string&>()))
         .WillOnce(testing::Return(true));
 
     AdfsAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider, mock_dialect, mock_odbc_helper);
@@ -238,9 +238,9 @@ TEST_F(AdfsAuthPluginTest, Connect_Fail_CacheHit_NonAccessError_NoRetry) {
         Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .Times(testing::Exactly(1))
         .WillOnce(testing::Return(SQL_ERROR));
-    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::An<DBC*>(), testing::_))
         .WillOnce(testing::Return("08001"));
-    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_, testing::An<const std::string&>()))
         .WillOnce(testing::Return(false));
 
     AdfsAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider, mock_dialect, mock_odbc_helper);

--- a/test/unit_test/aurora_initial_connection_strategy_plugin_test.cpp
+++ b/test/unit_test/aurora_initial_connection_strategy_plugin_test.cpp
@@ -24,7 +24,7 @@
 
 class AuroraInitialConnectionStrategyPluginTest : public ::testing::Test {
 protected:
-    MOCK_BASE_PLUGIN* mock_base_plugin = nullptr;
+    std::shared_ptr<MOCK_BASE_PLUGIN> mock_base_plugin = nullptr;
     std::shared_ptr<MOCK_PLUGIN_SERVICE> mock_plugin_service;
     std::shared_ptr<MOCK_HOST_LIST_PROVIDER> mock_host_list_provider;
     std::shared_ptr<MOCK_ODBC_HELPER> mock_odbc_helper;
@@ -48,7 +48,7 @@ protected:
 
     // Runs per test
     void SetUp() override {
-        mock_base_plugin = new MOCK_BASE_PLUGIN();
+        mock_base_plugin = std::make_shared<MOCK_BASE_PLUGIN>();
         mock_plugin_service = std::make_shared<MOCK_PLUGIN_SERVICE>();
         mock_host_list_provider = std::make_shared<MOCK_HOST_LIST_PROVIDER>();
         mock_odbc_helper = std::make_shared<MOCK_ODBC_HELPER>();
@@ -67,7 +67,6 @@ protected:
         all_hosts.push_back(*reader_host_c);
     }
     void TearDown() override {
-        // mock_base_plugin should be cleaned up by plugin chain
         if (dbc) delete dbc;
         all_hosts.clear();
     }

--- a/test/unit_test/common_mock_objects.h
+++ b/test/unit_test/common_mock_objects.h
@@ -17,6 +17,7 @@
 
 #include "gmock/gmock.h"
 
+#include <chrono>
 #include <sqltypes.h>
 
 #include "../../driver/host_list_providers/topology_util.h"
@@ -29,6 +30,7 @@ class MOCK_DIALECT : public Dialect {
 public:
     MOCK_DIALECT() : Dialect() {};
     MOCK_METHOD(bool, IsSqlStateNetworkError, (const char* sql_state), ());
+    MOCK_METHOD(bool, IsSqlStateAccessError, (const char* sql_state), ());
 };
 
 class MOCK_HOST_SELECTOR : public HighestWeightHostSelector {
@@ -56,6 +58,7 @@ class MOCK_ODBC_HELPER : public OdbcHelper {
 public:
     MOCK_ODBC_HELPER() : OdbcHelper(std::make_shared<RdsLibLoader>()) {};
     MOCK_METHOD(void, Disconnect, (const DBC *dbc), ());
+    MOCK_METHOD(std::string, GetSqlStateAndLogMessage, (DBC *dbc), ());
 };
 
 class MOCK_PLUGIN_SERVICE : public PluginService {

--- a/test/unit_test/common_mock_objects.h
+++ b/test/unit_test/common_mock_objects.h
@@ -60,7 +60,7 @@ public:
     MOCK_ODBC_HELPER() : OdbcHelper(std::make_shared<RdsLibLoader>()) {};
     MOCK_METHOD(void, Disconnect, (const DBC *dbc), ());
     MOCK_METHOD(std::string, GetSqlStateAndLogMessage, (DBC *dbc), ());
-    MOCK_METHOD(std::string, GetSqlStateAndLogMessage, (DBC *dbc, std::string* out_message), ());
+    MOCK_METHOD(std::string, GetSqlStateAndLogMessage, (DBC *dbc, std::string& out_message), ());
     MOCK_METHOD(std::string, GetStmtErrorMessage, (SQLHSTMT stmt), ());
 };
 

--- a/test/unit_test/common_mock_objects.h
+++ b/test/unit_test/common_mock_objects.h
@@ -30,7 +30,8 @@ class MOCK_DIALECT : public Dialect {
 public:
     MOCK_DIALECT() : Dialect() {};
     MOCK_METHOD(bool, IsSqlStateNetworkError, (const char* sql_state), ());
-    MOCK_METHOD(bool, IsSqlStateAccessError, (const char* sql_state), ());
+    MOCK_METHOD(bool, IsSqlStateAccessError, (const char* sql_state), (override));
+    MOCK_METHOD(bool, IsSqlStateAccessError, (const char* sql_state, const std::string& error_message), (override));
 };
 
 class MOCK_HOST_SELECTOR : public HighestWeightHostSelector {
@@ -59,6 +60,8 @@ public:
     MOCK_ODBC_HELPER() : OdbcHelper(std::make_shared<RdsLibLoader>()) {};
     MOCK_METHOD(void, Disconnect, (const DBC *dbc), ());
     MOCK_METHOD(std::string, GetSqlStateAndLogMessage, (DBC *dbc), ());
+    MOCK_METHOD(std::string, GetSqlStateAndLogMessage, (DBC *dbc, std::string* out_message), ());
+    MOCK_METHOD(std::string, GetStmtErrorMessage, (SQLHSTMT stmt), ());
 };
 
 class MOCK_PLUGIN_SERVICE : public PluginService {

--- a/test/unit_test/custom_endpoint_plugin_test.cpp
+++ b/test/unit_test/custom_endpoint_plugin_test.cpp
@@ -30,7 +30,7 @@
 
 class CustomEndpointPluginTest : public testing::Test {
 protected:
-    MOCK_BASE_PLUGIN* mock_base_plugin;
+    std::shared_ptr<MOCK_BASE_PLUGIN> mock_base_plugin;
     std::shared_ptr<MOCK_CUSTOM_ENDPOINT_MONITOR> mock_custom_endpoint_monitor;
     DBC* dbc;
 
@@ -39,7 +39,7 @@ protected:
     static void TearDownTestSuite() {}
 
     void SetUp() override {
-        mock_base_plugin = new MOCK_BASE_PLUGIN();
+        mock_base_plugin = std::make_shared<MOCK_BASE_PLUGIN>();
         mock_custom_endpoint_monitor = std::make_shared<MOCK_CUSTOM_ENDPOINT_MONITOR>();
         dbc = new DBC();
         dbc->conn_attr.insert_or_assign(KEY_CLUSTER_ID, "cluster_id");

--- a/test/unit_test/iam_auth_plugin_test.cpp
+++ b/test/unit_test/iam_auth_plugin_test.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include "auth_mock_objects.h"
+#include "common_mock_objects.h"
 
 #include "../../driver/plugin/iam/iam_auth_plugin.h"
 #include "../../driver/util/aws_sdk_helper.h"
@@ -31,8 +32,10 @@ namespace {
 
 class IamAuthPluginTest : public testing::Test {
 protected:
-    MOCK_BASE_PLUGIN* mock_base_plugin;
+    std::shared_ptr<MOCK_BASE_PLUGIN> mock_base_plugin;
     std::shared_ptr<MOCK_AUTH_PROVIDER> mock_auth_provider;
+    std::shared_ptr<MOCK_DIALECT> mock_dialect;
+    std::shared_ptr<MOCK_ODBC_HELPER> mock_odbc_helper;
     DBC* dbc;
 
     // Runs once per suite
@@ -46,7 +49,9 @@ protected:
     // Runs per test
     void SetUp() override {
         mock_auth_provider = std::make_shared<MOCK_AUTH_PROVIDER>();
-        mock_base_plugin = new MOCK_BASE_PLUGIN();
+        mock_base_plugin = std::make_shared<MOCK_BASE_PLUGIN>();
+        mock_dialect = std::make_shared<MOCK_DIALECT>();
+        mock_odbc_helper = std::make_shared<MOCK_ODBC_HELPER>();
         dbc = new DBC();
         dbc->conn_attr.insert_or_assign(KEY_SERVER, server);
         dbc->conn_attr.insert_or_assign(KEY_REGION, region);
@@ -54,7 +59,6 @@ protected:
         dbc->conn_attr.insert_or_assign(KEY_DB_USERNAME, username);
     }
     void TearDown() override {
-        // mock_base_plugin should be cleaned up by plugin chain
         if (dbc) delete dbc;
         if (mock_auth_provider) mock_auth_provider.reset();
     }
@@ -145,8 +149,12 @@ TEST_F(IamAuthPluginTest, Connect_Success_CacheExpire) {
         .Times(testing::Exactly(2))
         .WillOnce(testing::Return(SQL_ERROR))
         .WillOnce(testing::Return(SQL_SUCCESS));
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+        .WillOnce(testing::Return("28000"));
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+        .WillOnce(testing::Return(true));
 
-    IamAuthPlugin plugin(dbc, mock_base_plugin, mock_auth_provider);
+    IamAuthPlugin plugin(dbc, mock_base_plugin, mock_auth_provider, mock_dialect, mock_odbc_helper);
     SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
     EXPECT_EQ(SQL_SUCCESS, ret);
     EXPECT_EQ(valid_token_info.first, dbc->conn_attr.at(KEY_DB_PASSWORD));
@@ -171,7 +179,7 @@ TEST_F(IamAuthPluginTest, Connect_Fail_CacheMiss) {
     EXPECT_EQ(SQL_ERROR, ret);
 }
 
-TEST_F(IamAuthPluginTest, Connect_Fail_CacheHit) {
+TEST_F(IamAuthPluginTest, Connect_Fail_CacheHit_AccessError) {
     std::pair<std::string, bool> cached_token_info("cached_token", true);
     std::pair<std::string, bool> fresh_token_info("fresh_token", false);
     EXPECT_CALL(
@@ -185,8 +193,34 @@ TEST_F(IamAuthPluginTest, Connect_Fail_CacheHit) {
         Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .Times(testing::Exactly(2))
         .WillRepeatedly(testing::Return(SQL_ERROR));
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+        .WillOnce(testing::Return("28P01"));
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+        .WillOnce(testing::Return(true));
 
-    IamAuthPlugin plugin(dbc, mock_base_plugin, mock_auth_provider);
+    IamAuthPlugin plugin(dbc, mock_base_plugin, mock_auth_provider, mock_dialect, mock_odbc_helper);
+    SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_ERROR, ret);
+}
+
+TEST_F(IamAuthPluginTest, Connect_Fail_CacheHit_NonAccessError_NoRetry) {
+    std::pair<std::string, bool> cached_token_info("cached_token", true);
+    EXPECT_CALL(
+        *mock_auth_provider,
+        GetToken(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillOnce(testing::Return(cached_token_info));
+    EXPECT_CALL(
+        *mock_base_plugin,
+        Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillOnce(testing::Return(SQL_ERROR));
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+        .WillOnce(testing::Return("08001"));
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+        .WillOnce(testing::Return(false));
+
+    IamAuthPlugin plugin(dbc, mock_base_plugin, mock_auth_provider, mock_dialect, mock_odbc_helper);
     SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
     EXPECT_EQ(SQL_ERROR, ret);
 }

--- a/test/unit_test/iam_auth_plugin_test.cpp
+++ b/test/unit_test/iam_auth_plugin_test.cpp
@@ -149,9 +149,9 @@ TEST_F(IamAuthPluginTest, Connect_Success_CacheExpire) {
         .Times(testing::Exactly(2))
         .WillOnce(testing::Return(SQL_ERROR))
         .WillOnce(testing::Return(SQL_SUCCESS));
-    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::An<DBC*>(), testing::_))
         .WillOnce(testing::Return("28000"));
-    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_, testing::An<const std::string&>()))
         .WillOnce(testing::Return(true));
 
     IamAuthPlugin plugin(dbc, mock_base_plugin, mock_auth_provider, mock_dialect, mock_odbc_helper);
@@ -193,9 +193,9 @@ TEST_F(IamAuthPluginTest, Connect_Fail_CacheHit_AccessError) {
         Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .Times(testing::Exactly(2))
         .WillRepeatedly(testing::Return(SQL_ERROR));
-    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::An<DBC*>(), testing::_))
         .WillOnce(testing::Return("28P01"));
-    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_, testing::An<const std::string&>()))
         .WillOnce(testing::Return(true));
 
     IamAuthPlugin plugin(dbc, mock_base_plugin, mock_auth_provider, mock_dialect, mock_odbc_helper);
@@ -215,9 +215,9 @@ TEST_F(IamAuthPluginTest, Connect_Fail_CacheHit_NonAccessError_NoRetry) {
         Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .Times(testing::Exactly(1))
         .WillOnce(testing::Return(SQL_ERROR));
-    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::An<DBC*>(), testing::_))
         .WillOnce(testing::Return("08001"));
-    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_, testing::An<const std::string&>()))
         .WillOnce(testing::Return(false));
 
     IamAuthPlugin plugin(dbc, mock_base_plugin, mock_auth_provider, mock_dialect, mock_odbc_helper);

--- a/test/unit_test/limitless_plugin_test.cpp
+++ b/test/unit_test/limitless_plugin_test.cpp
@@ -25,7 +25,7 @@
 
 class LimitlessPluginTest : public testing::Test {
 protected:
-    MOCK_BASE_PLUGIN* mock_base_plugin;
+    std::shared_ptr<MOCK_BASE_PLUGIN> mock_base_plugin;
     DBC* dbc;
 
     // Runs once per suite
@@ -34,11 +34,10 @@ protected:
 
     // Runs per test
     void SetUp() override {
-        mock_base_plugin = new MOCK_BASE_PLUGIN();
+        mock_base_plugin = std::make_shared<MOCK_BASE_PLUGIN>();
         dbc = new DBC();
     }
     void TearDown() override {
-        // mock_base_plugin should be cleaned up by plugin chain
         if (dbc) delete dbc;
     }
 };

--- a/test/unit_test/limitless_router_service_test.cpp
+++ b/test/unit_test/limitless_router_service_test.cpp
@@ -22,10 +22,11 @@
 #include "../../driver/dialect/dialect_aurora_postgres.h"
 #include "../../driver/plugin/limitless/limitless_router_service.h"
 #include "../../driver/util/connection_string_keys.h"
+#include "../../driver/util/plugin_service.h"
 
 class LimitlessRouterServiceTest : public testing::Test {
 protected:
-    MOCK_BASE_PLUGIN* mock_base_plugin;
+    std::shared_ptr<MOCK_BASE_PLUGIN> mock_base_plugin;
     DBC* dbc;
     std::shared_ptr<OdbcHelper> odbc_helper_;
 
@@ -35,13 +36,14 @@ protected:
 
     // Runs per test
     void SetUp() override {
-        mock_base_plugin = new MOCK_BASE_PLUGIN();
+        mock_base_plugin = std::make_shared<MOCK_BASE_PLUGIN>();
         dbc = new DBC();
-        dbc->plugin_head = mock_base_plugin;
+        dbc->plugin_head = mock_base_plugin.get();
+        dbc->plugin_service = std::make_shared<PluginService>();
+        dbc->plugin_service->SetPluginChain(mock_base_plugin);
         odbc_helper_ = std::make_shared<OdbcHelper>(nullptr);
     }
     void TearDown() override {
-        // mock_base_plugin should be cleaned up by plugin chain
         if (dbc) delete dbc;
     }
 };

--- a/test/unit_test/okta_auth_plugin_test.cpp
+++ b/test/unit_test/okta_auth_plugin_test.cpp
@@ -159,9 +159,9 @@ TEST_F(OktaAuthPluginTest, Connect_Success_CacheExpire) {
         .Times(testing::Exactly(2))
         .WillOnce(testing::Return(SQL_ERROR))
         .WillOnce(testing::Return(SQL_SUCCESS));
-    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::An<DBC*>(), testing::_))
         .WillOnce(testing::Return("28000"));
-    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_, testing::An<const std::string&>()))
         .WillOnce(testing::Return(true));
 
     OktaAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider, mock_dialect, mock_odbc_helper);
@@ -216,9 +216,9 @@ TEST_F(OktaAuthPluginTest, Connect_Fail_CacheHit_AccessError) {
         Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .Times(testing::Exactly(2))
         .WillRepeatedly(testing::Return(SQL_ERROR));
-    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::An<DBC*>(), testing::_))
         .WillOnce(testing::Return("28P01"));
-    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_, testing::An<const std::string&>()))
         .WillOnce(testing::Return(true));
 
     OktaAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider, mock_dialect, mock_odbc_helper);
@@ -238,9 +238,9 @@ TEST_F(OktaAuthPluginTest, Connect_Fail_CacheHit_NonAccessError_NoRetry) {
         Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .Times(testing::Exactly(1))
         .WillOnce(testing::Return(SQL_ERROR));
-    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::An<DBC*>(), testing::_))
         .WillOnce(testing::Return("08001"));
-    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_, testing::An<const std::string&>()))
         .WillOnce(testing::Return(false));
 
     OktaAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider, mock_dialect, mock_odbc_helper);

--- a/test/unit_test/okta_auth_plugin_test.cpp
+++ b/test/unit_test/okta_auth_plugin_test.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include "auth_mock_objects.h"
+#include "common_mock_objects.h"
 
 #include "../../driver/plugin/federated/okta_auth_plugin.h"
 #include "../../driver/util/aws_sdk_helper.h"
@@ -33,9 +34,11 @@ namespace {
 
 class OktaAuthPluginTest : public testing::Test {
 protected:
-    MOCK_BASE_PLUGIN* mock_base_plugin;
+    std::shared_ptr<MOCK_BASE_PLUGIN> mock_base_plugin;
     std::shared_ptr<MOCK_AUTH_PROVIDER> mock_auth_provider;
     std::shared_ptr<MOCK_SAML_UTIL> mock_saml_util;
+    std::shared_ptr<MOCK_DIALECT> mock_dialect;
+    std::shared_ptr<MOCK_ODBC_HELPER> mock_odbc_helper;
     DBC* dbc;
 
     // Runs once per suite
@@ -50,7 +53,9 @@ protected:
     void SetUp() override {
         mock_auth_provider = std::make_shared<MOCK_AUTH_PROVIDER>();
         mock_saml_util = std::make_shared<MOCK_SAML_UTIL>();
-        mock_base_plugin = new MOCK_BASE_PLUGIN();
+        mock_base_plugin = std::make_shared<MOCK_BASE_PLUGIN>();
+        mock_dialect = std::make_shared<MOCK_DIALECT>();
+        mock_odbc_helper = std::make_shared<MOCK_ODBC_HELPER>();
         dbc = new DBC();
         dbc->conn_attr.insert_or_assign(KEY_SERVER, server);
         dbc->conn_attr.insert_or_assign(KEY_REGION, region);
@@ -58,7 +63,6 @@ protected:
         dbc->conn_attr.insert_or_assign(KEY_DB_USERNAME, username);
     }
     void TearDown() override {
-        // mock_base_plugin should be cleaned up by plugin chain
         if (dbc) delete dbc;
         if (mock_auth_provider) mock_auth_provider.reset();
         if (mock_saml_util) mock_saml_util.reset();
@@ -155,8 +159,12 @@ TEST_F(OktaAuthPluginTest, Connect_Success_CacheExpire) {
         .Times(testing::Exactly(2))
         .WillOnce(testing::Return(SQL_ERROR))
         .WillOnce(testing::Return(SQL_SUCCESS));
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+        .WillOnce(testing::Return("28000"));
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+        .WillOnce(testing::Return(true));
 
-    OktaAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider);
+    OktaAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider, mock_dialect, mock_odbc_helper);
     SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
     EXPECT_EQ(SQL_SUCCESS, ret);
     EXPECT_EQ(valid_token_info.first, dbc->conn_attr.at(KEY_DB_PASSWORD));
@@ -180,7 +188,7 @@ TEST_F(OktaAuthPluginTest, Connect_Fail_CacheMiss) {
     EXPECT_EQ(SQL_ERROR, ret);
 }
 
-TEST_F(OktaAuthPluginTest, Connect_Fail_CacheHit) {
+TEST_F(OktaAuthPluginTest, Connect_Fail_CacheHit_AccessError) {
     std::pair<std::string, bool> cached_token_info("cached_token", true);
     std::pair<std::string, bool> fresh_token_info("fresh_token", false);
     EXPECT_CALL(
@@ -208,8 +216,34 @@ TEST_F(OktaAuthPluginTest, Connect_Fail_CacheHit) {
         Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
         .Times(testing::Exactly(2))
         .WillRepeatedly(testing::Return(SQL_ERROR));
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+        .WillOnce(testing::Return("28P01"));
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+        .WillOnce(testing::Return(true));
 
-    OktaAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider);
+    OktaAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider, mock_dialect, mock_odbc_helper);
+    SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
+    EXPECT_EQ(SQL_ERROR, ret);
+}
+
+TEST_F(OktaAuthPluginTest, Connect_Fail_CacheHit_NonAccessError_NoRetry) {
+    std::pair<std::string, bool> cached_token_info("cached_token", true);
+    EXPECT_CALL(
+        *mock_auth_provider,
+        GetToken(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillOnce(testing::Return(cached_token_info));
+    EXPECT_CALL(
+        *mock_base_plugin,
+        Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
+        .Times(testing::Exactly(1))
+        .WillOnce(testing::Return(SQL_ERROR));
+    EXPECT_CALL(*mock_odbc_helper, GetSqlStateAndLogMessage(testing::_))
+        .WillOnce(testing::Return("08001"));
+    EXPECT_CALL(*mock_dialect, IsSqlStateAccessError(testing::_))
+        .WillOnce(testing::Return(false));
+
+    OktaAuthPlugin plugin(dbc, mock_base_plugin, mock_saml_util, mock_auth_provider, mock_dialect, mock_odbc_helper);
     SQLRETURN ret = plugin.Connect(dbc, nullptr, nullptr, 0, 0, SQL_DRIVER_NOPROMPT);
     EXPECT_EQ(SQL_ERROR, ret);
 }

--- a/test/unit_test/secrets_manager_plugin_test.cpp
+++ b/test/unit_test/secrets_manager_plugin_test.cpp
@@ -64,7 +64,7 @@ Aws::SecretsManager::Model::GetSecretValueOutcome GetMockSecretValueOutcomeMissi
 
 class SecretsManagerPluginTest : public testing::Test {
 protected:
-    MOCK_BASE_PLUGIN* mock_base_plugin;
+    std::shared_ptr<MOCK_BASE_PLUGIN> mock_base_plugin;
     std::shared_ptr<MOCK_SECRETS_MANAGER_CLIENT> mock_sm_client;
     DBC* dbc;
 
@@ -78,7 +78,7 @@ protected:
 
     void SetUp() override {
         mock_sm_client = std::make_shared<MOCK_SECRETS_MANAGER_CLIENT>();
-        mock_base_plugin = new MOCK_BASE_PLUGIN();
+        mock_base_plugin = std::make_shared<MOCK_BASE_PLUGIN>();
         EXPECT_CALL(
             *mock_base_plugin,
             Connect(testing::_, testing::_, testing::_, testing::_, testing::_, testing::_))
@@ -87,7 +87,6 @@ protected:
     }
 
     void TearDown() override {
-        // mock_base_plugin should be cleaned up by plugin chain
         if (mock_sm_client) mock_sm_client.reset();
         if (dbc) delete dbc;
     }


### PR DESCRIPTION

### Summary

Implement a base SAML plugin for the federated plugins to simplify future refactoring to the connect workflow.
Also utilize IsSqlStateAccessError method in the dialect classes to simplify connect workflow.

### Description

With the old implementation, every time the IAM plugin fails to connect, it assumes the failure was caused by an expired token, so it regenerates a token and tries again. This creates unnecessary overhead if the connect attempt failed due to network errors, where a new token would not impact the outcome of the connection attempt.
This PR checks the connect error and see if generating a new token and reattempting the connection actually makes sense.

### Testing

<!-- What did you test and how did you test it -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
