### PR TITLE
fix: utf32 buffers for bind/fetch/param

### DIFF
--- a/driver/driver.h
+++ b/driver/driver.h
@@ -136,7 +136,25 @@ struct BoundColBuffer {
     SQLLEN                  app_buf_len;        // User's BufferLength
     SQLLEN*                 app_str_len_ptr;    // User's StrLen_or_IndPtr
     std::vector<SQLTCHAR>   local_buf;          // Wrapper buffer passed to underlying driver
-    SQLLEN                  local_str_len;      // Wrapper StrLen_or_Ind
+    // Wrapper StrLen_or_Ind, heap-safe w/ shared_ptr
+    std::shared_ptr<SQLLEN> local_str_len = std::make_shared<SQLLEN>(0);
+
+};
+
+// Tracks SQLBindParameter WCHAR binding for 2-byte/4-byte conversion.
+struct BoundParamBuffer {
+    SQLUSMALLINT            param_number;
+    SQLSMALLINT             input_output_type;  // SQL_PARAM_INPUT, SQL_PARAM_OUTPUT, SQL_PARAM_INPUT_OUTPUT
+    SQLSMALLINT             value_type;
+    SQLSMALLINT             param_type;
+    SQLULEN                 column_size;
+    SQLSMALLINT             decimal_digits;
+    SQLPOINTER              app_ptr;            // User's ParameterValuePtr
+    SQLLEN                  app_buf_len;        // User's BufferLength
+    SQLLEN*                 app_str_len_ptr;    // User's StrLen_or_IndPtr
+    std::vector<SQLTCHAR>   local_buf;          // Wrapper buffer passed to underlying driver
+    // Wrapper StrLen_or_Ind, heap-safe w/ shared_ptr
+    std::shared_ptr<SQLLEN> local_str_len = std::make_shared<SQLLEN>(0);
 };
 
 struct STMT {
@@ -154,7 +172,10 @@ struct STMT {
     std::map<SQLINTEGER, std::pair<SQLPOINTER, SQLINTEGER>> attr_map;  // Key, <Value, Length>
     std::string cursor_name;
 
-    std::vector<BoundColBuffer> bound_col_buffers; // Intercepted WCHAR column bindings
+    // Buffers for UTF32 support
+    std::vector<BoundColBuffer> bound_col_buffers;      // Intercepted WCHAR column bindings
+    std::vector<BoundParamBuffer> bound_param_buffers;  // Intercepted WCHAR param bindings
+    bool put_data_char_conversion = false;
 
     ERR_INFO* err = nullptr;
     char sql_error_called = 0;

--- a/driver/driver.h
+++ b/driver/driver.h
@@ -60,6 +60,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <vector>
 
 /* Forward Declarations */
 struct ENV;
@@ -128,6 +129,16 @@ struct DBC {
     ~DBC();
 };  // DBC
 
+// Tracks SQLBindCol WCHAR binding for 2-byte/4-byte conversion.
+struct BoundColBuffer {
+    SQLUSMALLINT            column_number;
+    SQLPOINTER              app_ptr;            // User's TargetValuePtr
+    SQLLEN                  app_buf_len;        // User's BufferLength
+    SQLLEN*                 app_str_len_ptr;    // User's StrLen_or_IndPtr
+    std::vector<SQLTCHAR>   local_buf;          // Wrapper buffer passed to underlying driver
+    SQLLEN                  local_str_len;      // Wrapper StrLen_or_Ind
+};
+
 struct STMT {
     // TODO - Do we need lock?
     std::recursive_mutex lock;
@@ -142,6 +153,8 @@ struct STMT {
     // TODO - May need to change SQLPOINTER to an actual object
     std::map<SQLINTEGER, std::pair<SQLPOINTER, SQLINTEGER>> attr_map;  // Key, <Value, Length>
     std::string cursor_name;
+
+    std::vector<BoundColBuffer> bound_col_buffers; // Intercepted WCHAR column bindings
 
     ERR_INFO* err = nullptr;
     char sql_error_called = 0;

--- a/driver/odbcapi_common.cpp
+++ b/driver/odbcapi_common.cpp
@@ -18,6 +18,188 @@
 #include "util/plugin_service.h"
 #include "util/rds_lib_loader.h"
 
+// Unicode buffer helpers
+#if UNICODE && !defined(_WIN32)
+static void ConvertBoundColBuffersAfterFetch(STMT* stmt) {
+    std::vector<BoundColBuffer>& buffers = stmt->bound_col_buffers;
+    if (buffers.empty()) {
+        return;
+    }
+
+    const bool use_4_base = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+    const bool use_4_app = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+
+    for (BoundColBuffer& buffer : buffers) {
+        if (*buffer.local_str_len == SQL_NULL_DATA || *buffer.local_str_len < 0) {
+            if (buffer.app_str_len_ptr) {
+                *buffer.app_str_len_ptr = *buffer.local_str_len;
+            }
+            continue;
+        }
+
+        SQLTCHAR* local = buffer.local_buf.data();
+
+        // If base driver is 4-byte, convert UTF-32 to UTF-16 in place
+        if (use_4_base) {
+            const size_t char_count = 1 + static_cast<size_t>(*buffer.local_str_len) / sizeof(SQLTCHAR) / 2;
+            Convert4To2ByteString(true, local, nullptr, char_count);
+        }
+
+        // Copy to user's buffer in the expected encoding
+        const size_t src_len = UShortStrlen(reinterpret_cast<const uint16_t *>(local));
+        const size_t dst_len = use_4_app
+            ? static_cast<size_t>(buffer.app_buf_len) / 4
+            : static_cast<size_t>(buffer.app_buf_len) / 2;
+        if (use_4_app) {
+            ConvertUTF16ToUTF32(local, static_cast<SQLTCHAR*>(buffer.app_ptr), src_len, dst_len);
+            if (buffer.app_str_len_ptr) {
+                *buffer.app_str_len_ptr = static_cast<SQLLEN>(src_len) * 4;
+            }
+        } else {
+            const size_t max_chars = dst_len > 0 ? dst_len - 1 : 0;
+            const size_t copy_chars = src_len < max_chars ? src_len : max_chars;
+            SQLTCHAR* dst = reinterpret_cast<SQLTCHAR*>(buffer.app_ptr);
+            std::memcpy(dst, local, copy_chars * sizeof(SQLTCHAR));
+            dst[copy_chars] = '\0';
+            if (buffer.app_str_len_ptr) {
+                *buffer.app_str_len_ptr = static_cast<SQLLEN>(src_len) * sizeof(SQLTCHAR);
+            }
+        }
+    }
+}
+
+static void ConvertBoundParamBuffersBeforeExecute(STMT* stmt) {
+    const DBC* dbc = stmt->dbc;
+    const ENV* env = dbc->env;
+
+    std::vector<BoundParamBuffer>& bindings = stmt->bound_param_buffers;
+    if (bindings.empty()) {
+        return;
+    }
+
+    const bool use_4_base = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+    const bool use_4_app = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+
+    for (BoundParamBuffer& buffer : bindings) {
+        if (buffer.input_output_type == SQL_PARAM_OUTPUT) {
+            continue;
+        }
+
+        const SQLLEN app_ind = buffer.app_str_len_ptr ? *buffer.app_str_len_ptr : 0;
+        if (app_ind == SQL_NULL_DATA) {
+            *buffer.local_str_len = SQL_NULL_DATA;
+            continue;
+        }
+        // Skip as data will be put by SQLPutData
+        if (app_ind == SQL_DATA_AT_EXEC
+            || app_ind <= SQL_LEN_DATA_AT_EXEC(0)) {
+            continue;
+        }
+
+        SQLTCHAR* app_data = static_cast<SQLTCHAR*>(buffer.app_ptr);
+
+        // Get explicit user length or get length of app_data
+        size_t char_count;
+        if (app_ind == SQL_NTS || app_ind < 0) {
+            char_count = UShortStrlen(reinterpret_cast<const uint16_t*>(app_data), use_4_app);
+        } else {
+            char_count = static_cast<size_t>(app_ind);
+            // app_ind is byte count, divide by app's SQLWCHAR size
+            char_count = use_4_app
+                ? char_count / 4
+                : char_count / 2;
+        }
+
+        // Resize local buffer to runtime length of app_data
+        const size_t app_data_size = 1 + char_count;
+        const size_t local_buf_resize = use_4_base
+            ? app_data_size * 2
+            : app_data_size;
+        if (local_buf_resize > buffer.local_buf.size()) {
+            buffer.local_buf.resize(local_buf_resize, 0);
+        }
+
+        if (use_4_app) {
+            // User app UTF32 -> local buffer UTF16
+            Convert4To2ByteString(true, app_data, buffer.local_buf.data(), app_data_size);
+        } else {
+            // Copy as-is
+            const size_t src_len = char_count;
+            const size_t max_copy = static_cast<size_t>(buffer.local_buf.size());
+            const size_t copy_len = src_len < max_copy ? src_len : max_copy;
+            std::memcpy(buffer.local_buf.data(), app_data, copy_len * sizeof(SQLTCHAR));
+            buffer.local_buf[copy_len] = 0;
+        }
+
+        if (use_4_base) {
+            // Expand to UTF32 if needed
+            ExpandUTF16ToUTF32InPlace(buffer.local_buf.data(), app_data_size, buffer.local_buf.size());
+        }
+
+        *buffer.local_str_len = SQL_NTS;
+
+        // Rebind parameter
+        const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(
+            env->driver_lib_loader, RDS_FP_SQLBindParameter, RDS_STR_SQLBindParameter, stmt->wrapped_stmt,
+            buffer.param_number, buffer.input_output_type, buffer.value_type, buffer.param_type, buffer.column_size,
+            buffer.decimal_digits, buffer.local_buf.data(), buffer.app_buf_len, buffer.local_str_len.get()
+        );
+    }
+}
+
+static void ConvertBoundParamBuffersAfterExecute(STMT* stmt) {
+    std::vector<BoundParamBuffer>& bindings = stmt->bound_param_buffers;
+    if (bindings.empty()) {
+        return;
+    }
+
+    const bool use_4_base = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+    const bool use_4_app = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+
+    for (BoundParamBuffer& param : bindings) {
+        if (param.input_output_type == SQL_PARAM_INPUT) {
+            continue;
+        }
+
+        if (*param.local_str_len == SQL_NULL_DATA || *param.local_str_len < 0) {
+            if (param.app_str_len_ptr) {
+                *param.app_str_len_ptr = *param.local_str_len;
+            }
+            continue;
+        }
+
+        SQLTCHAR* local = param.local_buf.data();
+
+        // If base driver is 4-byte, convert UTF-32 to UTF-16 in place
+        if (use_4_base) {
+            const size_t char_count = 1 + static_cast<size_t>(*param.local_str_len) / sizeof(SQLTCHAR) / 2;
+            Convert4To2ByteString(true, local, nullptr, char_count);
+        }
+
+        // Copy to user's buffer in the expected encoding
+        const size_t src_len = UShortStrlen(reinterpret_cast<const uint16_t*>(local));
+        const size_t dst_len = use_4_app
+            ? static_cast<size_t>(param.app_buf_len) / 4
+            : static_cast<size_t>(param.app_buf_len) / 2;
+        if (use_4_app) {
+            ConvertUTF16ToUTF32(local, static_cast<SQLTCHAR*>(param.app_ptr), src_len, dst_len);
+            if (param.app_str_len_ptr) {
+                *param.app_str_len_ptr = static_cast<SQLLEN>(src_len) * 4;
+            }
+        } else {
+            const size_t max_chars = dst_len > 0 ? dst_len - 1 : 0;
+            const size_t copy_chars = src_len < max_chars ? src_len : max_chars;
+            SQLTCHAR* dst = static_cast<SQLTCHAR*>(param.app_ptr);
+            std::memcpy(dst, local, copy_chars * sizeof(SQLTCHAR));
+            dst[copy_chars] = '\0';
+            if (param.app_str_len_ptr) {
+                *param.app_str_len_ptr = static_cast<SQLLEN>(src_len) * 2;
+            }
+        }
+    }
+}
+#endif
+
 // Common ODBC Functions
 SQLRETURN SQL_API SQLAllocConnect(
     SQLHENV        EnvironmentHandle,
@@ -98,7 +280,6 @@ SQLRETURN SQL_API SQLBindCol(
                 std::remove_if(bindings.begin(), bindings.end(),
                     [ColumnNumber](const BoundColBuffer &b) { return b.column_number == ColumnNumber; }),
                 bindings.end());
-
         } else if ((use_4_base || use_4_app) && TargetType == SQL_C_TCHAR && BufferLength > 0) {
             bindings.erase(
                 std::remove_if(bindings.begin(), bindings.end(),
@@ -115,13 +296,12 @@ SQLRETURN SQL_API SQLBindCol(
             new_buffer.app_buf_len = BufferLength;
             new_buffer.app_str_len_ptr = StrLen_or_IndPtr;
             new_buffer.local_buf.resize(local_buf_size, 0);
-            new_buffer.local_str_len = 0;
             bindings.push_back(std::move(new_buffer));
 
             BoundColBuffer& ref = bindings.back();
             const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLBindCol, RDS_STR_SQLBindCol,
                 stmt->wrapped_stmt, ColumnNumber, TargetType, ref.local_buf.data(),
-                BufferLength, &ref.local_str_len
+                BufferLength, ref.local_str_len.get()
             );
             return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
         }
@@ -154,8 +334,96 @@ SQLRETURN SQL_API SQLBindParameter(
 
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
-
     CHECK_WRAPPED_STMT(stmt);
+
+    #if UNICODE && !defined(_WIN32)
+    {
+        const bool use_4_base = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+        const bool use_4_app = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+
+        std::vector<BoundParamBuffer>& bindings = stmt->bound_param_buffers;
+        if ((use_4_base || use_4_app) && ValueType == SQL_C_TCHAR) {
+            bindings.erase(
+                std::remove_if(bindings.begin(), bindings.end(),
+                    [ParameterNumber](const BoundParamBuffer& b) { return b.param_number == ParameterNumber; }),
+                bindings.end());
+
+            // Data to be handled at execute runtime
+            const bool is_data_at_exec = StrLen_or_IndPtr &&
+                (
+                    *StrLen_or_IndPtr == SQL_DATA_AT_EXEC
+                    || *StrLen_or_IndPtr <= SQL_LEN_DATA_AT_EXEC(0)
+                );
+
+            BoundParamBuffer new_buffer;
+            new_buffer.param_number = ParameterNumber;
+            new_buffer.input_output_type = InputOutputType;
+            new_buffer.value_type = ValueType;
+            new_buffer.param_type = ParameterType;
+            new_buffer.column_size = ColumnSize;
+            new_buffer.decimal_digits = DecimalDigits;
+            new_buffer.app_ptr = ParameterValuePtr;
+            new_buffer.app_buf_len = BufferLength;
+            new_buffer.app_str_len_ptr = StrLen_or_IndPtr;
+
+            // Get explicit user length or get length of app_data
+            const SQLLEN app_ind = new_buffer.app_str_len_ptr ? *new_buffer.app_str_len_ptr : 0;
+            size_t char_count = 0;
+            if (app_ind == SQL_NTS) {
+                char_count = UShortStrlen(reinterpret_cast<const uint16_t*>(new_buffer.app_ptr), use_4_app);
+            } else {
+                char_count = static_cast<size_t>(app_ind);
+                // app_ind is byte count, divide by app's SQLWCHAR size
+                char_count = use_4_app
+                    ? char_count / 4
+                    : char_count / 2;
+            }
+            const size_t str_len_bytes = use_4_base
+                ? char_count * 4
+                : char_count * 2;
+
+            if (ParameterValuePtr != nullptr && BufferLength > 0 && !is_data_at_exec) {
+                // Create a buffer if the input size was set
+                const size_t local_buf_size = use_4_base
+                    ? static_cast<size_t>(BufferLength) * 2
+                    : static_cast<size_t>(BufferLength);
+                new_buffer.local_buf.resize(1 + local_buf_size, 0);
+                *new_buffer.local_str_len = str_len_bytes;
+            } else if (!is_data_at_exec) {
+                // Pass null data to underlying if user did not pass data at exec
+                const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(
+                    env->driver_lib_loader, RDS_FP_SQLBindParameter, RDS_STR_SQLBindParameter, stmt->wrapped_stmt,
+                    ParameterNumber, InputOutputType, ValueType, ParameterType, ColumnSize,
+                    DecimalDigits, ParameterValuePtr, BufferLength, StrLen_or_IndPtr
+                );
+                return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+            }
+
+            bindings.push_back(std::move(new_buffer));
+            BoundParamBuffer& ref = bindings.back(); // Get stored reference instead of local stack reference
+
+            // If data_at_exec, pass original pointer
+            // so the driver can return token location properly
+            SQLPOINTER bind_ptr = is_data_at_exec
+                ? ParameterValuePtr
+                : ref.local_buf.data();
+            SQLLEN bind_len = is_data_at_exec
+                ? BufferLength
+                : ref.local_buf.size() * sizeof(SQLTCHAR);
+            SQLLEN* bind_itr = is_data_at_exec
+                ? StrLen_or_IndPtr
+                : ref.local_str_len.get();
+
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(
+                env->driver_lib_loader, RDS_FP_SQLBindParameter, RDS_STR_SQLBindParameter, stmt->wrapped_stmt,
+                ParameterNumber, InputOutputType, ValueType, ParameterType, ColumnSize,
+                DecimalDigits, bind_ptr, bind_len, bind_itr
+            );
+            return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+        }
+    }
+    #endif
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLBindParameter, RDS_STR_SQLBindParameter,
         stmt->wrapped_stmt, ParameterNumber, InputOutputType, ValueType, ParameterType, ColumnSize, DecimalDigits, ParameterValuePtr, BufferLength, StrLen_or_IndPtr
     );
@@ -431,54 +699,25 @@ SQLRETURN SQL_API SQLExecute(
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
 
+    SQLRETURN rc = SQL_ERROR;
     if (dbc->plugin_head) {
-        return dbc->plugin_head->Execute(StatementHandle);
+        #if UNICODE && !defined(_WIN32)
+            ConvertBoundParamBuffersBeforeExecute(stmt);
+        #endif
+        rc = dbc->plugin_head->Execute(StatementHandle);
+    } else {
+        LOG(ERROR) << "Cannot execute without an open connection";
+        stmt->err = new ERR_INFO("SQLExecute - Connection not open", ERR_CONNECTION_NOT_OPEN);
     }
-
-    LOG(ERROR) << "Cannot execute without an open connection";
-    stmt->err = new ERR_INFO("SQLExecute - Connection not open", ERR_CONNECTION_NOT_OPEN);
-    return SQL_ERROR;
-}
 
 #if UNICODE && !defined(_WIN32)
-static void ConvertBoundColBuffersAfterFetch(STMT* stmt) {
-    std::vector<BoundColBuffer>& buffers = stmt->bound_col_buffers;
-    if (buffers.empty()) {
-        return;
+    if (SQL_SUCCEEDED(rc)) {
+        ConvertBoundParamBuffersAfterExecute(stmt);
     }
-
-    const bool use_4_base = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
-    const bool use_4_app = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
-
-    for (BoundColBuffer& buffer : buffers) {
-        if (buffer.local_str_len == SQL_NULL_DATA || buffer.local_str_len < 0) {
-            if (buffer.app_str_len_ptr) {
-                *buffer.app_str_len_ptr = buffer.local_str_len;
-            }
-            continue;
-        }
-
-        SQLTCHAR* local = buffer.local_buf.data();
-
-        // If base driver is 4-byte, convert UTF-32 to UTF-16 in place
-        if (use_4_base) {
-            Convert4To2ByteString(true, local, nullptr, static_cast<size_t>(buffer.local_str_len));
-        }
-
-        // Copy to user's buffer in the expected encoding
-        const size_t src_len = UShortStrlen(reinterpret_cast<const uint16_t *>(local));
-        const size_t dst_len = buffer.app_buf_len;
-        if (use_4_app) {
-            ConvertUTF16ToUTF32(local, static_cast<SQLTCHAR*>(buffer.app_ptr), src_len, dst_len);
-        } else {
-            const size_t copy_chars = src_len < dst_len ? src_len : dst_len;
-            SQLTCHAR* dst = reinterpret_cast<SQLTCHAR*>(buffer.app_ptr);
-            std::memcpy(dst, local, copy_chars * sizeof(SQLTCHAR));
-            dst[copy_chars] = '\0';
-        }
-    }
-}
 #endif
+
+    return rc;
+}
 
 SQLRETURN SQL_API SQLExtendedFetch(
     SQLHSTMT       StatementHandle,
@@ -628,21 +867,37 @@ SQLRETURN SQL_API SQLGetData(
 
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
-
     CHECK_WRAPPED_STMT(stmt);
 
 #if UNICODE
     RdsLibResult res;
-    if (!dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp() && TargetType == SQL_C_TCHAR) {
-        SQLTCHAR* buf = reinterpret_cast<SQLTCHAR*>(TargetValuePtr);
-        std::vector<SQLTCHAR> new_buf_vector(static_cast<size_t>(BufferLength) * 2, '\0');
-        SQLTCHAR* new_buf = new_buf_vector.data();
+    const bool use_4_app = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+    const bool use_4_base = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+
+    if ((use_4_app || use_4_base) && TargetType == SQL_C_TCHAR) {
+        std::vector<SQLTCHAR> buffer(static_cast<size_t>(BufferLength) * 2, 0);
 
         res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetData, RDS_STR_SQLGetData,
-            stmt->wrapped_stmt, Col_or_Param_Num, TargetType, new_buf, BufferLength, StrLen_or_IndPtr
+            stmt->wrapped_stmt, Col_or_Param_Num, TargetType, buffer.data(), BufferLength, StrLen_or_IndPtr
         );
 
-        Convert4To2ByteString(dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver(), new_buf, buf, BufferLength);
+        if (SQL_SUCCEEDED(res.fn_result) && StrLen_or_IndPtr && *StrLen_or_IndPtr != SQL_NULL_DATA) {
+            SQLTCHAR* dst = reinterpret_cast<SQLTCHAR*>(TargetValuePtr);
+
+            if (use_4_base) {
+                Convert4To2ByteString(true, buffer.data(), nullptr, buffer.size());
+            }
+
+            const size_t src_len = UShortStrlen(reinterpret_cast<const uint16_t*>(buffer.data()));
+            const size_t dst_len = static_cast<size_t>(BufferLength) / sizeof(SQLTCHAR);
+            if (use_4_app) {
+                ConvertUTF16ToUTF32(buffer.data(), dst, src_len, dst_len);
+            } else {
+                const size_t copy_len = src_len < dst_len ? src_len : dst_len - 1;
+                std::memcpy(dst, buffer.data(), copy_len * sizeof(SQLTCHAR));
+                dst[copy_len] = 0;
+            }
+        }
     } else {
         res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetData, RDS_STR_SQLGetData,
             stmt->wrapped_stmt, Col_or_Param_Num, TargetType, TargetValuePtr, BufferLength, StrLen_or_IndPtr
@@ -817,11 +1072,30 @@ SQLRETURN SQL_API SQLParamData(
 
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
-
     CHECK_WRAPPED_STMT(stmt);
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLParamData, RDS_STR_SQLParamData,
         stmt->wrapped_stmt, ValuePtrPtr
     );
+
+#if UNICODE && !defined(_WIN32)
+    stmt->put_data_char_conversion = false;
+    if (res.fn_result == SQL_NEED_DATA && ValuePtrPtr && *ValuePtrPtr) {
+        const bool use_4_base = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+        const bool use_4_app = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+
+        if (use_4_base || use_4_app) {
+            // Check if this parameter was bound as SQL_C_TCHAR
+            for (const auto& p : stmt->bound_param_buffers) {
+                if (p.app_ptr == *ValuePtrPtr && p.value_type == SQL_C_TCHAR) {
+                    stmt->put_data_char_conversion = true;
+                    break;
+                }
+            }
+        }
+    }
+#endif
+
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }
 
@@ -858,8 +1132,37 @@ SQLRETURN SQL_API SQLPutData(
 
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
-
     CHECK_WRAPPED_STMT(stmt);
+
+#if UNICODE && !defined(_WIN32)
+    if (stmt->put_data_char_conversion && DataPtr != nullptr && StrLen_or_Ind != SQL_NULL_DATA && StrLen_or_Ind != 0) {
+        const bool use_4_base = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+        const bool use_4_app = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+
+        const SQLTCHAR* app_data = static_cast<const SQLTCHAR*>(DataPtr);
+
+        const size_t src_len = GetLenOfSqltcharArray(const_cast<SQLTCHAR*>(app_data), StrLen_or_Ind, use_4_app);
+        const size_t local_buf_size = use_4_base ? (src_len + 1) * 2 : src_len + 1;
+        std::vector<SQLTCHAR> local_buf(local_buf_size, 0);
+
+        if (use_4_app) {
+            Convert4To2ByteString(true, const_cast<SQLTCHAR*>(app_data), local_buf.data(), src_len + 1);
+        } else {
+            std::memcpy(local_buf.data(), app_data, src_len * sizeof(SQLTCHAR));
+            local_buf[src_len] = 0;
+        }
+
+        if (use_4_base) {
+            const size_t utf16_len = UShortStrlen(reinterpret_cast<const uint16_t*>(local_buf.data()));
+            ExpandUTF16ToUTF32InPlace(local_buf.data(), utf16_len, local_buf.size());
+        }
+
+        const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(
+            env->driver_lib_loader, RDS_FP_SQLPutData, RDS_STR_SQLPutData, stmt->wrapped_stmt, local_buf.data(), SQL_NTS);
+        return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+    }
+#endif
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLPutData, RDS_STR_SQLPutData,
         stmt->wrapped_stmt, DataPtr, StrLen_or_Ind
     );

--- a/driver/odbcapi_common.cpp
+++ b/driver/odbcapi_common.cpp
@@ -91,8 +91,15 @@ SQLRETURN SQL_API SQLBindCol(
         const bool use_4_base = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
         const bool use_4_app = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
 
-        if ((use_4_base || use_4_app) && TargetType == SQL_C_TCHAR && TargetValuePtr != nullptr && BufferLength > 0) {
-            std::vector<BoundColBuffer>& bindings = stmt->bound_col_buffers;
+        std::vector<BoundColBuffer>& bindings = stmt->bound_col_buffers;
+        if (TargetValuePtr == nullptr) {
+            // Unbind single column
+            bindings.erase(
+                std::remove_if(bindings.begin(), bindings.end(),
+                    [ColumnNumber](const BoundColBuffer &b) { return b.column_number == ColumnNumber; }),
+                bindings.end());
+
+        } else if ((use_4_base || use_4_app) && TargetType == SQL_C_TCHAR && BufferLength > 0) {
             bindings.erase(
                 std::remove_if(bindings.begin(), bindings.end(),
                     [ColumnNumber](const BoundColBuffer &b) { return b.column_number == ColumnNumber; }),
@@ -435,7 +442,7 @@ SQLRETURN SQL_API SQLExecute(
 
 #if UNICODE && !defined(_WIN32)
 static void ConvertBoundColBuffersAfterFetch(STMT* stmt) {
-    std::vector<BoundColBuffer> buffers = stmt->bound_col_buffers;
+    std::vector<BoundColBuffer>& buffers = stmt->bound_col_buffers;
     if (buffers.empty()) {
         return;
     }

--- a/driver/odbcapi_common.cpp
+++ b/driver/odbcapi_common.cpp
@@ -84,8 +84,43 @@ SQLRETURN SQL_API SQLBindCol(
 
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
-
     CHECK_WRAPPED_STMT(stmt);
+
+    #if UNICODE && !defined(_WIN32)
+    {
+        const bool use_4_base = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+        const bool use_4_app = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+
+        if ((use_4_base || use_4_app) && TargetType == SQL_C_TCHAR && TargetValuePtr != nullptr && BufferLength > 0) {
+            std::vector<BoundColBuffer>& bindings = stmt->bound_col_buffers;
+            bindings.erase(
+                std::remove_if(bindings.begin(), bindings.end(),
+                    [ColumnNumber](const BoundColBuffer &b) { return b.column_number == ColumnNumber; }),
+                bindings.end());
+
+            const size_t local_buf_size = use_4_base
+                ? static_cast<size_t>(BufferLength) * 2
+                : static_cast<size_t>(BufferLength);
+
+            BoundColBuffer new_buffer;
+            new_buffer.column_number = ColumnNumber;
+            new_buffer.app_ptr = TargetValuePtr;
+            new_buffer.app_buf_len = BufferLength;
+            new_buffer.app_str_len_ptr = StrLen_or_IndPtr;
+            new_buffer.local_buf.resize(local_buf_size, 0);
+            new_buffer.local_str_len = 0;
+            bindings.push_back(std::move(new_buffer));
+
+            BoundColBuffer& ref = bindings.back();
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLBindCol, RDS_STR_SQLBindCol,
+                stmt->wrapped_stmt, ColumnNumber, TargetType, ref.local_buf.data(),
+                BufferLength, &ref.local_str_len
+            );
+            return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+        }
+    }
+    #endif
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLBindCol, RDS_STR_SQLBindCol,
         stmt->wrapped_stmt, ColumnNumber, TargetType, TargetValuePtr, BufferLength, StrLen_or_IndPtr
     );
@@ -398,6 +433,46 @@ SQLRETURN SQL_API SQLExecute(
     return SQL_ERROR;
 }
 
+#if UNICODE && !defined(_WIN32)
+static void ConvertBoundColBuffersAfterFetch(STMT* stmt) {
+    std::vector<BoundColBuffer> buffers = stmt->bound_col_buffers;
+    if (buffers.empty()) {
+        return;
+    }
+
+    const bool use_4_base = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+    const bool use_4_app = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+
+    for (BoundColBuffer& buffer : buffers) {
+        if (buffer.local_str_len == SQL_NULL_DATA || buffer.local_str_len < 0) {
+            if (buffer.app_str_len_ptr) {
+                *buffer.app_str_len_ptr = buffer.local_str_len;
+            }
+            continue;
+        }
+
+        SQLTCHAR* local = buffer.local_buf.data();
+
+        // If base driver is 4-byte, convert UTF-32 to UTF-16 in place
+        if (use_4_base) {
+            Convert4To2ByteString(true, local, nullptr, static_cast<size_t>(buffer.local_str_len));
+        }
+
+        // Copy to user's buffer in the expected encoding
+        const size_t src_len = UShortStrlen(reinterpret_cast<const uint16_t *>(local));
+        const size_t dst_len = buffer.app_buf_len;
+        if (use_4_app) {
+            ConvertUTF16ToUTF32(local, static_cast<SQLTCHAR*>(buffer.app_ptr), src_len, dst_len);
+        } else {
+            const size_t copy_chars = src_len < dst_len ? src_len : dst_len;
+            SQLTCHAR* dst = reinterpret_cast<SQLTCHAR*>(buffer.app_ptr);
+            std::memcpy(dst, local, copy_chars * sizeof(SQLTCHAR));
+            dst[copy_chars] = '\0';
+        }
+    }
+}
+#endif
+
 SQLRETURN SQL_API SQLExtendedFetch(
     SQLHSTMT       StatementHandle,
     SQLUSMALLINT   FetchOrientation,
@@ -418,6 +493,13 @@ SQLRETURN SQL_API SQLExtendedFetch(
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLExtendedFetch, RDS_STR_SQLExtendedFetch,
         stmt->wrapped_stmt, FetchOrientation, FetchOffset, RowCountPtr, RowStatusArray
     );
+
+#if UNICODE && !defined(_WIN32)
+    if (SQL_SUCCEEDED(res.fn_result)) {
+        ConvertBoundColBuffersAfterFetch(stmt);
+    }
+#endif
+
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }
 
@@ -437,6 +519,13 @@ SQLRETURN SQL_API SQLFetch(
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLFetch, RDS_STR_SQLFetch,
         stmt->wrapped_stmt
     );
+
+#if UNICODE && !defined(_WIN32)
+    if (SQL_SUCCEEDED(res.fn_result)) {
+        ConvertBoundColBuffersAfterFetch(stmt);
+    }
+#endif
+
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }
 
@@ -458,6 +547,13 @@ SQLRETURN SQL_API SQLFetchScroll(
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLFetchScroll, RDS_STR_SQLFetchScroll,
         stmt->wrapped_stmt, FetchOrientation, FetchOffset
     );
+
+#if UNICODE && !defined(_WIN32)
+    if (SQL_SUCCEEDED(res.fn_result)) {
+        ConvertBoundColBuffersAfterFetch(stmt);
+    }
+#endif
+
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }
 

--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -42,6 +42,21 @@
     #include "gui/setup.h"
 #endif
 
+#if UNICODE
+std::shared_ptr<OdbcHelper> RDS_GetOdbcHelper(const DBC* dbc, const ENV* env) {
+    if (dbc && dbc->plugin_service) {
+        return dbc->plugin_service->GetOdbcHelper();
+    }
+    if (env && !env->dbc_list.empty()) {
+        const DBC* env_dbc = env->dbc_list.front();
+        if (env_dbc && env_dbc->plugin_service) {
+            return env_dbc->plugin_service->GetOdbcHelper();
+        }
+    }
+    return nullptr;
+}
+#endif
+
 SQLRETURN RDS_ProcessLibRes(
     SQLSMALLINT         HandleType,
     SQLHANDLE           InputHandle,
@@ -460,10 +475,24 @@ SQLRETURN RDS_GetConnectAttr(
 
     // If already connected, query value from underlying DBC
     if (dbc->wrapped_dbc) {
-        const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetConnectAttr, RDS_STR_SQLGetConnectAttr,
-            dbc->wrapped_dbc, Attribute, ValuePtr, BufferLength, StringLengthPtr
-        );
-        ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+#if UNICODE
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        if (odbc_helper->NeedsConversion() && ValuePtr && BufferLength > 0
+            && OdbcHelper::IsStringConnectAttr(Attribute)) {
+            auto attr_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetConnectAttr, RDS_STR_SQLGetConnectAttr,
+                dbc->wrapped_dbc, Attribute, attr_buf.data(), BufferLength, StringLengthPtr
+            );
+            odbc_helper->ConvertDriverOutputToTarget(attr_buf.data(), static_cast<SQLTCHAR*>(ValuePtr), static_cast<size_t>(BufferLength));
+            ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+        } else
+#endif
+        {
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetConnectAttr, RDS_STR_SQLGetConnectAttr,
+                dbc->wrapped_dbc, Attribute, ValuePtr, BufferLength, StringLengthPtr
+            );
+            ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+        }
     }
     // Otherwise get from the DBC's attribute map
     else if (dbc->attr_map.contains(Attribute)) {
@@ -500,10 +529,24 @@ SQLRETURN RDS_SQLSetConnectAttr(
 
     // If already connected, apply value to underlying DBC, otherwise track and apply on connect
     if (dbc->wrapped_dbc) {
-        const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLSetConnectAttr, RDS_STR_SQLSetConnectAttr,
-            dbc->wrapped_dbc, Attribute, ValuePtr, StringLength
-        );
-        ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+#if UNICODE
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        if (odbc_helper->NeedsConversion() && ValuePtr
+            && OdbcHelper::IsStringConnectAttr(Attribute)
+            && (StringLength == SQL_NTS || StringLength > 0)) {
+            auto value_converted = odbc_helper->ConvertInput(static_cast<SQLTCHAR*>(ValuePtr), StringLength);
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLSetConnectAttr, RDS_STR_SQLSetConnectAttr,
+                dbc->wrapped_dbc, Attribute, value_converted.tchar_ptr, StringLength
+            );
+            ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+        } else
+#endif
+        {
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLSetConnectAttr, RDS_STR_SQLSetConnectAttr,
+                dbc->wrapped_dbc, Attribute, ValuePtr, StringLength
+            );
+            ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+        }
     }
     dbc->attr_map.insert_or_assign(Attribute, std::make_pair(ValuePtr, StringLength));
 
@@ -551,6 +594,22 @@ SQLRETURN RDS_SQLColAttribute(
     CLEAR_STMT_ERROR(stmt);
 
     CHECK_WRAPPED_STMT(stmt);
+#if UNICODE
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+
+    if (odbc_helper->NeedsConversion() && CharacterAttributePtr && BufferLength > 0) {
+        auto attr_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+        const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLColAttribute, RDS_STR_SQLColAttribute,
+            stmt->wrapped_stmt, ColumnNumber, FieldIdentifier, attr_buf.data(), BufferLength, StringLengthPtr, NumericAttributePtr
+        );
+        if (StringLengthPtr && *StringLengthPtr > 0) {
+            odbc_helper->ConvertDriverOutputToTarget(attr_buf.data(), static_cast<SQLTCHAR*>(CharacterAttributePtr), static_cast<size_t>(BufferLength));
+        } else {
+            std::memcpy(CharacterAttributePtr, attr_buf.data(), static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR));
+        }
+        return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+    }
+#endif
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLColAttribute, RDS_STR_SQLColAttribute,
         stmt->wrapped_stmt, ColumnNumber, FieldIdentifier, CharacterAttributePtr, BufferLength, StringLengthPtr, NumericAttributePtr
     );
@@ -574,6 +633,24 @@ SQLRETURN RDS_SQLColAttributes(
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
 
     CHECK_WRAPPED_STMT(stmt);
+#if UNICODE
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+
+    if (odbc_helper->NeedsConversion() && CharacterAttributePtr && BufferLength > 0) {
+        auto attr_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+        const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLColAttributes, RDS_STR_SQLColAttributes,
+            stmt->wrapped_stmt, ColumnNumber, FieldIdentifier, attr_buf.data(), BufferLength, StringLengthPtr, NumericAttributePtr
+        );
+        if (StringLengthPtr && *StringLengthPtr > 0) {
+            // String data
+            odbc_helper->ConvertDriverOutputToTarget(attr_buf.data(), static_cast<SQLTCHAR*>(CharacterAttributePtr), static_cast<size_t>(BufferLength));
+        } else {
+            // Numeric data
+            std::memcpy(CharacterAttributePtr, attr_buf.data(), static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR));
+        }
+        return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+    }
+#endif
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLColAttributes, RDS_STR_SQLColAttributes,
         stmt->wrapped_stmt, ColumnNumber, FieldIdentifier, CharacterAttributePtr, BufferLength, StringLengthPtr, NumericAttributePtr
     );
@@ -781,6 +858,21 @@ SQLRETURN RDS_SQLDescribeCol(
     CLEAR_STMT_ERROR(stmt);
 
     CHECK_WRAPPED_STMT(stmt);
+#if UNICODE
+    {
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        if (odbc_helper->NeedsConversion()) {
+            // Bufferlength is in char count not bytes for SQLDescribeCol
+            const size_t buf_bytes = static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR);
+            auto name_buf = odbc_helper->AllocateConversionBuffer(buf_bytes);
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLDescribeCol, RDS_STR_SQLDescribeCol,
+                stmt->wrapped_stmt, ColumnNumber, name_buf.data(), BufferLength, NameLengthPtr, DataTypePtr, ColumnSizePtr, DecimalDigitsPtr, NullablePtr
+            );
+            odbc_helper->ConvertDriverOutputToTarget(name_buf.data(), ColumnName, buf_bytes);
+            return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+        }
+    }
+#endif
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLDescribeCol, RDS_STR_SQLDescribeCol,
         stmt->wrapped_stmt, ColumnNumber, ColumnName, BufferLength, NameLengthPtr, DataTypePtr, ColumnSizePtr, DecimalDigitsPtr, NullablePtr
     );
@@ -891,11 +983,10 @@ SQLRETURN RDS_SQLDriverConnect(
     if (OutConnectionString && StringLength2Ptr) {
         const SQLULEN len = conn_out_str_utf8.length();
 #ifdef UNICODE
-    #if _WIN32
-        const SQLULEN written = swprintf(OutConnectionString, MAX_KEY_SIZE, RDS_TSTR("%ls").c_str(), ConvertUTF8ToWString(conn_out_str_utf8).c_str());
-    #else
-        const SQLULEN written = CopyUTF8ToUTF16Buffer(OutConnectionString, MAX_KEY_SIZE, conn_out_str_utf8);
-    #endif
+    const SQLULEN written = CopyUTF8ToUTF16Buffer(OutConnectionString, MAX_KEY_SIZE, conn_out_str_utf8);
+    if (dbc->plugin_service) {
+        dbc->plugin_service->GetOdbcHelper()->ConvertWrapperOutputToTarget(OutConnectionString, written, BufferLength);
+    }
 #else
         const SQLULEN written = snprintf(AS_CHAR(OutConnectionString), MAX_KEY_SIZE, "%s", conn_out_str_utf8.c_str());
 #endif
@@ -985,7 +1076,7 @@ SQLRETURN RDS_SQLExecDirect(
     if (StatementText) {
         const std::string utf8 = ConvertUserAppToUTF8(
             odbc_helper->GetUse4BytesUserApp(), StatementText, TextLength);
-        // Plugin chain expects UTF16 
+        // Plugin chain expects UTF16
         stmt_utf16 = ConvertUTF8ToUTF16(utf8);
         stmt_text = reinterpret_cast<SQLTCHAR*>(stmt_utf16.data());
     }
@@ -1092,12 +1183,25 @@ SQLRETURN RDS_SQLGetCursorName(
 
     if (stmt->wrapped_stmt) {
 #if UNICODE
-#else
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        if (odbc_helper->NeedsConversion()) {
+            // Bufferlength is in char count not bytes for SQLGetCursorName
+            const size_t buf_bytes = static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR);
+            auto name_buf = odbc_helper->AllocateConversionBuffer(buf_bytes);
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetCursorName, RDS_STR_SQLGetCursorName,
+                stmt->wrapped_stmt, name_buf.data(), BufferLength, NameLengthPtr
+            );
+            odbc_helper->ConvertDriverOutputToTarget(name_buf.data(), CursorName, buf_bytes);
+            ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+        } else {
 #endif
-        const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetCursorName, RDS_STR_SQLGetCursorName,
-            stmt->wrapped_stmt, CursorName, BufferLength, NameLengthPtr
-        );
-        ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetCursorName, RDS_STR_SQLGetCursorName,
+                stmt->wrapped_stmt, CursorName, BufferLength, NameLengthPtr
+            );
+            ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+#if UNICODE
+        }
+#endif
     } else {
         if (stmt->cursor_name.empty()) {
             stmt->cursor_name = std::string("CUR_").append(std::to_string(stmt->dbc->unnamed_cursor_count++));
@@ -1105,7 +1209,15 @@ SQLRETURN RDS_SQLGetCursorName(
         const std::string name = stmt->cursor_name;
         const SQLULEN len = name.length();
         if (CursorName) {
+#ifdef UNICODE
+            const SQLLEN written = CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(CursorName), static_cast<size_t>(BufferLength), name.c_str());
+            if (dbc->plugin_service) {
+                const size_t buf_bytes = static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR);
+                dbc->plugin_service->GetOdbcHelper()->ConvertWrapperOutputToTarget(CursorName, written, buf_bytes);
+            }
+#else
             snprintf(reinterpret_cast<char*>(CursorName), static_cast<size_t>(BufferLength) / sizeof(SQLTCHAR), "%s", name.c_str());
+#endif
             if (len >= BufferLength) {
                 ret = SQL_SUCCESS_WITH_INFO;
             }
@@ -1134,6 +1246,20 @@ SQLRETURN RDS_SQLGetDescField(
     const std::lock_guard<std::recursive_mutex> lock_guard(desc->lock);
 
     CHECK_WRAPPED_DESC(desc);
+#if UNICODE
+    {
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        if (odbc_helper->NeedsConversion() && ValuePtr && BufferLength > 0
+            && OdbcHelper::IsStringDescField(FieldIdentifier)) {
+            auto field_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDescField, RDS_STR_SQLGetDescField,
+                desc->wrapped_desc, RecNumber, FieldIdentifier, field_buf.data(), BufferLength, StringLengthPtr
+            );
+            odbc_helper->ConvertDriverOutputToTarget(field_buf.data(), static_cast<SQLTCHAR*>(ValuePtr), static_cast<size_t>(BufferLength));
+            return RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
+        }
+    }
+#endif
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDescField, RDS_STR_SQLGetDescField,
         desc->wrapped_desc, RecNumber, FieldIdentifier, ValuePtr, BufferLength, StringLengthPtr
     );
@@ -1161,6 +1287,21 @@ SQLRETURN RDS_SQLGetDescRec(
     const std::lock_guard<std::recursive_mutex> lock_guard(desc->lock);
 
     CHECK_WRAPPED_DESC(desc);
+#if UNICODE
+    {
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        if (odbc_helper->NeedsConversion()) {
+            // Bufferlength is in char count not bytes for SQLGetDescRec
+            const size_t buf_bytes = static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR);
+            auto name_buf = odbc_helper->AllocateConversionBuffer(buf_bytes);
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDescRec, RDS_STR_SQLGetDescRec,
+                desc->wrapped_desc, RecNumber, name_buf.data(), BufferLength, StringLengthPtr, TypePtr, SubTypePtr, LengthPtr, PrecisionPtr, ScalePtr, NullablePtr
+            );
+            odbc_helper->ConvertDriverOutputToTarget(name_buf.data(), Name, buf_bytes);
+            return RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
+        }
+    }
+#endif
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDescRec, RDS_STR_SQLGetDescRec,
         desc->wrapped_desc, RecNumber, Name, BufferLength, StringLengthPtr, TypePtr, SubTypePtr, LengthPtr, PrecisionPtr, ScalePtr, NullablePtr
     );
@@ -1193,10 +1334,27 @@ SQLRETURN RDS_SQLGetDiagField(
                 env = static_cast<ENV*>(Handle);
                 const std::lock_guard<std::recursive_mutex> lock_guard(env->lock);
                 if (env->wrapped_env) {
-                    res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
-                        HandleType, env->wrapped_env, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
-                    );
-                    ret = RDS_ProcessLibRes(SQL_HANDLE_ENV, env, res);
+#if UNICODE
+                    const auto odbc_helper = RDS_GetOdbcHelper(nullptr, env);
+                    if (odbc_helper && odbc_helper->NeedsConversion() && DiagInfoPtr && BufferLength > 0
+                        && OdbcHelper::IsStringDiagField(DiagIdentifier)) {
+                        auto diag_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, env->wrapped_env, RecNumber, DiagIdentifier, diag_buf.data(), BufferLength, StringLengthPtr
+                        );
+                        odbc_helper->ConvertDriverOutputToTarget(
+                            diag_buf.data(),
+                            static_cast<SQLTCHAR*>(DiagInfoPtr),
+                            static_cast<size_t>(BufferLength));
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_ENV, env, res);
+                    } else
+#endif
+                    {
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, env->wrapped_env, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
+                        );
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_ENV, env, res);
+                    }
                 } else if (env->err) {
                     err = new ERR_INFO(*env->err);
                 }
