### PR TITLE
fix: sqlwchar encoding

### DIFF
--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -975,10 +975,15 @@ SQLRETURN RDS_SQLExecDirect(
 
     SQLTCHAR* stmt_text = StatementText;
 #if UNICODE
-    const size_t buffer_len = GetLenOfSqltcharArray(StatementText, TextLength, dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp());
-    std::vector<SQLTCHAR> stmt_buf_vector(buffer_len, '\0');
-    stmt_text = stmt_buf_vector.data();
-    Convert4To2ByteString(dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp(), StatementText, stmt_text, buffer_len);
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+    std::vector<uint16_t> stmt_utf16;
+    if (StatementText) {
+        const std::string utf8 = ConvertUserAppToUTF8(
+            odbc_helper->GetUse4BytesUserApp(), StatementText, TextLength);
+        // Plugin chain expects UTF16 
+        stmt_utf16 = ConvertUTF8ToUTF16(utf8);
+        stmt_text = reinterpret_cast<SQLTCHAR*>(stmt_utf16.data());
+    }
 #endif
 
     if (dbc->plugin_head) {

--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -595,8 +595,23 @@ SQLRETURN RDS_SQLColumnPrivileges(
     CLEAR_STMT_ERROR(stmt);
 
     CHECK_WRAPPED_STMT(stmt);
+
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+    auto catalog_converted = odbc_helper->ConvertInput(CatalogName, NameLength1);
+    auto schema_converted  = odbc_helper->ConvertInput(SchemaName,  NameLength2);
+    auto table_converted   = odbc_helper->ConvertInput(TableName,   NameLength3);
+    auto column_converted  = odbc_helper->ConvertInput(ColumnName,  NameLength4);
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLColumnPrivileges, RDS_STR_SQLColumnPrivileges,
-        stmt->wrapped_stmt, CatalogName, NameLength1, SchemaName, NameLength2, TableName, NameLength3, ColumnName, NameLength4
+        stmt->wrapped_stmt,
+            catalog_converted.tchar_ptr,
+            NameLength1,
+            schema_converted.tchar_ptr,
+            NameLength2,
+            table_converted.tchar_ptr,
+            NameLength3,
+            column_converted.tchar_ptr,
+            NameLength4
     );
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }
@@ -673,7 +688,9 @@ SQLRETURN RDS_SQLConnect(
     if (ServerName) {
         // Load input DSN followed by Base DSN retrieved from input DSN
 #ifdef UNICODE
-        conn_str_utf8 = ConvertUTF16ToUTF8(reinterpret_cast<uint16_t*>(ServerName));
+        conn_str_utf8 = ConvertUserAppToUTF8(
+            dbc->plugin_service ? dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp() : false,
+            ServerName, NameLength1);
 #else
         conn_str_utf8 = reinterpret_cast<const char *>(ServerName);
 #endif
@@ -689,7 +706,9 @@ SQLRETURN RDS_SQLConnect(
     // Replace with input parameters
     if (UserName) {
 #ifdef UNICODE
-        conn_str_utf8 = ConvertUTF16ToUTF8(reinterpret_cast<uint16_t*>(UserName));
+        conn_str_utf8 = ConvertUserAppToUTF8(
+            dbc->plugin_service ? dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp() : false,
+            UserName, NameLength2);
 #else
         conn_str_utf8 = reinterpret_cast<const char *>(UserName);
 #endif
@@ -698,7 +717,9 @@ SQLRETURN RDS_SQLConnect(
     }
     if (Authentication) {
 #ifdef UNICODE
-        conn_str_utf8 = ConvertUTF16ToUTF8(reinterpret_cast<uint16_t*>(Authentication));
+        conn_str_utf8 = ConvertUserAppToUTF8(
+            dbc->plugin_service ? dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp() : false,
+            Authentication, NameLength3);
 #else
         conn_str_utf8 = reinterpret_cast<const char *>(Authentication);
 #endif
@@ -994,8 +1015,28 @@ SQLRETURN RDS_SQLForeignKeys(
 
     CHECK_WRAPPED_STMT(stmt);
 
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+    auto pk_catalog_converted = odbc_helper->ConvertInput(PKCatalogName, NameLength1);
+    auto pk_schema_converted  = odbc_helper->ConvertInput(PKSchemaName,  NameLength2);
+    auto pk_table_converted   = odbc_helper->ConvertInput(PKTableName,   NameLength3);
+    auto fk_catalog_converted = odbc_helper->ConvertInput(FKCatalogName, NameLength4);
+    auto fk_schema_converted  = odbc_helper->ConvertInput(FKSchemaName,  NameLength5);
+    auto fk_table_converted   = odbc_helper->ConvertInput(FKTableName,   NameLength6);
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLForeignKeys, RDS_STR_SQLForeignKeys,
-        stmt->wrapped_stmt, PKCatalogName, NameLength1, PKSchemaName, NameLength2, PKTableName, NameLength3, FKCatalogName, NameLength4, FKSchemaName, NameLength5, FKTableName, NameLength6
+        stmt->wrapped_stmt,
+            pk_catalog_converted.tchar_ptr,
+            NameLength1,
+            pk_schema_converted.tchar_ptr,
+            NameLength2,
+            pk_table_converted.tchar_ptr,
+            NameLength3,
+            fk_catalog_converted.tchar_ptr,
+            NameLength4,
+            fk_schema_converted.tchar_ptr,
+            NameLength5,
+            fk_table_converted.tchar_ptr,
+            NameLength6
     );
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }
@@ -1757,8 +1798,17 @@ SQLRETURN RDS_SQLNativeSql(
     CLEAR_DBC_ERROR(dbc);
 
     CHECK_WRAPPED_DBC(dbc);
+
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+    auto stmt_converted = odbc_helper->ConvertInput(InStatementText, TextLength1);
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLNativeSql, RDS_STR_SQLNativeSql,
-        dbc->wrapped_dbc, InStatementText, TextLength1, OutStatementText, BufferLength, TextLength2Ptr
+        dbc->wrapped_dbc,
+            stmt_converted.tchar_ptr,
+            TextLength1,
+            OutStatementText,
+            BufferLength,
+            TextLength2Ptr
     );
     return RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
 }
@@ -1777,8 +1827,14 @@ SQLRETURN RDS_SQLPrepare(
     CLEAR_STMT_ERROR(stmt);
 
     CHECK_WRAPPED_STMT(stmt);
+
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+    auto stmt_converted = odbc_helper->ConvertInput(StatementText, TextLength);
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLPrepare, RDS_STR_SQLPrepare,
-        stmt->wrapped_stmt, StatementText, TextLength
+        stmt->wrapped_stmt,
+            stmt_converted.tchar_ptr,
+            TextLength
     );
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }
@@ -1801,8 +1857,20 @@ SQLRETURN RDS_SQLPrimaryKeys(
     CLEAR_STMT_ERROR(stmt);
 
     CHECK_WRAPPED_STMT(stmt);
+
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+    auto catalog_converted = odbc_helper->ConvertInput(CatalogName, NameLength1);
+    auto schema_converted  = odbc_helper->ConvertInput(SchemaName,  NameLength2);
+    auto table_converted   = odbc_helper->ConvertInput(TableName,   NameLength3);
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLPrimaryKeys, RDS_STR_SQLPrimaryKeys,
-        stmt->wrapped_stmt, CatalogName, NameLength1, SchemaName, NameLength2, TableName, NameLength3
+        stmt->wrapped_stmt,
+            catalog_converted.tchar_ptr,
+            NameLength1,
+            schema_converted.tchar_ptr,
+            NameLength2,
+            table_converted.tchar_ptr,
+            NameLength3
     );
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }
@@ -1827,8 +1895,23 @@ SQLRETURN RDS_SQLProcedureColumns(
     CLEAR_STMT_ERROR(stmt);
 
     CHECK_WRAPPED_STMT(stmt);
+
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+    auto catalog_converted = odbc_helper->ConvertInput(CatalogName, NameLength1);
+    auto schema_converted  = odbc_helper->ConvertInput(SchemaName,  NameLength2);
+    auto proc_converted    = odbc_helper->ConvertInput(ProcName,    NameLength3);
+    auto column_converted  = odbc_helper->ConvertInput(ColumnName,  NameLength4);
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLProcedureColumns, RDS_STR_SQLProcedureColumns,
-        stmt->wrapped_stmt, CatalogName, NameLength1, SchemaName, NameLength2, ProcName, NameLength3, ColumnName, NameLength4
+        stmt->wrapped_stmt,
+            catalog_converted.tchar_ptr,
+            NameLength1,
+            schema_converted.tchar_ptr,
+            NameLength2,
+            proc_converted.tchar_ptr,
+            NameLength3,
+            column_converted.tchar_ptr,
+            NameLength4
     );
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }
@@ -1851,8 +1934,20 @@ SQLRETURN RDS_SQLProcedures(
     CLEAR_STMT_ERROR(stmt);
 
     CHECK_WRAPPED_STMT(stmt);
+
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+    auto catalog_converted = odbc_helper->ConvertInput(CatalogName, NameLength1);
+    auto schema_converted  = odbc_helper->ConvertInput(SchemaName,  NameLength2);
+    auto proc_converted    = odbc_helper->ConvertInput(ProcName,    NameLength3);
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLProcedures, RDS_STR_SQLProcedures,
-        stmt->wrapped_stmt, CatalogName, NameLength1, SchemaName, NameLength2, ProcName, NameLength3
+        stmt->wrapped_stmt,
+            catalog_converted.tchar_ptr,
+            NameLength1,
+            schema_converted.tchar_ptr,
+            NameLength2,
+            proc_converted.tchar_ptr,
+            NameLength3
     );
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }
@@ -1884,15 +1979,22 @@ SQLRETURN RDS_SQLSetCursorName(
     CLEAR_STMT_ERROR(stmt);
 
     if (stmt->wrapped_stmt) {
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        auto cursor_converted = odbc_helper->ConvertInput(CursorName, NameLength);
+
         const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLSetCursorName, RDS_STR_SQLSetCursorName,
-            stmt->wrapped_stmt, CursorName, NameLength
+            stmt->wrapped_stmt,
+                cursor_converted.tchar_ptr,
+                NameLength
         );
         ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
     }
 
     std::string conn_str_utf8;
 #ifdef UNICODE
