### PR TITLE
fix: missing writer role verification in failoverWriter logic

### DIFF
--- a/driver/host_list_providers/cluster_topology_monitor.cpp
+++ b/driver/host_list_providers/cluster_topology_monitor.cpp
@@ -479,8 +479,16 @@ void ClusterTopologyMonitor::NodeMonitoringThread::Run() {
                 // Get Writer ID
                 const std::string writer_id = main_monitor_->topology_util_->GetWriterId(hdbc_);
                 if (!writer_id.empty()) { // Connected to a Writer
-                    LOG(WARNING) << "Writer " << writer_id << " detected by node monitoring thread: " << thread_host;
-                    HandleWriterConn();
+                    // Verify writer role
+                    const HOST_ROLE role = main_monitor_->topology_util_->GetConnectionRole(hdbc_);
+                    if (role != HOST_ROLE::WRITER) {
+                        LOG(WARNING) << "Node " << thread_host << " reported itself as writer via GetWriterId, "
+                                     << "but GetConnectionRole returned READER. Ignoring stale writer claim.";
+                        HandleReaderConn();
+                    } else {
+                        LOG(WARNING) << "Writer " << writer_id << " detected by node monitoring thread: " << thread_host;
+                        HandleWriterConn();
+                    }
                 } else { // Connected to a Reader
                     HandleReaderConn();
                 }

--- a/driver/plugin/failover/failover_plugin.cpp
+++ b/driver/plugin/failover/failover_plugin.cpp
@@ -289,18 +289,14 @@ bool FailoverPlugin::FailoverWriter(DBC *dbc)
         LOG(INFO) << "Writer failover unable to connect to any instance for: " << cluster_id_;
         return false;
     }
-    if (!GetNodeId(dbc, dialect_, odbc_helper_).empty()) {
-        if (!topology_util_->GetWriterId(dbc).empty()) {
-            LOG(INFO) << "Writer failover connected to a new writer for: " << host_string;
-            curr_host_ = host;
-            return true;
-        }
-        LOG(ERROR) << "The new writer was identified to be " << host_string << ", but querying the instance for its role returned a reader";
+    if (topology_util_->GetConnectionRole(dbc) != HOST_ROLE::WRITER) {
+        LOG(ERROR) << "Writer failover connected to " << host_string << ", but it is not a writer. Connection may be stale.";
+        odbc_helper_->Disconnect(dbc);
         return false;
     }
-    LOG(INFO) << "Writer failover unable to connect to any instance for: " << cluster_id_;
-    odbc_helper_->Disconnect(dbc);
-    return false;
+    LOG(INFO) << "Writer failover connected to a new writer for: " << host_string;
+    curr_host_ = host;
+    return true;
 }
 
 bool FailoverPlugin::ConnectToHost(DBC* dbc, const std::string& host_string, const std::shared_ptr<OdbcHelper> &odbc_helper)


### PR DESCRIPTION

### Description

Double verify writer candidate using the is_reader query. This ensures we don't connect to a stale writer.

### Testing

<!-- What did you test and how did you test it -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