@@ -1209,10 +1367,27 @@ SQLRETURN RDS_SQLGetDiagField(
                 env = dbc->env;
                 const std::lock_guard<std::recursive_mutex> lock_guard(dbc->lock);
                 if (dbc->wrapped_dbc) {
-                    res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
-                        HandleType, dbc->wrapped_dbc, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
-                    );
-                    ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+#if UNICODE
+                    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                    if (odbc_helper->NeedsConversion() && DiagInfoPtr && BufferLength > 0
+                        && OdbcHelper::IsStringDiagField(DiagIdentifier)) {
+                        auto diag_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, dbc->wrapped_dbc, RecNumber, DiagIdentifier, diag_buf.data(), BufferLength, StringLengthPtr
+                        );
+                        odbc_helper->ConvertDriverOutputToTarget(
+                            diag_buf.data(),
+                            static_cast<SQLTCHAR*>(DiagInfoPtr),
+                            static_cast<size_t>(BufferLength));
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+                    } else
+#endif
+                    {
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, dbc->wrapped_dbc, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
+                        );
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+                    }
                 } else if (dbc->err) {
                     err = new ERR_INFO(*dbc->err);
                 }
@@ -1226,10 +1401,27 @@ SQLRETURN RDS_SQLGetDiagField(
                 env = dbc->env;
                 const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
                 if (stmt->wrapped_stmt) {
-                    res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
-                        HandleType, stmt->wrapped_stmt, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
-                    );
-                    ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+#if UNICODE
+                    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                    if (odbc_helper->NeedsConversion() && DiagInfoPtr && BufferLength > 0
+                        && OdbcHelper::IsStringDiagField(DiagIdentifier)) {
+                        auto diag_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, stmt->wrapped_stmt, RecNumber, DiagIdentifier, diag_buf.data(), BufferLength, StringLengthPtr
+                        );
+                        odbc_helper->ConvertDriverOutputToTarget(
+                            diag_buf.data(),
+                            static_cast<SQLTCHAR*>(DiagInfoPtr),
+                            static_cast<size_t>(BufferLength));
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+                    } else
+#endif
+                    {
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, stmt->wrapped_stmt, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
+                        );
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+                    }
                 } else if (stmt->err) {
                     err = new ERR_INFO(*stmt->err);
                 }