-    conn_str_utf8 = ConvertUTF16ToUTF8(reinterpret_cast<uint16_t*>(CursorName));
+    conn_str_utf8 = ConvertUserAppToUTF8(
+        dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp(),
+        CursorName, NameLength);
 #else
     conn_str_utf8 = reinterpret_cast<const char *>(CursorName);
 #endif
@@ -1980,8 +2082,23 @@ SQLRETURN RDS_SQLSpecialColumns(
     CLEAR_STMT_ERROR(stmt);
 
     CHECK_WRAPPED_STMT(stmt);
+
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+    auto catalog_converted = odbc_helper->ConvertInput(CatalogName, NameLength1);
+    auto schema_converted  = odbc_helper->ConvertInput(SchemaName,  NameLength2);
+    auto table_converted   = odbc_helper->ConvertInput(TableName,   NameLength3);
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLSpecialColumns, RDS_STR_SQLSpecialColumns,
-        stmt->wrapped_stmt, IdentifierType, CatalogName, NameLength1, SchemaName, NameLength2, TableName, NameLength3, Scope, Nullable
+        stmt->wrapped_stmt,
+            IdentifierType,
+            catalog_converted.tchar_ptr,
+            NameLength1,
+            schema_converted.tchar_ptr,
+            NameLength2,
+            table_converted.tchar_ptr,
+            NameLength3,
+            Scope,
+            Nullable
     );
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }
@@ -2006,8 +2123,22 @@ SQLRETURN RDS_SQLStatistics(
     CLEAR_STMT_ERROR(stmt);
 
     CHECK_WRAPPED_STMT(stmt);
+
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+    auto catalog_converted = odbc_helper->ConvertInput(CatalogName, NameLength1);
+    auto schema_converted  = odbc_helper->ConvertInput(SchemaName,  NameLength2);
+    auto table_converted   = odbc_helper->ConvertInput(TableName,   NameLength3);
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLStatistics, RDS_STR_SQLStatistics,
-        stmt->wrapped_stmt, CatalogName, NameLength1, SchemaName, NameLength2, TableName, NameLength3, Unique, Reserved
+        stmt->wrapped_stmt,
+            catalog_converted.tchar_ptr,
+            NameLength1,
+            schema_converted.tchar_ptr,
+            NameLength2,
+            table_converted.tchar_ptr,
+            NameLength3,
+            Unique,
+            Reserved
     );
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }
@@ -2030,8 +2161,20 @@ SQLRETURN RDS_SQLTablePrivileges(
     CLEAR_STMT_ERROR(stmt);
 
     CHECK_WRAPPED_STMT(stmt);
+
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+    auto catalog_converted = odbc_helper->ConvertInput(CatalogName, NameLength1);
+    auto schema_converted  = odbc_helper->ConvertInput(SchemaName,  NameLength2);
+    auto table_converted   = odbc_helper->ConvertInput(TableName,   NameLength3);
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLTablePrivileges, RDS_STR_SQLTablePrivileges,
-        stmt->wrapped_stmt, CatalogName, NameLength1, SchemaName, NameLength2, TableName, NameLength3
+        stmt->wrapped_stmt,
+            catalog_converted.tchar_ptr,
+            NameLength1,
+            schema_converted.tchar_ptr,
+            NameLength2,
+            table_converted.tchar_ptr,
+            NameLength3
     );
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }
@@ -2056,8 +2199,23 @@ SQLRETURN RDS_SQLTables(
     CLEAR_STMT_ERROR(stmt);
 
     CHECK_WRAPPED_STMT(stmt);
+
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+    auto catalog_converted  = odbc_helper->ConvertInput(CatalogName, NameLength1);
+    auto schema_converted   = odbc_helper->ConvertInput(SchemaName,  NameLength2);
+    auto table_converted    = odbc_helper->ConvertInput(TableName,   NameLength3);
+    auto table_type_converted = odbc_helper->ConvertInput(TableType,  NameLength4);
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLTables, RDS_STR_SQLTables,
-        stmt->wrapped_stmt, CatalogName, NameLength1, SchemaName, NameLength2, TableName, NameLength3, TableType, NameLength4
+        stmt->wrapped_stmt,
+            catalog_converted.tchar_ptr,
+            NameLength1,
+            schema_converted.tchar_ptr,
+            NameLength2,
+            table_converted.tchar_ptr,
+            NameLength3,
+            table_type_converted.tchar_ptr,
+            NameLength4
     );
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }

