### PR TITLE
chore: set cluster id to test name and allow time for logs to get flushed after each test

### DIFF
--- a/.github/workflows/compatibility_test.yaml
+++ b/.github/workflows/compatibility_test.yaml
@@ -397,6 +397,10 @@ jobs:
         run: |
           echo "Base driver path: $(cd psqlodbc/.libs && pwd)"
           ls psqlodbc/.libs/
+          echo "--- ANSI driver ---"
+          ldd {{ github.workspace }}/psqlodbc/.libs/psqlodbca.so
+          echo "--- Unicode driver ---"
+          ldd {{ github.workspace }}/psqlodbc/.libs/psqlodbc2.so
           echo "--- ODBC DSN config ---"
           odbcinst -j 2>/dev/null || true
           cat /etc/odbcinst.ini 2>/dev/null || true

--- a/.github/workflows/compatibility_test.yaml
+++ b/.github/workflows/compatibility_test.yaml
@@ -393,14 +393,24 @@ jobs:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver
           fail-on-cache-miss: true
-      - name: Log psqlODBC driver location
+      - name: Detect psqlODBC driver path
+        id: psqlodbc-path
         run: |
           echo "Base driver path: $(cd psqlodbc/.libs && pwd)"
-          ls psqlodbc/.libs/
-          echo "--- ANSI driver ---"
-          ldd {{ github.workspace }}/psqlodbc/.libs/psqlodbca.so
-          echo "--- Unicode driver ---"
-          ldd {{ github.workspace }}/psqlodbc/.libs/psqlodbc2.so
+          ls -la psqlodbc/.libs/
+          # On macOS, libtool may produce .so or .dylib files
+          if [ -f "${{ github.workspace }}/psqlodbc/.libs/psqlodbca.so" ]; then
+            PG_DRIVER="${{ github.workspace }}/psqlodbc/.libs/psqlodbca.so"
+          elif [ -f "${{ github.workspace }}/psqlodbc/.libs/psqlodbca.dylib" ]; then
+            PG_DRIVER="${{ github.workspace }}/psqlodbc/.libs/psqlodbca.dylib"
+          else
+            echo "ERROR: Could not find psqlODBC ANSI driver in psqlodbc/.libs/"
+            exit 1
+          fi
+          echo "Detected psqlODBC driver: $PG_DRIVER"
+          file "$PG_DRIVER"
+          otool -L "$PG_DRIVER"
+          echo "PSQLODBC_DRIVER_PATH=$PG_DRIVER" >> "$GITHUB_OUTPUT"
           echo "--- ODBC DSN config ---"
           odbcinst -j 2>/dev/null || true
           cat /etc/odbcinst.ini 2>/dev/null || true
@@ -421,9 +431,24 @@ jobs:
           key: ${{ runner.os }}-mysql-driver
           fail-on-cache-miss: true
       - name: Log MySQL driver location
+        id: mysql-path
         run: |
           echo "Base driver path: $(cd mysql-connector && pwd)"
-          ls mysql-connector/
+          ls -la mysql-connector/
+          ls -la mysql-connector/lib/ 2>/dev/null || true
+          # On macOS, MySQL connector may produce .so or .dylib files
+          if [ -f "${{ github.workspace }}/mysql-connector/lib/libmyodbc9a.so" ]; then
+            MYSQL_DRIVER="${{ github.workspace }}/mysql-connector/lib/libmyodbc9a.so"
+          elif [ -f "${{ github.workspace }}/mysql-connector/lib/libmyodbc9a.dylib" ]; then
+            MYSQL_DRIVER="${{ github.workspace }}/mysql-connector/lib/libmyodbc9a.dylib"
+          else
+            echo "ERROR: Could not find MySQL ODBC ANSI driver in mysql-connector/lib/"
+            exit 1
+          fi
+          echo "Detected MySQL driver: $MYSQL_DRIVER"
+          file "$MYSQL_DRIVER"
+          otool -L "$MYSQL_DRIVER"
+          echo "MYSQL_DRIVER_PATH=$MYSQL_DRIVER" >> "$GITHUB_OUTPUT"
           echo "--- ODBC DSN config ---"
           odbcinst -j 2>/dev/null || true
           cat /etc/odbcinst.ini 2>/dev/null || true