@@ -1245,10 +1437,24 @@ SQLRETURN RDS_SQLGetDiagField(
                 const std::lock_guard<std::recursive_mutex> lock_guard(desc->lock);
 
                 if (desc->wrapped_desc) {
-                    res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
-                        HandleType, desc->wrapped_desc, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
-                    );
-                    ret = RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
+#if UNICODE
+                    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                    if (odbc_helper->NeedsConversion() && DiagInfoPtr && BufferLength > 0
+                        && OdbcHelper::IsStringDiagField(DiagIdentifier)) {
+                        auto diag_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, desc->wrapped_desc, RecNumber, DiagIdentifier, diag_buf.data(), BufferLength, StringLengthPtr
+                        );
+                        odbc_helper->ConvertDriverOutputToTarget(diag_buf.data(), static_cast<SQLTCHAR*>(DiagInfoPtr), static_cast<size_t>(BufferLength));
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
+                    } else
+#endif
+                    {
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, desc->wrapped_desc, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
+                        );
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
+                    }
                 } else if (desc->err) {
                     err = new ERR_INFO(*desc->err);
                 }
@@ -1420,6 +1626,9 @@ SQLRETURN RDS_SQLGetDiagRec(
     bool has_underlying_data = false;
 
 #if UNICODE
+    const size_t state_bytes = MAX_SQL_STATE_LEN * sizeof(SQLTCHAR);
+    // Bufferlength is in char count not bytes for SQLGetDiagRec
+    const size_t msg_bytes = static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR);
     SQLTCHAR new_state_buffer[MAX_SQL_STATE_LEN * 2] = {0};
     std::vector<SQLTCHAR> new_msg_vector(static_cast<size_t>(BufferLength) * 2, '\0');
     SQLTCHAR* new_msg_buffer = new_msg_vector.data();