--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -622,43 +622,24 @@ SQLRETURN RDS_SQLColumns(
 
     CHECK_WRAPPED_STMT(stmt);
 
-    SQLTCHAR* catalog_name_sqltchar;
-    SQLTCHAR* schema_name_sqltchar;
-    SQLTCHAR* table_name_sqltchar;
-    SQLTCHAR* column_name_sqltchar;
-
-#if UNICODE
-    const bool user_4_byte   = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
-    const bool driver_4_byte = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
-
-    std::vector<SQLTCHAR> catalog_name_vec = ConvertUserAppInputToBaseDriver(user_4_byte, driver_4_byte, CatalogName, NameLength1);
-    std::vector<SQLTCHAR> schema_name_vec = ConvertUserAppInputToBaseDriver(user_4_byte, driver_4_byte, SchemaName, NameLength2);
-    std::vector<SQLTCHAR> table_name_vec = ConvertUserAppInputToBaseDriver(user_4_byte, driver_4_byte, TableName, NameLength3);
-    std::vector<SQLTCHAR> column_name_vec = ConvertUserAppInputToBaseDriver(user_4_byte, driver_4_byte, ColumnName, NameLength4);
-
-    catalog_name_sqltchar = catalog_name_vec.data();
-    schema_name_sqltchar = schema_name_vec.data();
-    table_name_sqltchar = table_name_vec.data();
-    column_name_sqltchar = column_name_vec.data();
-#else
-    catalog_name_sqltchar = CatalogName;
-    schema_name_sqltchar = SchemaName;
-    table_name_sqltchar = TableName;
-    column_name_sqltchar = ColumnName;
-#endif
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+    auto catalog_converted = odbc_helper->ConvertInput(CatalogName, NameLength1);
+    auto schema_converted  = odbc_helper->ConvertInput(SchemaName,  NameLength2);
+    auto table_converted   = odbc_helper->ConvertInput(TableName,   NameLength3);
+    auto column_converted  = odbc_helper->ConvertInput(ColumnName,  NameLength4);
 
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(
         env->driver_lib_loader,
         RDS_FP_SQLColumns,
         RDS_STR_SQLColumns,
         stmt->wrapped_stmt,
-            catalog_name_sqltchar,
+            catalog_converted.tchar_ptr,
             NameLength1,
-            schema_name_sqltchar,
+            schema_converted.tchar_ptr,
             NameLength2,
-            table_name_sqltchar,
+            table_converted.tchar_ptr,
             NameLength3,
-            column_name_sqltchar,
+            column_converted.tchar_ptr,
             NameLength4
     );
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);