@@ -443,10 +468,10 @@ jobs:
         run: |
           cmake -S test/compatibility -B test-compatibility \
             -D TEST_DRIVER_PATH="${{ github.workspace }}/build/driver/aws-advanced-odbc-wrapper-a.dylib" \
-            -D PG_DRIVER_PATH="${{ github.workspace }}/psqlodbc/.libs/psqlodbca.so" \
+            -D PG_DRIVER_PATH="${{ steps.psqlodbc-path.outputs.PSQLODBC_DRIVER_PATH }}" \
             -D PG_SERVER="localhost" \
             -D PG_DATABASE="${{env.LOCAL_DB_NAME}}" \
-            -D MYSQL_DRIVER_PATH="${{ github.workspace }}/mysql-connector/lib/libmyodbc9a.so" \
+            -D MYSQL_DRIVER_PATH="${{ steps.mysql-path.outputs.MYSQL_DRIVER_PATH }}" \
             -D MYSQL_SERVER="localhost" \
             -D MYSQL_DATABASE="${{env.LOCAL_DB_NAME}}"
           cmake --build test-compatibility
@@ -460,7 +485,7 @@ jobs:
           TEST_DATABASE: ${{env.LOCAL_DB_NAME}}
           TEST_USERNAME: ${{env.LOCAL_DB_UID}}
           TEST_PASSWORD: ${{env.LOCAL_DB_PWD}}
-          TEST_BASE_DRIVER: ${{ github.workspace }}/psqlodbc/.libs/psqlodbca.so
+          TEST_BASE_DRIVER: ${{ steps.psqlodbc-path.outputs.PSQLODBC_DRIVER_PATH }}
           TEST_BASE_DSN: pg-dsn
           ODBCINI: "${{ github.workspace }}/test/resources/odbc.ini"
           ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
@@ -480,7 +505,7 @@ jobs:
           TEST_DATABASE: ${{env.LOCAL_DB_NAME}}
           TEST_USERNAME: ${{env.LOCAL_DB_UID}}
           TEST_PASSWORD: ${{env.LOCAL_DB_PWD}}
-          TEST_BASE_DRIVER: ${{ github.workspace }}/mysql-connector/lib/libmyodbc9a.so
+          TEST_BASE_DRIVER: ${{ steps.mysql-path.outputs.MYSQL_DRIVER_PATH }}
           TEST_BASE_DSN: mysql-dsn
           ODBCINI: "${{ github.workspace }}/test/resources/odbc.ini"
           ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"