@@ -1445,11 +1654,10 @@ SQLRETURN RDS_SQLGetDiagRec(
                     );
                     ret = RDS_ProcessLibRes(SQL_HANDLE_ENV, env, res);
 
-                    if (!env->dbc_list.empty()) {
-                        const DBC* dbc = env->dbc_list.front();
-                        const bool use_4_bytes = WrapperCall ? dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver() : dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
-                        Convert4To2ByteString(use_4_bytes, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
-                        Convert4To2ByteString(use_4_bytes, new_msg_buffer, MessageText, BufferLength);
+                    const auto odbc_helper = RDS_GetOdbcHelper(nullptr, env);
+                    if (odbc_helper) {
+                        odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, state_bytes);
+                        odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, msg_bytes);
                     }
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
@@ -1478,9 +1686,9 @@ SQLRETURN RDS_SQLGetDiagRec(
                     );
                     ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
 
-                    const bool use_4_bytes = WrapperCall ? dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver() : dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
-                    Convert4To2ByteString(use_4_bytes, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
-                    Convert4To2ByteString(use_4_bytes, new_msg_buffer, MessageText, BufferLength);
+                    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, state_bytes);
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, msg_bytes);
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
                         HandleType, dbc->wrapped_dbc, RecNumber, SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
@@ -1509,9 +1717,9 @@ SQLRETURN RDS_SQLGetDiagRec(
                     );
                     ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 