--- a/driver/util/odbc_helper.cpp
+++ b/driver/util/odbc_helper.cpp
@@ -143,7 +143,7 @@ void OdbcHelper::SetUse4BytesUserApp(const bool use_4_bytes) {
     this->use_4_bytes_user_app_ = use_4_bytes;
 }
 
-ConvertedSqltchar OdbcHelper::ConvertInput(SQLTCHAR* in, SQLSMALLINT in_length) const {
+ConvertedSqltchar OdbcHelper::ConvertInput(SQLTCHAR* in, SQLINTEGER in_length) const {
     ConvertedSqltchar result;
 #if UNICODE
     if (!in) {
@@ -151,7 +151,10 @@ ConvertedSqltchar OdbcHelper::ConvertInput(SQLTCHAR* in, SQLSMALLINT in_length) 
         return result;
     }
     result.data = ConvertUserAppInputToBaseDriver(
-        use_4_bytes_user_app_, use_4_bytes_base_driver_, in, in_length);
+        use_4_bytes_user_app_,
+        use_4_bytes_base_driver_,
+        in,
+        in_length);
     result.tchar_ptr = result.data.data();
 #else
     result.tchar_ptr = in;

--- a/driver/util/odbc_helper.cpp
+++ b/driver/util/odbc_helper.cpp
@@ -143,6 +143,7 @@ void OdbcHelper::SetUse4BytesUserApp(const bool use_4_bytes) {
     this->use_4_bytes_user_app_ = use_4_bytes;
 }
 
+// codechecker_suppress [readability-convert-member-functions-to-static]
 ConvertedSqltchar OdbcHelper::ConvertInput(SQLTCHAR* in, SQLINTEGER in_length) const {
     ConvertedSqltchar result;
 #if UNICODE

--- a/driver/util/odbc_helper.cpp
+++ b/driver/util/odbc_helper.cpp
@@ -143,6 +143,22 @@ void OdbcHelper::SetUse4BytesUserApp(const bool use_4_bytes) {
     this->use_4_bytes_user_app_ = use_4_bytes;
 }
 
+ConvertedSqltchar OdbcHelper::ConvertInput(SQLTCHAR* in, SQLSMALLINT in_length) const {
+    ConvertedSqltchar result;
+#if UNICODE
+    if (!in) {
+        // Return as-is if this is a nullptr, let the caller decide how to handle nullptr.
+        return result;
+    }
+    result.data = ConvertUserAppInputToBaseDriver(
+        use_4_bytes_user_app_, use_4_bytes_base_driver_, in, in_length);
+    result.tchar_ptr = result.data.data();
+#else
+    result.tchar_ptr = in;
+#endif
+    return result;
+}
+
 std::string OdbcHelper::GetSqlStateAndLogMessage(DBC* dbc) {
     SQLSMALLINT stmt_length;
     SQLINTEGER native_error;

--- a/driver/util/odbc_helper.h
+++ b/driver/util/odbc_helper.h
@@ -19,6 +19,16 @@
 #include "../odbcapi.h"
 #include "rds_lib_loader.h"
 
+#include <vector>
+
+// Holds a converted SQLTCHAR buffer and a pointer suitable for passing to the
+// base driver.  The vector keeps the data alive; `ptr` is nullptr when the
+// original input was nullptr (preserving ODBC nullptr semantics).
+struct ConvertedSqltchar {
+    std::vector<SQLTCHAR> data;
+    SQLTCHAR* tchar_ptr = nullptr;
+};
+
 class OdbcHelper {
 public:
     OdbcHelper(const std::shared_ptr<RdsLibLoader> &lib_loader);
@@ -46,6 +56,12 @@ public:
     bool GetUse4BytesUserApp() const;
     void SetUse4BytesBaseDriver(bool use_4_bytes);
     void SetUse4BytesUserApp(bool use_4_bytes);
+
+    // Converts a user-app SQLTCHAR* input to the encoding expected by the base
+    // driver, respecting the current user_4_byte / driver_4_byte flags.
+    // Returns a ConvertedSqltchar whose `ptr` is nullptr when `in` is nullptr.
+    // In non-Unicode builds the input pointer is passed through unchanged.
+    ConvertedSqltchar ConvertInput(SQLTCHAR* in, SQLSMALLINT in_length) const;
 
     virtual std::string GetSqlStateAndLogMessage(DBC *dbc);
 

--- a/driver/util/odbc_helper.h
+++ b/driver/util/odbc_helper.h
@@ -59,9 +59,9 @@ public:
 
     // Converts a user-app SQLTCHAR* input to the encoding expected by the base
     // driver, respecting the current user_4_byte / driver_4_byte flags.
-    // Returns a ConvertedSqltchar whose `ptr` is nullptr when `in` is nullptr.
+    // Returns a ConvertedSqltchar whose `tchar_ptr` is nullptr when `in` is nullptr.
     // In non-Unicode builds the input pointer is passed through unchanged.
-    ConvertedSqltchar ConvertInput(SQLTCHAR* in, SQLSMALLINT in_length) const;
+    ConvertedSqltchar ConvertInput(SQLTCHAR* in, SQLINTEGER in_length) const;
 
     virtual std::string GetSqlStateAndLogMessage(DBC *dbc);
 

--- a/driver/util/rds_strings.h
+++ b/driver/util/rds_strings.h
@@ -209,7 +209,7 @@ inline std::vector<SQLTCHAR> ConvertUserAppInputToBaseDriver(bool user_4_byte, b
 
         size_t size_converted = size * 2 + 2; // Each char expands to 2 SQLTCHAR + null pair
         SQLTCHAR* wide_converted_4byte = new SQLTCHAR[size_converted];
-        const size_t chars_written = ConvertUTF16ToUTF32(reinterpret_cast<const SQLTCHAR*>(utf16.data()), wide_converted_4byte, size, size_converted);
+        ConvertUTF16ToUTF32(reinterpret_cast<const SQLTCHAR*>(utf16.data()), wide_converted_4byte, size, size_converted);
         std::vector<SQLTCHAR> result(wide_converted_4byte, wide_converted_4byte + size_converted);
         delete[] wide_converted_4byte;
         return result;

--- a/driver/util/rds_strings.h
+++ b/driver/util/rds_strings.h
@@ -187,16 +187,47 @@ inline void ConvertUTF8ToDriver(bool driver_4_byte, std::string input, SQLTCHAR*
 }
 
 inline std::vector<SQLTCHAR> ConvertUserAppInputToBaseDriver(bool user_4_byte, bool driver_4_byte, SQLTCHAR* in, SQLSMALLINT in_length) {
+    LOG(INFO) << "[ConvertUserAppInputToBaseDriver] in_length=" << in_length
+              << " (sizeof(SQLTCHAR)=" << sizeof(SQLTCHAR) << ", "
+              << (sizeof(SQLTCHAR) == 4 ? "4-byte" : "2-byte") << " SQLTCHAR)";
+
+    // nullptr is valid ODBC inputå
+    if (in == nullptr) {
+        return std::vector<SQLTCHAR>();
+    }
+
     const std::string utf8 = ConvertUserAppToUTF8(user_4_byte, in, in_length);
     if (driver_4_byte) {
-        std::wstring wide = ConvertUTF8ToWString(utf8);
-        size_t size = in_length > wide.length()
-            ? wide.length()
-            : in_length - 1; // For null terminating character
-        size_t size_converted = size * 2 + 1;
-        SQLTCHAR* wide_converted_2byte = new SQLTCHAR[size_converted];
-        ConvertUTF16ToUTF32(wide.data(), wide_converted_2byte, in_length, size);
-        return std::vector<SQLTCHAR>(wide_converted_2byte, wide_converted_2byte + size_converted);
+        std::vector<uint16_t> utf16 = ConvertUTF8ToUTF16(utf8);
+        size_t utf16_len = utf16.size() > 0 ? utf16.size() - 1 : 0;
+å
+        size_t size;
+        if (in_length == SQL_NTS || in_length < 0) {
+            size = utf16_len;
+        } else {
+            size = static_cast<size_t>(in_length) < utf16_len
+                ? static_cast<size_t>(in_length)
+                : utf16_len;
+        }
+
+        size_t size_converted = size * 2 + 2; // Each char expands to 2 SQLTCHAR + null pair
+        SQLTCHAR* wide_converted_4byte = new SQLTCHAR[size_converted];
+        
+        LOG(INFO) << "[ConvertUserAppInputToBaseDriver] Before ConvertUTF16ToUTF32: utf16_len=" << utf16_len
+                  << ", size=" << size << ", size_converted=" << size_converted
+                  << ", utf16 bytes=" << utf16.size() * sizeof(uint16_t);
+        
+        const size_t chars_written = ConvertUTF16ToUTF32(reinterpret_cast<const SQLTCHAR*>(utf16.data()), wide_converted_4byte, size, size_converted);
+        
+        LOG(INFO) << "[ConvertUserAppInputToBaseDriver] After ConvertUTF16ToUTF32: chars_written=" << chars_written
+                  << ", output SQLTCHAR elements=" << size_converted
+                  << ", output bytes=" << size_converted * sizeof(SQLTCHAR)
+                  << " (data: " << chars_written << " chars * 2 SQLTCHAR = " << chars_written * 2
+                  << " + 2 null SQLTCHAR = " << chars_written * 2 + 2 << " total)";
+        
+        std::vector<SQLTCHAR> result(wide_converted_4byte, wide_converted_4byte + size_converted);
+        delete[] wide_converted_4byte;
+        return result;
     } else {
         std::vector<uint16_t> utf16 = ConvertUTF8ToUTF16(utf8);
         return std::vector<SQLTCHAR>(

--- a/driver/util/rds_strings.h
+++ b/driver/util/rds_strings.h
@@ -145,24 +145,21 @@ inline std::string Convert4ByteSqlWChar(
     SQLTCHAR *     InputStr,
     SQLINTEGER     BufferLength
     ) {
-    bool end_found = false;
-    int i = 0;
     std::vector<SQLTCHAR> conn_in_vector;
-    while (!end_found) {
-        if (BufferLength > 0 && i > BufferLength) {
+    int i = 0;
+    while (true) {
+        if (BufferLength > 0 && (i / 2) >= BufferLength) {
             break;
         }
-        if (InputStr[i] == '\0' && InputStr[i + 1] == '\0') {
-            end_found = true;
+        if (InputStr[i] == 0 && InputStr[i + 1] == 0) {
+            break;
         }
-        // TODO: is this missing a char??
         conn_in_vector.push_back(InputStr[i]);
         i += 2;
     }
+    conn_in_vector.push_back(0);
 
-    SQLTCHAR* conn_in_w = conn_in_vector.data();
-
-    const std::string str_utf8_w = ConvertUTF16ToUTF8(reinterpret_cast<uint16_t*>(conn_in_w));
+    const std::string str_utf8_w = ConvertUTF16ToUTF8(reinterpret_cast<uint16_t*>(conn_in_vector.data()));
     return str_utf8_w;
 }
 
@@ -175,12 +172,16 @@ inline std::string ConvertUserAppToUTF8(bool user_4_byte, SQLTCHAR* in, SQLINTEG
 }
 
 inline void ConvertUTF8ToDriver(bool driver_4_byte, std::string input, SQLTCHAR* out, SQLSMALLINT out_length) {
+    if (out_length <= 0) {
+        return;
+    }
     if (driver_4_byte) {
         std::wstring w_input = ConvertUTF8ToWString(input);
-        size_t copy_size = out_length > w_input.length()
+        size_t copy_size = static_cast<size_t>(out_length) > w_input.length()
             ? w_input.length()
-            : out_length - 1; // For null terminating character
+            : static_cast<size_t>(out_length) - 1; // For null terminating character
         std::copy(w_input.begin(), w_input.begin() + copy_size, out);
+        out[copy_size] = 0;
     } else {
         CopyUTF8ToUTF16Buffer(out, out_length, input);
     }

--- a/driver/util/rds_strings.h
+++ b/driver/util/rds_strings.h
@@ -143,7 +143,7 @@ inline size_t ConvertUTF16ToUTF32(const SQLTCHAR* src, SQLTCHAR* dst, const size
 
 inline std::string Convert4ByteSqlWChar(
     SQLTCHAR *     InputStr,
-    SQLSMALLINT    BufferLength
+    SQLINTEGER     BufferLength
     ) {
     bool end_found = false;
     int i = 0;
@@ -166,7 +166,7 @@ inline std::string Convert4ByteSqlWChar(
     return str_utf8_w;
 }
 
-inline std::string ConvertUserAppToUTF8(bool user_4_byte, SQLTCHAR* in, SQLSMALLINT in_length) {
+inline std::string ConvertUserAppToUTF8(bool user_4_byte, SQLTCHAR* in, SQLINTEGER in_length) {
     if (user_4_byte) {
         size_t length = GetLenOfSqltcharArray(in, in_length, user_4_byte);
         return Convert4ByteSqlWChar(in, length);
@@ -186,12 +186,12 @@ inline void ConvertUTF8ToDriver(bool driver_4_byte, std::string input, SQLTCHAR*
     }
 }
 
-inline std::vector<SQLTCHAR> ConvertUserAppInputToBaseDriver(bool user_4_byte, bool driver_4_byte, SQLTCHAR* in, SQLSMALLINT in_length) {
+inline std::vector<SQLTCHAR> ConvertUserAppInputToBaseDriver(bool user_4_byte, bool driver_4_byte, SQLTCHAR* in, SQLINTEGER in_length) {
     LOG(INFO) << "[ConvertUserAppInputToBaseDriver] in_length=" << in_length
               << " (sizeof(SQLTCHAR)=" << sizeof(SQLTCHAR) << ", "
               << (sizeof(SQLTCHAR) == 4 ? "4-byte" : "2-byte") << " SQLTCHAR)";
 
-    // nullptr is valid ODBC inputå
+    // nullptr is valid ODBC input
     if (in == nullptr) {
         return std::vector<SQLTCHAR>();
     }
@@ -200,7 +200,7 @@ inline std::vector<SQLTCHAR> ConvertUserAppInputToBaseDriver(bool user_4_byte, b
     if (driver_4_byte) {
         std::vector<uint16_t> utf16 = ConvertUTF8ToUTF16(utf8);
         size_t utf16_len = utf16.size() > 0 ? utf16.size() - 1 : 0;
-å
+
         size_t size;
         if (in_length == SQL_NTS || in_length < 0) {
             size = utf16_len;

--- a/driver/util/rds_strings.h
+++ b/driver/util/rds_strings.h
@@ -188,10 +188,6 @@ inline void ConvertUTF8ToDriver(bool driver_4_byte, std::string input, SQLTCHAR*
 }
 
 inline std::vector<SQLTCHAR> ConvertUserAppInputToBaseDriver(bool user_4_byte, bool driver_4_byte, SQLTCHAR* in, SQLINTEGER in_length) {
-    LOG(INFO) << "[ConvertUserAppInputToBaseDriver] in_length=" << in_length
-              << " (sizeof(SQLTCHAR)=" << sizeof(SQLTCHAR) << ", "
-              << (sizeof(SQLTCHAR) == 4 ? "4-byte" : "2-byte") << " SQLTCHAR)";
-
     // nullptr is valid ODBC input
     if (in == nullptr) {
         return std::vector<SQLTCHAR>();
@@ -213,19 +209,7 @@ inline std::vector<SQLTCHAR> ConvertUserAppInputToBaseDriver(bool user_4_byte, b
 
         size_t size_converted = size * 2 + 2; // Each char expands to 2 SQLTCHAR + null pair
         SQLTCHAR* wide_converted_4byte = new SQLTCHAR[size_converted];
-        
-        LOG(INFO) << "[ConvertUserAppInputToBaseDriver] Before ConvertUTF16ToUTF32: utf16_len=" << utf16_len
-                  << ", size=" << size << ", size_converted=" << size_converted
-                  << ", utf16 bytes=" << utf16.size() * sizeof(uint16_t);
-        
         const size_t chars_written = ConvertUTF16ToUTF32(reinterpret_cast<const SQLTCHAR*>(utf16.data()), wide_converted_4byte, size, size_converted);
-        
-        LOG(INFO) << "[ConvertUserAppInputToBaseDriver] After ConvertUTF16ToUTF32: chars_written=" << chars_written
-                  << ", output SQLTCHAR elements=" << size_converted
-                  << ", output bytes=" << size_converted * sizeof(SQLTCHAR)
-                  << " (data: " << chars_written << " chars * 2 SQLTCHAR = " << chars_written * 2
-                  << " + 2 null SQLTCHAR = " << chars_written * 2 + 2 << " total)";
-        
         std::vector<SQLTCHAR> result(wide_converted_4byte, wide_converted_4byte + size_converted);
         delete[] wide_converted_4byte;
         return result;


### PR DESCRIPTION
### Description


### Testing

Manually tested the following method calls in Mac:

1. SQLColumns
2. SQLTables
3. SQLColumnPrivileges
4. SQLPrimaryKeys
5. SQLForeignKeys
6. SQLStatistics
7. SQLSpecialColumns
8. SQLTablePrivileges
9. SQLProcedures
10. SQLProcedureColumns
11. SQLPrepare
12. SQLSetCursorName
13. SQLNativeSql

Tests in the following environments:

|            | iODBC | unixODBC |
|------------|-------|----------|
| **MySQL**      | ✅     | ✅        |
| **PostgreSQL** | ✅     | ✅        |


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