--- a/scripts/db_resources.py
+++ b/scripts/db_resources.py
@@ -156,11 +156,14 @@ def remove_ip_from_sg(ec2_client, rds_client, ip, cluster_id, is_rds_instance=Fa
 
 def create_aurora_cluster(rds_client, args):
     version = resolve_engine_version(rds_client, args.engine, args.engine_version)
+    username = args.username
+    if args.extra_mysql_user is not None:
+        username = args.extra_mysql_user
 
     create_kwargs = dict(
         DBClusterIdentifier=args.cluster_id,
         DatabaseName=args.database,
-        MasterUsername=args.username,
+        MasterUsername=username,
         MasterUserPassword=args.password,
         SourceRegion=args.region,
         EnableIAMDatabaseAuthentication=True,
@@ -291,6 +294,9 @@ def create_rds_instance(rds_client, args, multi_az=False):
     rds_engine = args.engine.replace("aurora-", "")
     version = resolve_rds_engine_version(rds_client, rds_engine, args.engine_version)
     az_label = "Multi-AZ" if multi_az else "Single-AZ"
+    username = args.username
+    if args.extra_mysql_user is not None:
+        username = args.extra_mysql_user
 
     print(f"Creating {az_label} RDS instance ({rds_engine} {version})...")
     rds_client.create_db_instance(
@@ -298,7 +304,7 @@ def create_rds_instance(rds_client, args, multi_az=False):
         DBInstanceClass=args.instance_class,
         Engine=rds_engine,
         EngineVersion=version,
-        MasterUsername=args.username,
+        MasterUsername=username,
         MasterUserPassword=args.password,
         DBName=args.database,
         AllocatedStorage=args.allocated_storage,
@@ -376,12 +382,16 @@ def setup_pg_iam_user(endpoint, port, database, username, password, iam_user):
 def setup_mysql_iam_user(endpoint, database, username, password, iam_user,
                          extra_user=None, extra_password=None):
     print(f"Connecting to MySQL via AWS Advanced Python Wrapper: {endpoint}:3306/{database}")
+    current_user = username
+    if extra_user:
+        current_user = extra_user
+
     try:
         with AwsWrapperConnection.connect(
             mysql.connector.Connect,
             host=endpoint,
             database=database,
-            user=username,
+            user=current_user,
             password=password,
             wrapper_dialect="aurora-mysql",
             plugins="",
@@ -394,9 +404,9 @@ def setup_mysql_iam_user(endpoint, database, username, password, iam_user,
             cur.execute("FLUSH PRIVILEGES")
 
             if extra_user and extra_password:
-                print(f"  CREATE USER {extra_user}")
-                cur.execute(f"CREATE USER '{extra_user}' IDENTIFIED WITH caching_sha2_password BY '{extra_password}'")
-                cur.execute(f"GRANT ALL ON {database}.* TO '{extra_user}'@'%'")
+                print(f"  CREATE USER {username}")
+                cur.execute(f"CREATE USER '{username}' IDENTIFIED WITH caching_sha2_password BY '{extra_password}'")
+                cur.execute(f"GRANT ALL ON {database}.* TO '{username}'@'%'")
                 cur.execute("FLUSH PRIVILEGES")
 
             cur.close()

--- a/test/common/base_connection_test.h
+++ b/test/common/base_connection_test.h
@@ -59,6 +59,9 @@ protected:
         ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc));
     }
     void TearDown() override {
+        // Allow ng-log to flush before ShutdownLogging() is triggered by freeing the env handle.
+        // Without this, rapid init/shutdown cycles (e.g. skipped tests) can lose log files.
+        std::this_thread::sleep_for(std::chrono::seconds(1));
         ODBC_HELPER::CleanUpHandles(env, dbc, nullptr);
     }
 private:

--- a/test/common/connection_string_builder.h
+++ b/test/common/connection_string_builder.h
@@ -159,6 +159,11 @@ public:
         return *this;
     }
 
+    ConnectionStringBuilder& withClusterId(const std::string& cluster_id) {
+        length += sprintf(conn_in + length, "CLUSTER_ID=%s;", cluster_id.c_str());
+        return *this;
+    }
+
     std::string getString() const {
         return conn_in;
     }

--- a/test/integration/aurora_initial_connection_strategy_integration_test.cpp
+++ b/test/integration/aurora_initial_connection_strategy_integration_test.cpp
@@ -69,6 +69,7 @@ TEST_F(AuroraInitialConnectionStrategyIntegrationTest, AuroraInitialConnectionSt
         .withDatabase(test_db)
         .withAuroraInitialConnectionStrategy(true)
         .withDatabaseDialect(test_dialect)
+        .withClusterId("AuroraInitialConnectionStrategyWriterDns")
         .getString();
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);
     EXPECT_EQ(SQL_SUCCESS, rc);
@@ -89,6 +90,7 @@ TEST_F(AuroraInitialConnectionStrategyIntegrationTest, AuroraInitialConnectionSt
         .withDatabase(test_db)
         .withAuroraInitialConnectionStrategy(true)
         .withDatabaseDialect(test_dialect)
+        .withClusterId("AuroraInitialConnectionStrategyReaderDns")
         .getString();
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);
     EXPECT_EQ(SQL_SUCCESS, rc);
@@ -112,6 +114,7 @@ TEST_F(AuroraInitialConnectionStrategyIntegrationTest, AuroraInitialConnectionSt
         .withDatabaseDialect(test_dialect)
         .withAuroraInitialConnectionStrategy(true)
         .withVerifyInitialConnectionType("READER")
+        .withClusterId("AuroraInitialConnectionStrategyWriterDnsReaderOverride")
         .getString();
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);
     EXPECT_EQ(SQL_SUCCESS, rc);
@@ -136,6 +139,7 @@ TEST_F(AuroraInitialConnectionStrategyIntegrationTest, AuroraInitialConnectionSt
         .withDatabaseDialect(test_dialect)
         .withAuroraInitialConnectionStrategy(true)
         .withVerifyInitialConnectionType("WRITER")
+        .withClusterId("AuroraInitialConnectionStrategyReaderDnsWriterOverride")
         .getString();
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);
     EXPECT_EQ(SQL_SUCCESS, rc);

--- a/test/integration/custom_endpoint_integration_test.cpp
+++ b/test/integration/custom_endpoint_integration_test.cpp
@@ -81,6 +81,7 @@ TEST_F(CustomEndpointIntegrationTest, CustomEndpointFailover) {
         .withEnableClusterFailover(true)
         .withFailoverMode("READER_OR_WRITER")
         .withDatabaseDialect(test_dialect)
+        .withClusterId("CustomEndpointFailover")
         .getString();
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);
     EXPECT_EQ(SQL_SUCCESS, rc);

--- a/test/integration/failover_integration_test.cpp
+++ b/test/integration/failover_integration_test.cpp
@@ -76,6 +76,9 @@ protected:
 
 /** Writer fails to a reader **/
 TEST_F(FailoverIntegrationTest, WriterFailToReader) {
+    conn_str = ConnectionStringBuilder(conn_str)
+        .withClusterId("WriterFailToReader")
+        .getString();
     std::string strict_reader_conn_str = ConnectionStringBuilder(conn_str)
         .withFailoverMode("STRICT_READER")
         .getString();
@@ -108,6 +111,9 @@ TEST_F(FailoverIntegrationTest, WriterFailToReader) {
 
 /** Writer fails within a transaction. Open transaction by explicitly calling BEGIN */
 TEST_F(FailoverIntegrationTest, WriterFailWithinTransaction_DisableAutocommit) {
+    conn_str = ConnectionStringBuilder(conn_str)
+        .withClusterId("WriterFailWithinTransaction_DisableAutocommit")
+        .getString();
     EXPECT_EQ(SQL_SUCCESS, ODBC_HELPER::DriverConnect(dbc, conn_str));
 
     // Setup tests
@@ -155,6 +161,9 @@ TEST_F(FailoverIntegrationTest, WriterFailWithinTransaction_DisableAutocommit) {
 
 /** Writer fails within a transaction. Open transaction with SQLSetConnectAttr */
 TEST_F(FailoverIntegrationTest, WriterFailWithinTransaction_setAutoCommitFalse) {
+    conn_str = ConnectionStringBuilder(conn_str)
+        .withClusterId("WriterFailWithinTransaction_setAutoCommitFalse")
+        .getString();
     EXPECT_EQ(SQL_SUCCESS, ODBC_HELPER::DriverConnect(dbc, conn_str));
 
     // Setup tests

--- a/test/integration/iam_authentication_integration_test.cpp
+++ b/test/integration/iam_authentication_integration_test.cpp
@@ -66,6 +66,7 @@ TEST_F(IamAuthenticationIntegrationTest, SimpleIamConnection) {
         .withAuthExpiration(900)
         .withExtraUrlEncode(true)
         .withSslMode("allow")
+        .withClusterId("SimpleIamConnection")
         .getString();
 
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);
@@ -88,6 +89,7 @@ TEST_F(IamAuthenticationIntegrationTest, ConnectToIpAddress) {
         .withExtraUrlEncode(true)
         .withSslMode("allow")
         .withIamHost(test_server)
+        .withClusterId("ConnectToIpAddress")
         .getString();
 
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);
@@ -109,6 +111,7 @@ TEST_F(IamAuthenticationIntegrationTest, WrongPassword) {
         .withAuthExpiration(900)
         .withExtraUrlEncode(true)
         .withSslMode("allow")
+        .withClusterId("WrongPassword")
         .getString();
 
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);
@@ -128,6 +131,7 @@ TEST_F(IamAuthenticationIntegrationTest, WrongUser) {
         .withAuthExpiration(900)
         .withExtraUrlEncode(true)
         .withSslMode("allow")
+        .withClusterId("WrongUser")
         .getString();
 
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);
@@ -151,6 +155,7 @@ TEST_F(IamAuthenticationIntegrationTest, EmptyUser) {
         .withAuthExpiration(900)
         .withExtraUrlEncode(true)
         .withSslMode("allow")
+        .withClusterId("EmptyUser")
         .getString();
 
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);

--- a/test/integration/limitless_integration_test.cpp
+++ b/test/integration/limitless_integration_test.cpp
@@ -176,6 +176,7 @@ TEST_F(LimitlessIntegrationTest, LimitlessImmediate) {
         .withLimitlessEnabled(true)
         .withLimitlessMode("immediate")
         .withLimitlessMonitorIntervalMs(1000)
+        .withClusterId("LimitlessImmediate")
         .getString();
 
     SQLHDBC local_dbc = nullptr;
@@ -200,6 +201,7 @@ TEST_F(LimitlessIntegrationTest, LimitlessLazy) {
         .withLimitlessEnabled(true)
         .withLimitlessMode("lazy")
         .withLimitlessMonitorIntervalMs(MONITOR_INTERVAL_MS)
+        .withClusterId("LimitlessLazy")
         .getString();
 
     SQLHDBC first_dbc = nullptr;
@@ -265,6 +267,7 @@ TEST_F(LimitlessIntegrationTest, HeavyLoadInitial) {
         .withLimitlessEnabled(true)
         .withLimitlessMode("immediate")
         .withLimitlessMonitorIntervalMs(MONITOR_INTERVAL_MS)
+        .withClusterId("HeavyLoadInitial")
         .getString();
 
     std::vector<SQLHDBC> limitless_dbcs;

--- a/test/integration/secrets_manager_integration_test.cpp
+++ b/test/integration/secrets_manager_integration_test.cpp
@@ -57,6 +57,7 @@ TEST_F(SecretsManagerIntegrationTest, EnableSecretsManagerWithRegion) {
         .withAuthMode(auth_type)
         .withAuthRegion(test_region)
         .withSecretId(test_secret_arn)
+        .withClusterId("EnableSecretsManagerWithRegion")
         .getString();
 
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);
@@ -71,6 +72,7 @@ TEST_F(SecretsManagerIntegrationTest, EnableSecretsManagerWithoutRegion) {
         .withDatabase(test_db)
         .withAuthMode(auth_type)
         .withSecretId(test_secret_arn)
+        .withClusterId("EnableSecretsManagerWithoutRegion")
         .getString();
 
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);
@@ -88,6 +90,7 @@ TEST_F(SecretsManagerIntegrationTest, EnableSecretsManagerWrongRegion) {
         .withAuthMode(auth_type)
         .withAuthRegion("us-fake-1")
         .withSecretId(test_secret_arn)
+        .withClusterId("EnableSecretsManagerWrongRegion")
         .getString();
 
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);
@@ -103,6 +106,7 @@ TEST_F(SecretsManagerIntegrationTest, EnableSecretsManagerInvalidSecretID) {
         .withAuthMode(auth_type)
         .withAuthRegion(test_region)
         .withSecretId("invalid-id")
+        .withClusterId("EnableSecretsManagerInvalidSecretID")
         .getString();
 
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);


### PR DESCRIPTION

### Summary

Add a 1 second sleep to tear down.
Set cluster ID to test case name.

### Description

The uploaded driver logs sometimes miss logs from certain tests. This PR adds a 1 second sleep at the end of test to sure all the logs are flushed into a file.

Also sets the cluster ID to the test case name so it is easier to identify the logs corresponding to a specific test.

### Testing

<!-- What did you test and how did you test it -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