-                    const bool use_4_bytes = WrapperCall ? dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver() : dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
-                    Convert4To2ByteString(use_4_bytes, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
-                    Convert4To2ByteString(use_4_bytes, new_msg_buffer, MessageText, BufferLength);
+                    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, state_bytes);
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, msg_bytes);
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
                         HandleType, stmt->wrapped_stmt, RecNumber, SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
@@ -1540,9 +1748,9 @@ SQLRETURN RDS_SQLGetDiagRec(
                     );
                     ret = RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
 
-                    const bool use_4_bytes = WrapperCall ? dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver() : dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
-                    Convert4To2ByteString(use_4_bytes, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
-                    Convert4To2ByteString(use_4_bytes, new_msg_buffer, MessageText, BufferLength);
+                    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, state_bytes);
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, msg_bytes);
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
                         HandleType, desc->wrapped_desc, RecNumber, SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
@@ -1564,10 +1772,18 @@ SQLRETURN RDS_SQLGetDiagRec(
             return SQL_NO_DATA_FOUND;
         }
 
+#if UNICODE
+        // Resolve the OdbcHelper for wrapper-generated output conversion
+        const auto odbc_helper = RDS_GetOdbcHelper(dbc, env);
+#endif
+
         ret = SQL_SUCCESS;
         if (SQLState) {
 #ifdef UNICODE
             CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(SQLState), MAX_SQL_STATE_LEN, err->sqlstate);
