### PR TITLE
support SQLBindParameter / ParamData / PutData

### DIFF
--- a/driver/driver.h
+++ b/driver/driver.h
@@ -136,7 +136,9 @@ struct BoundColBuffer {
     SQLLEN                  app_buf_len;        // User's BufferLength
     SQLLEN*                 app_str_len_ptr;    // User's StrLen_or_IndPtr
     std::vector<SQLTCHAR>   local_buf;          // Wrapper buffer passed to underlying driver
-    SQLLEN                  local_str_len;      // Wrapper StrLen_or_Ind
+    // Wrapper StrLen_or_Ind, heap-safe w/ shared_ptr
+    std::shared_ptr<SQLLEN> local_str_len = std::make_shared<SQLLEN>(0);
+
 };
 
 // Tracks SQLBindParameter WCHAR binding for 2-byte/4-byte conversion.
@@ -151,7 +153,8 @@ struct BoundParamBuffer {
     SQLLEN                  app_buf_len;        // User's BufferLength
     SQLLEN*                 app_str_len_ptr;    // User's StrLen_or_IndPtr
     std::vector<SQLTCHAR>   local_buf;          // Wrapper buffer passed to underlying driver
-    SQLLEN                  local_str_len;      // Wrapper StrLen_or_Ind
+    // Wrapper StrLen_or_Ind, heap-safe w/ shared_ptr
+    std::shared_ptr<SQLLEN> local_str_len = std::make_shared<SQLLEN>(0);
 };
 
 struct STMT {

--- a/driver/driver.h
+++ b/driver/driver.h
@@ -139,6 +139,21 @@ struct BoundColBuffer {
     SQLLEN                  local_str_len;      // Wrapper StrLen_or_Ind
 };
 
+// Tracks SQLBindParameter WCHAR binding for 2-byte/4-byte conversion.
+struct BoundParamBuffer {
+    SQLUSMALLINT            param_number;
+    SQLSMALLINT             input_output_type;  // SQL_PARAM_INPUT, SQL_PARAM_OUTPUT, SQL_PARAM_INPUT_OUTPUT
+    SQLSMALLINT             value_type;
+    SQLSMALLINT             param_type;
+    SQLULEN                 column_size;
+    SQLSMALLINT             decimal_digits;
+    SQLPOINTER              app_ptr;            // User's ParameterValuePtr
+    SQLLEN                  app_buf_len;        // User's BufferLength
+    SQLLEN*                 app_str_len_ptr;    // User's StrLen_or_IndPtr
+    std::vector<SQLTCHAR>   local_buf;          // Wrapper buffer passed to underlying driver
+    SQLLEN                  local_str_len;      // Wrapper StrLen_or_Ind
+};
+
 struct STMT {
     // TODO - Do we need lock?
     std::recursive_mutex lock;
@@ -154,7 +169,10 @@ struct STMT {
     std::map<SQLINTEGER, std::pair<SQLPOINTER, SQLINTEGER>> attr_map;  // Key, <Value, Length>
     std::string cursor_name;
 
-    std::vector<BoundColBuffer> bound_col_buffers; // Intercepted WCHAR column bindings
+    // Buffers for UTF32 support
+    std::vector<BoundColBuffer> bound_col_buffers;      // Intercepted WCHAR column bindings
+    std::vector<BoundParamBuffer> bound_param_buffers;  // Intercepted WCHAR param bindings
+    bool put_data_char_conversion = false;
 
     ERR_INFO* err = nullptr;
     char sql_error_called = 0;

--- a/driver/odbcapi_common.cpp
+++ b/driver/odbcapi_common.cpp
@@ -18,6 +18,168 @@
 #include "util/plugin_service.h"
 #include "util/rds_lib_loader.h"
 
+// Unicode buffer helpers
+#if UNICODE && !defined(_WIN32)
+static void ConvertBoundColBuffersAfterFetch(STMT* stmt) {
+    std::vector<BoundColBuffer>& buffers = stmt->bound_col_buffers;
+    if (buffers.empty()) {
+        return;
+    }
+
+    const bool use_4_base = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+    const bool use_4_app = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+
+    for (BoundColBuffer& buffer : buffers) {
+        if (buffer.local_str_len == SQL_NULL_DATA || buffer.local_str_len < 0) {
+            if (buffer.app_str_len_ptr) {
+                *buffer.app_str_len_ptr = buffer.local_str_len;
+            }
+            continue;
+        }
+
+        SQLTCHAR* local = buffer.local_buf.data();
+
+        // If base driver is 4-byte, convert UTF-32 to UTF-16 in place
+        if (use_4_base) {
+            Convert4To2ByteString(true, local, nullptr, static_cast<size_t>(buffer.local_str_len));
+        }
+
+        // Copy to user's buffer in the expected encoding
+        const size_t src_len = UShortStrlen(reinterpret_cast<const uint16_t *>(local));
+        const size_t dst_len = buffer.app_buf_len;
+        if (use_4_app) {
+            ConvertUTF16ToUTF32(local, static_cast<SQLTCHAR*>(buffer.app_ptr), src_len, dst_len);
+        } else {
+            const size_t copy_chars = src_len < dst_len ? src_len : dst_len;
+            SQLTCHAR* dst = reinterpret_cast<SQLTCHAR*>(buffer.app_ptr);
+            std::memcpy(dst, local, copy_chars * sizeof(SQLTCHAR));
+            dst[copy_chars] = '\0';
+        }
+    }
+}
+
+static void ConvertBoundParamBuffersBeforeExecute(STMT* stmt) {
+    const DBC* dbc = stmt->dbc;
+    const ENV* env = dbc->env;
+
+    std::vector<BoundParamBuffer>& bindings = stmt->bound_param_buffers;
+    if (bindings.empty()) {
+        return;
+    }
+
+    const bool use_4_base = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+    const bool use_4_app = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+
+    for (BoundParamBuffer& buffer : bindings) {
+        if (buffer.input_output_type == SQL_PARAM_OUTPUT) {
+            continue;
+        }
+
+        const SQLLEN app_ind = buffer.app_str_len_ptr ? *buffer.app_str_len_ptr : 0;
+        if (app_ind == SQL_NULL_DATA) {
+            buffer.local_str_len = SQL_NULL_DATA;
+            continue;
+        }
+        // Skip as data will be put by SQLPutData
+        if (app_ind == SQL_DATA_AT_EXEC
+            || app_ind <= SQL_LEN_DATA_AT_EXEC(0)) {
+            continue;
+        }
+
+        SQLTCHAR* app_data = static_cast<SQLTCHAR*>(buffer.app_ptr);
+
+        // Get explicit user length or get length of app_data
+        size_t char_count;
+        if (app_ind == SQL_NTS || app_ind < 0) {
+            char_count = UShortStrlen(reinterpret_cast<const uint16_t*>(app_data), use_4_app);
+        } else {
+            char_count = static_cast<size_t>(app_ind);
+            // app_ind is byte count, divide by app's SQLWCHAR size
+            char_count = use_4_app
+                ? char_count / 4
+                : char_count / 2;
+        }
+
+        // Resize local buffer to runtime length of app_data
+        const size_t app_data_size = 1 + char_count;
+        const size_t local_buf_resize = use_4_base
+            ? app_data_size * 2
+            : app_data_size;
+        if (local_buf_resize > buffer.local_buf.size()) {
+            buffer.local_buf.resize(local_buf_resize, 0);
+        }
+
+        if (use_4_app) {
+            // User app UTF32 -> local buffer UTF16
+            Convert4To2ByteString(true, app_data, buffer.local_buf.data(), app_data_size);
+        } else {
+            // Copy as-is
+            const size_t src_len = char_count;
+            const size_t max_copy = static_cast<size_t>(buffer.local_buf.size());
+            const size_t copy_len = src_len < max_copy ? src_len : max_copy;
+            std::memcpy(buffer.local_buf.data(), app_data, copy_len * sizeof(SQLTCHAR));
+            buffer.local_buf[copy_len] = 0;
+        }
+
+        if (use_4_base) {
+            // Expand to UTF32 if needed
+            ExpandUTF16ToUTF32InPlace(buffer.local_buf.data(), app_data_size, buffer.local_buf.size());
+        }
+
+        buffer.local_str_len = SQL_NTS;
+
+        // Rebind parameter
+        const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(
+            env->driver_lib_loader, RDS_FP_SQLBindParameter, RDS_STR_SQLBindParameter, stmt->wrapped_stmt,
+            buffer.param_number, buffer.input_output_type, buffer.value_type, buffer.param_type, buffer.column_size,
+            buffer.decimal_digits, buffer.local_buf.data(), buffer.app_buf_len, &buffer.local_str_len
+        );
+    }
+}
+
+static void ConvertBoundParamBuffersAfterExecute(STMT* stmt) {
+    std::vector<BoundParamBuffer>& bindings = stmt->bound_param_buffers;
+    if (bindings.empty()) {
+        return;
+    }
+
+    const bool use_4_base = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+    const bool use_4_app = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+
+    for (BoundParamBuffer& param : bindings) {
+        if (param.input_output_type == SQL_PARAM_INPUT) {
+            continue;
+        }
+
+        if (param.local_str_len == SQL_NULL_DATA || param.local_str_len < 0) {
+            if (param.app_str_len_ptr) {
+                *param.app_str_len_ptr = param.local_str_len;
+            }
+            continue;
+        }
+
+        SQLTCHAR* local = param.local_buf.data();
+
+        // If base driver is 4-byte, convert UTF-32 to UTF-16 in place
+        if (use_4_base) {
+            Convert4To2ByteString(true, local, nullptr, static_cast<size_t>(param.local_str_len));
+        }
+
+        // Copy to user's buffer in the expected encoding
+        const size_t src_len = UShortStrlen(reinterpret_cast<const uint16_t*>(local));
+        const size_t dst_len = static_cast<size_t>(param.app_buf_len);
+        if (use_4_app) {
+            ConvertUTF16ToUTF32(local, static_cast<SQLTCHAR*>(param.app_ptr), src_len, dst_len);
+        } else {
+            const size_t copy_chars = src_len < dst_len ? src_len : dst_len;
+            SQLTCHAR* dst = static_cast<SQLTCHAR*>(param.app_ptr);
+            std::memcpy(dst, local, copy_chars * sizeof(SQLTCHAR));
+            dst[copy_chars] = '\0';
+        }
+    }
+}
+#endif
+
 // Common ODBC Functions
 SQLRETURN SQL_API SQLAllocConnect(
     SQLHENV        EnvironmentHandle,
@@ -98,7 +260,6 @@ SQLRETURN SQL_API SQLBindCol(
                 std::remove_if(bindings.begin(), bindings.end(),
                     [ColumnNumber](const BoundColBuffer &b) { return b.column_number == ColumnNumber; }),
                 bindings.end());
-
         } else if ((use_4_base || use_4_app) && TargetType == SQL_C_TCHAR && BufferLength > 0) {
             bindings.erase(
                 std::remove_if(bindings.begin(), bindings.end(),
@@ -154,8 +315,77 @@ SQLRETURN SQL_API SQLBindParameter(
 
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
-
     CHECK_WRAPPED_STMT(stmt);
+
+    #if UNICODE && !defined(_WIN32)
+    {
+        const bool use_4_base = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+        const bool use_4_app = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+
+        std::vector<BoundParamBuffer>& bindings = stmt->bound_param_buffers;
+        if ((use_4_base || use_4_app) && ValueType == SQL_C_TCHAR) {
+            bindings.erase(
+                std::remove_if(bindings.begin(), bindings.end(),
+                    [ParameterNumber](const BoundParamBuffer& b) { return b.param_number == ParameterNumber; }),
+                bindings.end());
+
+            // Data to be handled at execute runtime
+            const bool is_data_at_exec = StrLen_or_IndPtr &&
+                (
+                    *StrLen_or_IndPtr == SQL_DATA_AT_EXEC
+                    || *StrLen_or_IndPtr <= SQL_LEN_DATA_AT_EXEC(0)
+                );
+
+            BoundParamBuffer new_buffer;
+            new_buffer.param_number = ParameterNumber;
+            new_buffer.input_output_type = InputOutputType;
+            new_buffer.value_type = ValueType;
+            new_buffer.param_type = ParameterType;
+            new_buffer.column_size = ColumnSize;
+            new_buffer.decimal_digits = DecimalDigits;
+            new_buffer.app_ptr = ParameterValuePtr;
+            new_buffer.app_buf_len = BufferLength;
+            new_buffer.app_str_len_ptr = StrLen_or_IndPtr;
+
+            if (ParameterValuePtr != nullptr && BufferLength > 0 && !is_data_at_exec) {
+                // Create a buffer if the input size was set
+                const size_t local_buf_size = use_4_base
+                    ? static_cast<size_t>(BufferLength + 1) * 2
+                    : static_cast<size_t>(BufferLength + 1);
+                new_buffer.local_buf.resize(local_buf_size, 0);
+                new_buffer.local_str_len = 0;
+            } else if (!is_data_at_exec) {
+                // Pass null data to underlying if user did not pass data at exec
+                const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(
+                    env->driver_lib_loader, RDS_FP_SQLBindParameter, RDS_STR_SQLBindParameter, stmt->wrapped_stmt,
+                    ParameterNumber, InputOutputType, ValueType, ParameterType, ColumnSize,
+                    DecimalDigits, ParameterValuePtr, BufferLength, StrLen_or_IndPtr
+                );
+                return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+            }
+
+            bindings.push_back(std::move(new_buffer));
+            BoundParamBuffer& ref = bindings.back(); // Get stored reference instead of local stack reference
+
+            // If data_at_exec, pass original pointer
+            // so the driver can return token location properly
+            SQLPOINTER bind_ptr = is_data_at_exec
+                ? ParameterValuePtr
+                : ref.local_buf.data();
+            SQLLEN* bind_itr = is_data_at_exec
+                ? StrLen_or_IndPtr
+                : &ref.local_str_len;
+
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(
+                env->driver_lib_loader, RDS_FP_SQLBindParameter, RDS_STR_SQLBindParameter, stmt->wrapped_stmt,
+                ParameterNumber, InputOutputType, ValueType, ParameterType, ColumnSize,
+                DecimalDigits, bind_ptr, BufferLength, bind_itr
+            );
+            return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+        }
+    }
+    #endif
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLBindParameter, RDS_STR_SQLBindParameter,
         stmt->wrapped_stmt, ParameterNumber, InputOutputType, ValueType, ParameterType, ColumnSize, DecimalDigits, ParameterValuePtr, BufferLength, StrLen_or_IndPtr
     );
@@ -431,54 +661,25 @@ SQLRETURN SQL_API SQLExecute(
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
 
+    SQLRETURN rc = SQL_ERROR;
     if (dbc->plugin_head) {
-        return dbc->plugin_head->Execute(StatementHandle);
+        #if UNICODE && !defined(_WIN32)
+            ConvertBoundParamBuffersBeforeExecute(stmt);
+        #endif
+        rc = dbc->plugin_head->Execute(StatementHandle);
+    } else {
+        LOG(ERROR) << "Cannot execute without an open connection";
+        stmt->err = new ERR_INFO("SQLExecute - Connection not open", ERR_CONNECTION_NOT_OPEN);
     }
-
-    LOG(ERROR) << "Cannot execute without an open connection";
-    stmt->err = new ERR_INFO("SQLExecute - Connection not open", ERR_CONNECTION_NOT_OPEN);
-    return SQL_ERROR;
-}
 
 #if UNICODE && !defined(_WIN32)
-static void ConvertBoundColBuffersAfterFetch(STMT* stmt) {
-    std::vector<BoundColBuffer>& buffers = stmt->bound_col_buffers;
-    if (buffers.empty()) {
-        return;
+    if (SQL_SUCCEEDED(rc)) {
+        ConvertBoundParamBuffersAfterExecute(stmt);
     }
-
-    const bool use_4_base = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
-    const bool use_4_app = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
-
-    for (BoundColBuffer& buffer : buffers) {
-        if (buffer.local_str_len == SQL_NULL_DATA || buffer.local_str_len < 0) {
-            if (buffer.app_str_len_ptr) {
-                *buffer.app_str_len_ptr = buffer.local_str_len;
-            }
-            continue;
-        }
-
-        SQLTCHAR* local = buffer.local_buf.data();
-
-        // If base driver is 4-byte, convert UTF-32 to UTF-16 in place
-        if (use_4_base) {
-            Convert4To2ByteString(true, local, nullptr, static_cast<size_t>(buffer.local_str_len));
-        }
-
-        // Copy to user's buffer in the expected encoding
-        const size_t src_len = UShortStrlen(reinterpret_cast<const uint16_t *>(local));
-        const size_t dst_len = buffer.app_buf_len;
-        if (use_4_app) {
-            ConvertUTF16ToUTF32(local, static_cast<SQLTCHAR*>(buffer.app_ptr), src_len, dst_len);
-        } else {
-            const size_t copy_chars = src_len < dst_len ? src_len : dst_len;
-            SQLTCHAR* dst = reinterpret_cast<SQLTCHAR*>(buffer.app_ptr);
-            std::memcpy(dst, local, copy_chars * sizeof(SQLTCHAR));
-            dst[copy_chars] = '\0';
-        }
-    }
-}
 #endif
+
+    return rc;
+}
 
 SQLRETURN SQL_API SQLExtendedFetch(
     SQLHSTMT       StatementHandle,
@@ -817,11 +1018,30 @@ SQLRETURN SQL_API SQLParamData(
 
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
-
     CHECK_WRAPPED_STMT(stmt);
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLParamData, RDS_STR_SQLParamData,
         stmt->wrapped_stmt, ValuePtrPtr
     );
+
+#if UNICODE && !defined(_WIN32)
+    stmt->put_data_char_conversion = false;
+    if (res.fn_result == SQL_NEED_DATA && ValuePtrPtr && *ValuePtrPtr) {
+        const bool use_4_base = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+        const bool use_4_app = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+
+        if (use_4_base || use_4_app) {
+            // Check if this parameter was bound as SQL_C_TCHAR
+            for (const auto& p : stmt->bound_param_buffers) {
+                if (p.app_ptr == *ValuePtrPtr && p.value_type == SQL_C_TCHAR) {
+                    stmt->put_data_char_conversion = true;
+                    break;
+                }
+            }
+        }
+    }
+#endif
+
     return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 }
 
@@ -858,8 +1078,37 @@ SQLRETURN SQL_API SQLPutData(
 
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
-
     CHECK_WRAPPED_STMT(stmt);
+
+#if UNICODE && !defined(_WIN32)
+    if (stmt->put_data_char_conversion && DataPtr != nullptr && StrLen_or_Ind != SQL_NULL_DATA && StrLen_or_Ind != 0) {
+        const bool use_4_base = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+        const bool use_4_app = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+
+        const SQLTCHAR* app_data = static_cast<const SQLTCHAR*>(DataPtr);
+
+        const size_t src_len = GetLenOfSqltcharArray(const_cast<SQLTCHAR*>(app_data), StrLen_or_Ind, use_4_app);
+        const size_t local_buf_size = use_4_base ? (src_len + 1) * 2 : src_len + 1;
+        std::vector<SQLTCHAR> local_buf(local_buf_size, 0);
+
+        if (use_4_app) {
+            Convert4To2ByteString(true, const_cast<SQLTCHAR*>(app_data), local_buf.data(), src_len + 1);
+        } else {
+            std::memcpy(local_buf.data(), app_data, src_len * sizeof(SQLTCHAR));
+            local_buf[src_len] = 0;
+        }
+
+        if (use_4_base) {
+            const size_t utf16_len = UShortStrlen(reinterpret_cast<const uint16_t*>(local_buf.data()));
+            ExpandUTF16ToUTF32InPlace(local_buf.data(), utf16_len, local_buf.size());
+        }
+
+        const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(
+            env->driver_lib_loader, RDS_FP_SQLPutData, RDS_STR_SQLPutData, stmt->wrapped_stmt, local_buf.data(), SQL_NTS);
+        return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+    }
+#endif
+
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLPutData, RDS_STR_SQLPutData,
         stmt->wrapped_stmt, DataPtr, StrLen_or_Ind
     );

--- a/driver/odbcapi_common.cpp
+++ b/driver/odbcapi_common.cpp
@@ -30,9 +30,9 @@ static void ConvertBoundColBuffersAfterFetch(STMT* stmt) {
     const bool use_4_app = stmt->dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
 
     for (BoundColBuffer& buffer : buffers) {
-        if (buffer.local_str_len == SQL_NULL_DATA || buffer.local_str_len < 0) {
+        if (*buffer.local_str_len == SQL_NULL_DATA || *buffer.local_str_len < 0) {
             if (buffer.app_str_len_ptr) {
-                *buffer.app_str_len_ptr = buffer.local_str_len;
+                *buffer.app_str_len_ptr = *buffer.local_str_len;
             }
             continue;
         }
@@ -41,19 +41,29 @@ static void ConvertBoundColBuffersAfterFetch(STMT* stmt) {
 
         // If base driver is 4-byte, convert UTF-32 to UTF-16 in place
         if (use_4_base) {
-            Convert4To2ByteString(true, local, nullptr, static_cast<size_t>(buffer.local_str_len));
+            const size_t char_count = 1 + static_cast<size_t>(*buffer.local_str_len) / sizeof(SQLTCHAR) / 2;
+            Convert4To2ByteString(true, local, nullptr, char_count);
         }
 
         // Copy to user's buffer in the expected encoding
         const size_t src_len = UShortStrlen(reinterpret_cast<const uint16_t *>(local));
-        const size_t dst_len = buffer.app_buf_len;
+        const size_t dst_len = use_4_app
+            ? static_cast<size_t>(buffer.app_buf_len) / 4
+            : static_cast<size_t>(buffer.app_buf_len) / 2;
         if (use_4_app) {
             ConvertUTF16ToUTF32(local, static_cast<SQLTCHAR*>(buffer.app_ptr), src_len, dst_len);
+            if (buffer.app_str_len_ptr) {
+                *buffer.app_str_len_ptr = static_cast<SQLLEN>(src_len) * 4;
+            }
         } else {
-            const size_t copy_chars = src_len < dst_len ? src_len : dst_len;
+            const size_t max_chars = dst_len > 0 ? dst_len - 1 : 0;
+            const size_t copy_chars = src_len < max_chars ? src_len : max_chars;
             SQLTCHAR* dst = reinterpret_cast<SQLTCHAR*>(buffer.app_ptr);
             std::memcpy(dst, local, copy_chars * sizeof(SQLTCHAR));
             dst[copy_chars] = '\0';
+            if (buffer.app_str_len_ptr) {
+                *buffer.app_str_len_ptr = static_cast<SQLLEN>(src_len) * sizeof(SQLTCHAR);
+            }
         }
     }
 }
@@ -77,7 +87,7 @@ static void ConvertBoundParamBuffersBeforeExecute(STMT* stmt) {
 
         const SQLLEN app_ind = buffer.app_str_len_ptr ? *buffer.app_str_len_ptr : 0;
         if (app_ind == SQL_NULL_DATA) {
-            buffer.local_str_len = SQL_NULL_DATA;
+            *buffer.local_str_len = SQL_NULL_DATA;
             continue;
         }
         // Skip as data will be put by SQLPutData
@@ -126,13 +136,13 @@ static void ConvertBoundParamBuffersBeforeExecute(STMT* stmt) {
             ExpandUTF16ToUTF32InPlace(buffer.local_buf.data(), app_data_size, buffer.local_buf.size());
         }
 
-        buffer.local_str_len = SQL_NTS;
+        *buffer.local_str_len = SQL_NTS;
 
         // Rebind parameter
         const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(
             env->driver_lib_loader, RDS_FP_SQLBindParameter, RDS_STR_SQLBindParameter, stmt->wrapped_stmt,
             buffer.param_number, buffer.input_output_type, buffer.value_type, buffer.param_type, buffer.column_size,
-            buffer.decimal_digits, buffer.local_buf.data(), buffer.app_buf_len, &buffer.local_str_len
+            buffer.decimal_digits, buffer.local_buf.data(), buffer.app_buf_len, buffer.local_str_len.get()
         );
     }
 }
@@ -151,9 +161,9 @@ static void ConvertBoundParamBuffersAfterExecute(STMT* stmt) {
             continue;
         }
 
-        if (param.local_str_len == SQL_NULL_DATA || param.local_str_len < 0) {
+        if (*param.local_str_len == SQL_NULL_DATA || *param.local_str_len < 0) {
             if (param.app_str_len_ptr) {
-                *param.app_str_len_ptr = param.local_str_len;
+                *param.app_str_len_ptr = *param.local_str_len;
             }
             continue;
         }
@@ -162,19 +172,29 @@ static void ConvertBoundParamBuffersAfterExecute(STMT* stmt) {
 
         // If base driver is 4-byte, convert UTF-32 to UTF-16 in place
         if (use_4_base) {
-            Convert4To2ByteString(true, local, nullptr, static_cast<size_t>(param.local_str_len));
+            const size_t char_count = 1 + static_cast<size_t>(*param.local_str_len) / sizeof(SQLTCHAR) / 2;
+            Convert4To2ByteString(true, local, nullptr, char_count);
         }
 
         // Copy to user's buffer in the expected encoding
         const size_t src_len = UShortStrlen(reinterpret_cast<const uint16_t*>(local));
-        const size_t dst_len = static_cast<size_t>(param.app_buf_len);
+        const size_t dst_len = use_4_app
+            ? static_cast<size_t>(param.app_buf_len) / 4
+            : static_cast<size_t>(param.app_buf_len) / 2;
         if (use_4_app) {
             ConvertUTF16ToUTF32(local, static_cast<SQLTCHAR*>(param.app_ptr), src_len, dst_len);
+            if (param.app_str_len_ptr) {
+                *param.app_str_len_ptr = static_cast<SQLLEN>(src_len) * 4;
+            }
         } else {
-            const size_t copy_chars = src_len < dst_len ? src_len : dst_len;
+            const size_t max_chars = dst_len > 0 ? dst_len - 1 : 0;
+            const size_t copy_chars = src_len < max_chars ? src_len : max_chars;
             SQLTCHAR* dst = static_cast<SQLTCHAR*>(param.app_ptr);
             std::memcpy(dst, local, copy_chars * sizeof(SQLTCHAR));
             dst[copy_chars] = '\0';
+            if (param.app_str_len_ptr) {
+                *param.app_str_len_ptr = static_cast<SQLLEN>(src_len) * 2;
+            }
         }
     }
 }
@@ -276,13 +296,12 @@ SQLRETURN SQL_API SQLBindCol(
             new_buffer.app_buf_len = BufferLength;
             new_buffer.app_str_len_ptr = StrLen_or_IndPtr;
             new_buffer.local_buf.resize(local_buf_size, 0);
-            new_buffer.local_str_len = 0;
             bindings.push_back(std::move(new_buffer));
 
             BoundColBuffer& ref = bindings.back();
             const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLBindCol, RDS_STR_SQLBindCol,
                 stmt->wrapped_stmt, ColumnNumber, TargetType, ref.local_buf.data(),
-                BufferLength, &ref.local_str_len
+                BufferLength, ref.local_str_len.get()
             );
             return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
         }
@@ -347,13 +366,29 @@ SQLRETURN SQL_API SQLBindParameter(
             new_buffer.app_buf_len = BufferLength;
             new_buffer.app_str_len_ptr = StrLen_or_IndPtr;
 
+            // Get explicit user length or get length of app_data
+            const SQLLEN app_ind = new_buffer.app_str_len_ptr ? *new_buffer.app_str_len_ptr : 0;
+            size_t char_count = 0;
+            if (app_ind == SQL_NTS) {
+                char_count = UShortStrlen(reinterpret_cast<const uint16_t*>(new_buffer.app_ptr), use_4_app);
+            } else {
+                char_count = static_cast<size_t>(app_ind);
+                // app_ind is byte count, divide by app's SQLWCHAR size
+                char_count = use_4_app
+                    ? char_count / 4
+                    : char_count / 2;
+            }
+            const size_t str_len_bytes = use_4_base
+                ? char_count * 4
+                : char_count * 2;
+
             if (ParameterValuePtr != nullptr && BufferLength > 0 && !is_data_at_exec) {
                 // Create a buffer if the input size was set
                 const size_t local_buf_size = use_4_base
-                    ? static_cast<size_t>(BufferLength + 1) * 2
-                    : static_cast<size_t>(BufferLength + 1);
-                new_buffer.local_buf.resize(local_buf_size, 0);
-                new_buffer.local_str_len = 0;
+                    ? static_cast<size_t>(BufferLength) * 2
+                    : static_cast<size_t>(BufferLength);
+                new_buffer.local_buf.resize(1 + local_buf_size, 0);
+                *new_buffer.local_str_len = str_len_bytes;
             } else if (!is_data_at_exec) {
                 // Pass null data to underlying if user did not pass data at exec
                 const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(
@@ -372,14 +407,17 @@ SQLRETURN SQL_API SQLBindParameter(
             SQLPOINTER bind_ptr = is_data_at_exec
                 ? ParameterValuePtr
                 : ref.local_buf.data();
+            SQLLEN bind_len = is_data_at_exec
+                ? BufferLength
+                : ref.local_buf.size() * sizeof(SQLTCHAR);
             SQLLEN* bind_itr = is_data_at_exec
                 ? StrLen_or_IndPtr
-                : &ref.local_str_len;
+                : ref.local_str_len.get();
 
             const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(
                 env->driver_lib_loader, RDS_FP_SQLBindParameter, RDS_STR_SQLBindParameter, stmt->wrapped_stmt,
                 ParameterNumber, InputOutputType, ValueType, ParameterType, ColumnSize,
-                DecimalDigits, bind_ptr, BufferLength, bind_itr
+                DecimalDigits, bind_ptr, bind_len, bind_itr
             );
             return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
         }
@@ -829,21 +867,37 @@ SQLRETURN SQL_API SQLGetData(
 
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
-
     CHECK_WRAPPED_STMT(stmt);
 
 #if UNICODE
     RdsLibResult res;
-    if (!dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp() && TargetType == SQL_C_TCHAR) {
-        SQLTCHAR* buf = reinterpret_cast<SQLTCHAR*>(TargetValuePtr);
-        std::vector<SQLTCHAR> new_buf_vector(static_cast<size_t>(BufferLength) * 2, '\0');
-        SQLTCHAR* new_buf = new_buf_vector.data();
+    const bool use_4_app = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
+    const bool use_4_base = dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver();
+
+    if ((use_4_app || use_4_base) && TargetType == SQL_C_TCHAR) {
+        std::vector<SQLTCHAR> buffer(static_cast<size_t>(BufferLength) * 2, 0);
 
         res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetData, RDS_STR_SQLGetData,
-            stmt->wrapped_stmt, Col_or_Param_Num, TargetType, new_buf, BufferLength, StrLen_or_IndPtr
+            stmt->wrapped_stmt, Col_or_Param_Num, TargetType, buffer.data(), BufferLength, StrLen_or_IndPtr
         );
 
-        Convert4To2ByteString(dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver(), new_buf, buf, BufferLength);
+        if (SQL_SUCCEEDED(res.fn_result) && StrLen_or_IndPtr && *StrLen_or_IndPtr != SQL_NULL_DATA) {
+            SQLTCHAR* dst = reinterpret_cast<SQLTCHAR*>(TargetValuePtr);
+
+            if (use_4_base) {
+                Convert4To2ByteString(true, buffer.data(), nullptr, buffer.size());
+            }
+
+            const size_t src_len = UShortStrlen(reinterpret_cast<const uint16_t*>(buffer.data()));
+            const size_t dst_len = static_cast<size_t>(BufferLength) / sizeof(SQLTCHAR);
+            if (use_4_app) {
+                ConvertUTF16ToUTF32(buffer.data(), dst, src_len, dst_len);
+            } else {
+                const size_t copy_len = src_len < dst_len ? src_len : dst_len - 1;
+                std::memcpy(dst, buffer.data(), copy_len * sizeof(SQLTCHAR));
+                dst[copy_len] = 0;
+            }
+        }
     } else {
         res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetData, RDS_STR_SQLGetData,
             stmt->wrapped_stmt, Col_or_Param_Num, TargetType, TargetValuePtr, BufferLength, StrLen_or_IndPtr

--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -37,6 +37,7 @@
 #include "util/odbc_dsn_helper.h"
 #include "util/plugin_service.h"
 #include "util/rds_lib_loader.h"
+#include "util/rds_strings.h"
 
 #ifdef WIN32
     #include "gui/setup.h"
@@ -400,8 +401,13 @@ SQLRETURN RDS_FreeStmt(
                     ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
                 }
 
+                // Let underlying driver cleanup before we remove any of our data
                 if (Option == SQL_UNBIND) {
                     stmt->bound_col_buffers.clear();
+                }
+                if (Option == SQL_RESET_PARAMS) {
+                    stmt->put_data_char_conversion = false;
+                    stmt->bound_param_buffers.clear();
                 }
 
                 return ret;
@@ -1835,7 +1841,6 @@ SQLRETURN RDS_SQLPrepare(
 
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
-
     CHECK_WRAPPED_STMT(stmt);
 
     const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
@@ -1865,7 +1870,6 @@ SQLRETURN RDS_SQLPrimaryKeys(
 
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
     CLEAR_STMT_ERROR(stmt);
-
     CHECK_WRAPPED_STMT(stmt);
 
     const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();

--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -991,7 +991,7 @@ SQLRETURN RDS_SQLExecDirect(
     if (StatementText) {
         const std::string utf8 = ConvertUserAppToUTF8(
             odbc_helper->GetUse4BytesUserApp(), StatementText, TextLength);
-        // Plugin chain expects UTF16 
+        // Plugin chain expects UTF16
         stmt_utf16 = ConvertUTF8ToUTF16(utf8);
         stmt_text = reinterpret_cast<SQLTCHAR*>(stmt_utf16.data());
     }

--- a/driver/util/rds_strings.h
+++ b/driver/util/rds_strings.h
@@ -67,10 +67,20 @@ inline size_t GetLenOfSqltcharArray(SQLTCHAR *in, SQLLEN buffer_len, bool use_4_
 
 #ifdef UNICODE
 #include "unicode/unistr.h"
-inline size_t UShortStrlen(const uint16_t* str) {
+inline size_t UShortStrlen(const uint16_t* str, const bool use_4_byte = false) {
     size_t length = 0;
-    while (str[length] != 0) {
-        length++;
+    if (!str) {
+        return length;
+    }
+
+    if (use_4_byte) {
+        while (str[length * 2] != 0 || str[length * 2 + 1] != 0) {
+            length++;
+        }
+    } else {
+        while (str[length] != 0) {
+            length++;
+        }
     }
     return length;
 }


### PR DESCRIPTION
### Summary

Support UTF32 SQLBindParameter / ParamData / PutData

### Description

Creates an intermediate buffer to hold SQLTCHAR types to support both 2-byte and 4-byte user applications and underlying drivers.

### Testing
Manual testing using sample application on Mac Unicode using:

Tested:

SQL_PARAM_INPUT for Fixed (e.g. original pointer has 10 len, but put StrIdr to 5) and Dynamic sized inputs (SQL_NTS), and nulls (SQL_NULL_DATA) for 
`INSERT INTO bind_test VALUES (?);`

SQLPutData for `SQL_DATA_AT_EXEC`

MySQL & Postgres procedures for Input+Output w/ string concats
MySQL for Output, similar to above

| SQL_PARAM_INPUT |  Fixed & Dynamic sizing of defferred input             | **Underlying Driver**      |                                        |
|--------------------|----------------------------|----------------------------|----------------------------------------|
|                    |                            | psqlodbc (2-byte SQLWCHAR) | mysql-odbc-connector (4-byte SQLWCHAR) |
| **Driver Manager** | UnixODBC (2-Byte SQLWCHAR) | ✅                          | ✅                                   |
|                    | iodbc (4-Byte SQLWCHAR)    |    ✅                       | ✅                                      |
 


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