+            if (odbc_helper) {
+                odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, SQLState, MAX_SQL_STATE_LEN - 1, MAX_SQL_STATE_LEN * 2 * sizeof(SQLTCHAR));
+            }
 #else
             snprintf(reinterpret_cast<char*>(SQLState), MAX_SQL_STATE_LEN, "%s", err->sqlstate);
 #endif
@@ -1583,7 +1799,10 @@ SQLRETURN RDS_SQLGetDiagRec(
         }
         if (MessageText && (BufferLength > 0) && err->error_msg) {
 #ifdef UNICODE
-            const SQLLEN written = CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(MessageText), static_cast<size_t>(BufferLength) / sizeof(uint16_t), err->error_msg);
+            const SQLLEN written = CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(MessageText), static_cast<size_t>(BufferLength), err->error_msg);
+            if (odbc_helper) {
+                odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, MessageText, written, msg_bytes);
+            }
 #else
             const SQLLEN written = snprintf(reinterpret_cast<char*>(MessageText), static_cast<size_t>(BufferLength) / sizeof(SQLTCHAR), "%s", err->error_msg);
 #endif
@@ -1604,6 +1823,13 @@ SQLRETURN RDS_SQLGetDiagRec(
         if (SQLState) {
 #ifdef UNICODE
             CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(SQLState), MAX_SQL_STATE_LEN, NO_DATA_SQL_STATE);
+            // Expand to 4-byte if user app expects it
+            {
+                const auto odbc_helper = RDS_GetOdbcHelper(dbc, env);
+                if (odbc_helper) {
+                    odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, SQLState, MAX_SQL_STATE_LEN - 1, MAX_SQL_STATE_LEN * 2 * sizeof(SQLTCHAR));
+                }
+            }
 #else
             snprintf(reinterpret_cast<char*>(SQLState), MAX_SQL_STATE_LEN, "%s", NO_DATA_SQL_STATE);
 #endif
@@ -1661,6 +1887,24 @@ SQLRETURN RDS_SQLGetInfo(
             if (dbc->wrapped_dbc) {
                 const ENV* env = dbc->env;
                 CLEAR_DBC_ERROR(dbc);
+#if UNICODE
+                const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                if (odbc_helper->NeedsConversion() && InfoValuePtr && BufferLength > 0) {
+                    auto info_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+                    const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetInfo, RDS_STR_SQLGetInfo,
+                        dbc->wrapped_dbc, InfoType, info_buf.data(), BufferLength, StringLengthPtr
+                    );
+                    if (StringLengthPtr && *StringLengthPtr > 0) {
+                        odbc_helper->ConvertDriverOutputToTarget(
+                            info_buf.data(),
+                            static_cast<SQLTCHAR*>(InfoValuePtr),
+                            static_cast<size_t>(BufferLength));
+                    } else {
+                        std::memcpy(InfoValuePtr, info_buf.data(), static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR));
+                    }
+                    return RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+                }
+#endif
                 const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetInfo, RDS_STR_SQLGetInfo,
                     dbc->wrapped_dbc, InfoType, InfoValuePtr, BufferLength, StringLengthPtr
                 );
@@ -1697,7 +1941,11 @@ SQLRETURN RDS_SQLGetInfo(
         len = strlen(char_value);
         if (InfoValuePtr) {
 #ifdef UNICODE
-            CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(InfoValuePtr), BufferLength / sizeof(uint16_t), char_value);
+            const SQLLEN written = CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(InfoValuePtr), static_cast<size_t>(BufferLength), char_value);
+            if (dbc->plugin_service) {
+                dbc->plugin_service->GetOdbcHelper()->ConvertWrapperOutputToTarget(
+                    static_cast<SQLTCHAR*>(InfoValuePtr), written, static_cast<size_t>(BufferLength));
+            }
 #else
             snprintf(static_cast<char*>(InfoValuePtr), static_cast<size_t>(BufferLength) / sizeof(SQLTCHAR), "%s", char_value);
 #endif
@@ -1811,6 +2059,25 @@ SQLRETURN RDS_SQLNativeSql(
 
     const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
     auto stmt_converted = odbc_helper->ConvertInput(InStatementText, TextLength1);
+
+#if UNICODE
+    {
+        if (odbc_helper->NeedsConversion()) {
+            // Bufferlength is in char count not bytes for SQLNativeSQL
+            const size_t buf_bytes = static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR);
+            auto out_buf = odbc_helper->AllocateConversionBuffer(buf_bytes);
+            SQLTCHAR* out_ptr = OutStatementText ? out_buf.data() : nullptr;
+
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLNativeSql, RDS_STR_SQLNativeSql,
+                dbc->wrapped_dbc, stmt_converted.tchar_ptr, TextLength1, out_ptr, BufferLength, TextLength2Ptr
+            );
+            if (OutStatementText && out_ptr) {
+                odbc_helper->ConvertDriverOutputToTarget(out_ptr, OutStatementText, buf_bytes);
+            }
+            return RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+        }
+    }
+#endif
 
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLNativeSql, RDS_STR_SQLNativeSql,
         dbc->wrapped_dbc,
@@ -2028,6 +2295,20 @@ SQLRETURN RDS_SQLSetDescField(
     const std::lock_guard<std::recursive_mutex> lock_guard(desc->lock);
 
     CHECK_WRAPPED_DESC(desc);
+#if UNICODE
+    {
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        if (odbc_helper->NeedsConversion() && ValuePtr
+            && OdbcHelper::IsStringDescField(FieldIdentifier)
+            && (BufferLength == SQL_NTS || BufferLength > 0)) {
+            auto value_converted = odbc_helper->ConvertInput(static_cast<SQLTCHAR*>(ValuePtr), BufferLength);
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLSetDescField, RDS_STR_SQLSetDescField,
+                desc->wrapped_desc, RecNumber, FieldIdentifier, value_converted.tchar_ptr, BufferLength
+            );
+            return RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
+        }
+    }
+#endif
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLSetDescField, RDS_STR_SQLSetDescField,
         desc->wrapped_desc, RecNumber, FieldIdentifier, ValuePtr, BufferLength
     );

--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -37,6 +37,7 @@
 #include "util/odbc_dsn_helper.h"
 #include "util/plugin_service.h"
 #include "util/rds_lib_loader.h"
+#include "util/rds_strings.h"
 
 #ifdef WIN32
     #include "gui/setup.h"
@@ -415,8 +416,13 @@ SQLRETURN RDS_FreeStmt(
                     ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
                 }
 
+                // Let underlying driver cleanup before we remove any of our data
                 if (Option == SQL_UNBIND) {
                     stmt->bound_col_buffers.clear();
+                }
+                if (Option == SQL_RESET_PARAMS) {
+                    stmt->put_data_char_conversion = false;
+                    stmt->bound_param_buffers.clear();
                 }
 
                 return ret;
@@ -2102,7 +2108,6 @@ SQLRETURN RDS_SQLPrepare(
 
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
-
     CHECK_WRAPPED_STMT(stmt);
 
     const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
@@ -2132,7 +2137,6 @@ SQLRETURN RDS_SQLPrimaryKeys(
 
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
-
     CHECK_WRAPPED_STMT(stmt);
 
     const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();

--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -399,6 +399,11 @@ SQLRETURN RDS_FreeStmt(
                     );
                     ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
                 }
+
+                if (Option == SQL_UNBIND) {
+                    stmt->bound_col_buffers.clear();
+                }
+
                 return ret;
             }
         case SQL_DROP:

--- a/driver/odbcapi_rds_helper.h
+++ b/driver/odbcapi_rds_helper.h
@@ -397,4 +397,10 @@ SQLRETURN RDS_SQLTables(
 
 SQLRETURN RDS_InitializeConnection(DBC* dbc, const std::string& conn_str);
 
+#if UNICODE
+// Forward declaration for RDS_GetOdbcHelper
+class OdbcHelper;
+std::shared_ptr<OdbcHelper> RDS_GetOdbcHelper(const DBC* dbc, const ENV* env);
+#endif
+
 #endif // ODBCAPI_RDS_HELPER_H_

--- a/driver/util/odbc_helper.cpp
+++ b/driver/util/odbc_helper.cpp
@@ -172,3 +172,126 @@ std::string OdbcHelper::GetSqlStateAndLogMessage(DBC* dbc) {
     LOG(WARNING) << "SQL State: " << AS_UTF8_CSTR(sql_state) << ". Message: " << AS_UTF8_CSTR(message);
     return AS_UTF8_CSTR(sql_state);
 }
+
+// Convert base driver output to either 2-byte or 4-byte output for the client application
+void OdbcHelper::ConvertDriverOutputToTarget(
+    const SQLTCHAR* src,
+    SQLTCHAR* dst,
+    const size_t dst_byte_count) const
+{
+    ConvertDriverOutputToTarget(false, src, dst, dst_byte_count);
+}
+
+// codechecker_suppress [readability-convert-member-functions-to-static]
+void OdbcHelper::ConvertDriverOutputToTarget(
+    const bool wrapper_call,
+    const SQLTCHAR* src,
+    SQLTCHAR* dst,
+    const size_t dst_byte_count) const
+{
+#if UNICODE
+    const size_t dst_char_count = dst_byte_count / sizeof(SQLTCHAR);
+    const bool user_4_byte = !wrapper_call && use_4_bytes_user_app_;
+
+    if (user_4_byte && use_4_bytes_base_driver_) {
+        // Both the client application and the base driver use 4-byte data.
+        // Copy the data as-is.
+        std::memcpy(dst, src, dst_byte_count);
+    } else if (user_4_byte) {
+        // Expand the driver output from 2-byte to 4-byte for the client application.
+        ConvertUTF16ToUTF32(src, dst, dst_char_count > 0 ? dst_char_count - 1 : 0, dst_char_count);
+    } else {
+        // Narrow driver output from 4-byte to 2-byte for the client application.
+        // Or copy as-is if both are 2-byte.
+        Convert4To2ByteString(use_4_bytes_base_driver_, const_cast<SQLTCHAR*>(src), dst, dst_char_count);
+    }
+#else
+    std::memcpy(dst, src, dst_byte_count);
+#endif
+}
+
+// Convert wrapper output to either 2-byte or 4-byte output for the client application
+void OdbcHelper::ConvertWrapperOutputToTarget(
+    SQLTCHAR* buf,
+    const size_t char_count,
+    const size_t buf_byte_count) const
+{
+    ConvertWrapperOutputToTarget(false, buf, char_count, buf_byte_count);
+}
+
+void OdbcHelper::ConvertWrapperOutputToTarget(
+    const bool wrapper_call,
+    SQLTCHAR* buf,
+    const size_t char_count,
+    const size_t buf_byte_count) const
+{
+#if UNICODE
+    // Wrapper output is already in 2-bytes. Only need to expand if client application requires 4-bytes.
+    if (!wrapper_call && use_4_bytes_user_app_) {
+        const size_t buf_char_count = buf_byte_count / sizeof(SQLTCHAR);
+        ExpandUTF16ToUTF32InPlace(buf, char_count, buf_char_count);
+    }
+#endif
+}
+
+// codechecker_suppress [readability-convert-member-functions-to-static]
+bool OdbcHelper::NeedsConversion() const {
+#if UNICODE
+    return use_4_bytes_user_app_ != use_4_bytes_base_driver_;
+#else
+    return false;
+#endif
+}
+
+std::vector<SQLTCHAR> OdbcHelper::AllocateConversionBuffer(const size_t byte_count) const {
+    const size_t char_count = byte_count / sizeof(SQLTCHAR);
+    const size_t local_buf_size = use_4_bytes_base_driver_
+        ? char_count * 2
+        : char_count;
+    return std::vector<SQLTCHAR>(local_buf_size, 0);
+}
+
+bool OdbcHelper::IsStringConnectAttr(const SQLINTEGER attribute) {
+    switch (attribute) {
+        case SQL_ATTR_CURRENT_CATALOG:
+        case SQL_ATTR_TRACEFILE:
+        case SQL_ATTR_TRANSLATE_LIB:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool OdbcHelper::IsStringDescField(const SQLSMALLINT field_identifier) {
+    switch (field_identifier) {
+        case SQL_DESC_BASE_COLUMN_NAME:
+        case SQL_DESC_BASE_TABLE_NAME:
+        case SQL_DESC_CATALOG_NAME:
+        case SQL_DESC_LABEL:
+        case SQL_DESC_LITERAL_PREFIX:
+        case SQL_DESC_LITERAL_SUFFIX:
+        case SQL_DESC_LOCAL_TYPE_NAME:
+        case SQL_DESC_NAME:
+        case SQL_DESC_SCHEMA_NAME:
+        case SQL_DESC_TABLE_NAME:
+        case SQL_DESC_TYPE_NAME:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool OdbcHelper::IsStringDiagField(const SQLSMALLINT diag_identifier) {
+    switch (diag_identifier) {
+        case SQL_DIAG_CLASS_ORIGIN:
+        case SQL_DIAG_CONNECTION_NAME:
+        case SQL_DIAG_DYNAMIC_FUNCTION:
+        case SQL_DIAG_MESSAGE_TEXT:
+        case SQL_DIAG_SERVER_NAME:
+        case SQL_DIAG_SQLSTATE:
+        case SQL_DIAG_SUBCLASS_ORIGIN:
+            return true;
+        default:
+            return false;
+    }
+}

--- a/driver/util/odbc_helper.h
+++ b/driver/util/odbc_helper.h
@@ -65,6 +65,23 @@ public:
 
     virtual std::string GetSqlStateAndLogMessage(DBC *dbc);
 
+    void ConvertDriverOutputToTarget(const SQLTCHAR* src, SQLTCHAR* dst, size_t dst_byte_count) const;
+    void ConvertDriverOutputToTarget(bool wrapper_call, const SQLTCHAR* src, SQLTCHAR* dst, size_t dst_byte_count) const;
+
+    void ConvertWrapperOutputToTarget(SQLTCHAR* buf, size_t char_count, size_t buf_byte_count) const;
+    void ConvertWrapperOutputToTarget(bool wrapper_call, SQLTCHAR* buf, size_t char_count, size_t buf_byte_count) const;
+
+    // Returns true if driver and user app character widths differ and conversion is needed.
+    bool NeedsConversion() const;
+
+    // Returns an appropriately sized intermediate buffer for driver output conversion.
+    // Caller should check NeedsConversion() first.
+    std::vector<SQLTCHAR> AllocateConversionBuffer(size_t byte_count) const;
+
+    static bool IsStringConnectAttr(SQLINTEGER attribute);
+    static bool IsStringDescField(SQLSMALLINT field_identifier);
+    static bool IsStringDiagField(SQLSMALLINT diag_identifier);
+
 private:
     std::shared_ptr<RdsLibLoader> lib_loader_;
     bool use_4_bytes_base_driver_ = false;

--- a/driver/util/rds_strings.h
+++ b/driver/util/rds_strings.h
@@ -67,10 +67,20 @@ inline size_t GetLenOfSqltcharArray(SQLTCHAR *in, SQLLEN buffer_len, bool use_4_
 
 #ifdef UNICODE
 #include "unicode/unistr.h"
-inline size_t UShortStrlen(const uint16_t* str) {
+inline size_t UShortStrlen(const uint16_t* str, const bool use_4_byte = false) {
     size_t length = 0;
-    while (str[length] != 0) {
-        length++;
+    if (!str) {
+        return length;
+    }
+
+    if (use_4_byte) {
+        while (str[length * 2] != 0 || str[length * 2 + 1] != 0) {
+            length++;
+        }
+    } else {
+        while (str[length] != 0) {
+            length++;
+        }
     }
     return length;
 }

--- a/driver/util/rds_strings.h
+++ b/driver/util/rds_strings.h
@@ -141,6 +141,23 @@ inline size_t ConvertUTF16ToUTF32(const SQLTCHAR* src, SQLTCHAR* dst, const size
     return written;
 }
 
+inline void ExpandUTF16ToUTF32InPlace(SQLTCHAR* buf, size_t src_chars, size_t buf_slots) {
+    if (buf == nullptr || src_chars == 0) {
+        return;
+    }
+
+    const size_t max_chars = (buf_slots >= 2) ? (buf_slots - 2) / 2 : 0;
+    const size_t chars = src_chars < max_chars ? src_chars : max_chars;
+
+    // Work backwards to avoid overwriting source data
+    for (size_t i = chars; i > 0; --i) {
+        buf[((i - 1) * 2) + 1] = 0;
+        buf[(i - 1) * 2] = buf[i - 1];
+    }
+    buf[chars * 2] = 0;
+    buf[(chars * 2) + 1] = 0;
+}
+
 inline std::string Convert4ByteSqlWChar(
     SQLTCHAR *     InputStr,
     SQLINTEGER     BufferLength


### PR DESCRIPTION
### Summary

Support UTF32 SQLBind / Fetch

### Description

Creates an intermediate buffer to hold SQLTCHAR types to support both 2-byte and 4-byte user applications and underlying drivers.

### Testing
Manual testing using sample application on Mac Unicode using:

MySQL - `SELECT @@aurora_server_id;`
Postgres - `SELECT pg_catalog.aurora_db_instance_identifier()`

Each set below ran `SQLFetch`, `SQLExtendedFetch` and `SQLFetchScroll`

|                    |                            | **Underlying Driver**      |                                        |
|--------------------|----------------------------|----------------------------|----------------------------------------|
|                    |                            | psqlodbc (2-byte SQLWCHAR) | mysql-odbc-connector (4-byte SQLWCHAR) |
| **Driver Manager** | UnixODBC (2-Byte SQLWCHAR) | ✅                          | ✅                                      |
|                    | iodbc (4-Byte SQLWCHAR)    | ✅                          | ✅                                      |


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
