### PR TITLE
fix: ensure output has the correct encoding

### DIFF
--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -551,6 +551,22 @@ SQLRETURN RDS_SQLColAttribute(
     CLEAR_STMT_ERROR(stmt);
 
     CHECK_WRAPPED_STMT(stmt);
+#if UNICODE
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+
+    if (odbc_helper->NeedsConversion(false) && CharacterAttributePtr && BufferLength > 0) {
+        auto attr_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+        const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLColAttribute, RDS_STR_SQLColAttribute,
+            stmt->wrapped_stmt, ColumnNumber, FieldIdentifier, attr_buf.data(), BufferLength, StringLengthPtr, NumericAttributePtr
+        );
+        if (StringLengthPtr && *StringLengthPtr > 0) {
+            odbc_helper->ConvertDriverOutputToTarget(false, attr_buf.data(), static_cast<SQLTCHAR*>(CharacterAttributePtr), static_cast<size_t>(BufferLength));
+        } else {
+            std::memcpy(CharacterAttributePtr, attr_buf.data(), static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR));
+        }
+        return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+    }
+#endif
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLColAttribute, RDS_STR_SQLColAttribute,
         stmt->wrapped_stmt, ColumnNumber, FieldIdentifier, CharacterAttributePtr, BufferLength, StringLengthPtr, NumericAttributePtr
     );
@@ -574,6 +590,24 @@ SQLRETURN RDS_SQLColAttributes(
     const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
 
     CHECK_WRAPPED_STMT(stmt);
+#if UNICODE
+    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+
+    if (odbc_helper->NeedsConversion(false) && CharacterAttributePtr && BufferLength > 0) {
+        auto attr_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+        const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLColAttributes, RDS_STR_SQLColAttributes,
+            stmt->wrapped_stmt, ColumnNumber, FieldIdentifier, attr_buf.data(), BufferLength, StringLengthPtr, NumericAttributePtr
+        );
+        if (StringLengthPtr && *StringLengthPtr > 0) {
+            // String data
+            odbc_helper->ConvertDriverOutputToTarget(false, attr_buf.data(), static_cast<SQLTCHAR*>(CharacterAttributePtr), static_cast<size_t>(BufferLength));
+        } else {
+            // Numeric data
+            std::memcpy(CharacterAttributePtr, attr_buf.data(), static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR));
+        }
+        return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+    }
+#endif
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLColAttributes, RDS_STR_SQLColAttributes,
         stmt->wrapped_stmt, ColumnNumber, FieldIdentifier, CharacterAttributePtr, BufferLength, StringLengthPtr, NumericAttributePtr
     );
@@ -781,6 +815,19 @@ SQLRETURN RDS_SQLDescribeCol(
     CLEAR_STMT_ERROR(stmt);
 
     CHECK_WRAPPED_STMT(stmt);
+#if UNICODE
+    {
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        if (odbc_helper->NeedsConversion(false)) {
+            auto name_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLDescribeCol, RDS_STR_SQLDescribeCol,
+                stmt->wrapped_stmt, ColumnNumber, name_buf.data(), BufferLength, NameLengthPtr, DataTypePtr, ColumnSizePtr, DecimalDigitsPtr, NullablePtr
+            );
+            odbc_helper->ConvertDriverOutputToTarget(false, name_buf.data(), ColumnName, BufferLength);
+            return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+        }
+    }
+#endif
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLDescribeCol, RDS_STR_SQLDescribeCol,
         stmt->wrapped_stmt, ColumnNumber, ColumnName, BufferLength, NameLengthPtr, DataTypePtr, ColumnSizePtr, DecimalDigitsPtr, NullablePtr
     );
@@ -891,11 +938,10 @@ SQLRETURN RDS_SQLDriverConnect(
     if (OutConnectionString && StringLength2Ptr) {
         const SQLULEN len = conn_out_str_utf8.length();
 #ifdef UNICODE
-    #if _WIN32
-        const SQLULEN written = swprintf(OutConnectionString, MAX_KEY_SIZE, RDS_TSTR("%ls").c_str(), ConvertUTF8ToWString(conn_out_str_utf8).c_str());
-    #else
-        const SQLULEN written = CopyUTF8ToUTF16Buffer(OutConnectionString, MAX_KEY_SIZE, conn_out_str_utf8);
-    #endif
+    const SQLULEN written = CopyUTF8ToUTF16Buffer(OutConnectionString, MAX_KEY_SIZE, conn_out_str_utf8);
+    if (dbc->plugin_service) {
+        dbc->plugin_service->GetOdbcHelper()->ConvertWrapperOutputToTarget(false, OutConnectionString, written, BufferLength);
+    }
 #else
         const SQLULEN written = snprintf(AS_CHAR(OutConnectionString), MAX_KEY_SIZE, "%s", conn_out_str_utf8.c_str());
 #endif
@@ -985,7 +1031,7 @@ SQLRETURN RDS_SQLExecDirect(
     if (StatementText) {
         const std::string utf8 = ConvertUserAppToUTF8(
             odbc_helper->GetUse4BytesUserApp(), StatementText, TextLength);
-        // Plugin chain expects UTF16 
+        // Plugin chain expects UTF16
         stmt_utf16 = ConvertUTF8ToUTF16(utf8);
         stmt_text = reinterpret_cast<SQLTCHAR*>(stmt_utf16.data());
     }
@@ -1092,12 +1138,23 @@ SQLRETURN RDS_SQLGetCursorName(
 
     if (stmt->wrapped_stmt) {
 #if UNICODE
-#else
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        if (odbc_helper->NeedsConversion(false)) {
+            auto name_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetCursorName, RDS_STR_SQLGetCursorName,
+                stmt->wrapped_stmt, name_buf.data(), BufferLength, NameLengthPtr
+            );
+            odbc_helper->ConvertDriverOutputToTarget(false, name_buf.data(), CursorName, BufferLength);
+            ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+        } else {
 #endif
-        const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetCursorName, RDS_STR_SQLGetCursorName,
-            stmt->wrapped_stmt, CursorName, BufferLength, NameLengthPtr
-        );
-        ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetCursorName, RDS_STR_SQLGetCursorName,
+                stmt->wrapped_stmt, CursorName, BufferLength, NameLengthPtr
+            );
+            ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+#if UNICODE
+        }
+#endif
     } else {
         if (stmt->cursor_name.empty()) {
             stmt->cursor_name = std::string("CUR_").append(std::to_string(stmt->dbc->unnamed_cursor_count++));
@@ -1105,7 +1162,14 @@ SQLRETURN RDS_SQLGetCursorName(
         const std::string name = stmt->cursor_name;
         const SQLULEN len = name.length();
         if (CursorName) {
+#ifdef UNICODE
+            const SQLLEN written = CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(CursorName), static_cast<size_t>(BufferLength), name.c_str());
+            if (dbc->plugin_service) {
+                dbc->plugin_service->GetOdbcHelper()->ConvertWrapperOutputToTarget(false, CursorName, written, BufferLength);
+            }
+#else
             snprintf(reinterpret_cast<char*>(CursorName), static_cast<size_t>(BufferLength) / sizeof(SQLTCHAR), "%s", name.c_str());
+#endif
             if (len >= BufferLength) {
                 ret = SQL_SUCCESS_WITH_INFO;
             }
@@ -1161,6 +1225,19 @@ SQLRETURN RDS_SQLGetDescRec(
     const std::lock_guard<std::recursive_mutex> lock_guard(desc->lock);
 
     CHECK_WRAPPED_DESC(desc);
+#if UNICODE
+    {
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        if (odbc_helper->NeedsConversion(false)) {
+            auto name_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDescRec, RDS_STR_SQLGetDescRec,
+                desc->wrapped_desc, RecNumber, name_buf.data(), BufferLength, StringLengthPtr, TypePtr, SubTypePtr, LengthPtr, PrecisionPtr, ScalePtr, NullablePtr
+            );
+            odbc_helper->ConvertDriverOutputToTarget(false, name_buf.data(), Name, BufferLength);
+            return RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
+        }
+    }
+#endif
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDescRec, RDS_STR_SQLGetDescRec,
         desc->wrapped_desc, RecNumber, Name, BufferLength, StringLengthPtr, TypePtr, SubTypePtr, LengthPtr, PrecisionPtr, ScalePtr, NullablePtr
     );
@@ -1447,9 +1524,9 @@ SQLRETURN RDS_SQLGetDiagRec(
 
                     if (!env->dbc_list.empty()) {
                         const DBC* dbc = env->dbc_list.front();
-                        const bool use_4_bytes = WrapperCall ? dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver() : dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
-                        Convert4To2ByteString(use_4_bytes, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
-                        Convert4To2ByteString(use_4_bytes, new_msg_buffer, MessageText, BufferLength);
+                        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                        odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
+                        odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, BufferLength);
                     }
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
@@ -1478,9 +1555,9 @@ SQLRETURN RDS_SQLGetDiagRec(
                     );
                     ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
 
-                    const bool use_4_bytes = WrapperCall ? dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver() : dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
-                    Convert4To2ByteString(use_4_bytes, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
-                    Convert4To2ByteString(use_4_bytes, new_msg_buffer, MessageText, BufferLength);
+                    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, BufferLength);
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
                         HandleType, dbc->wrapped_dbc, RecNumber, SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
@@ -1509,9 +1586,9 @@ SQLRETURN RDS_SQLGetDiagRec(
                     );
                     ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 
-                    const bool use_4_bytes = WrapperCall ? dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver() : dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
-                    Convert4To2ByteString(use_4_bytes, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
-                    Convert4To2ByteString(use_4_bytes, new_msg_buffer, MessageText, BufferLength);
+                    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, BufferLength);
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
                         HandleType, stmt->wrapped_stmt, RecNumber, SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
@@ -1540,9 +1617,9 @@ SQLRETURN RDS_SQLGetDiagRec(
                     );
                     ret = RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
 
-                    const bool use_4_bytes = WrapperCall ? dbc->plugin_service->GetOdbcHelper()->GetUse4BytesBaseDriver() : dbc->plugin_service->GetOdbcHelper()->GetUse4BytesUserApp();
-                    Convert4To2ByteString(use_4_bytes, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
-                    Convert4To2ByteString(use_4_bytes, new_msg_buffer, MessageText, BufferLength);
+                    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, BufferLength);
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
                         HandleType, desc->wrapped_desc, RecNumber, SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
@@ -1564,10 +1641,26 @@ SQLRETURN RDS_SQLGetDiagRec(
             return SQL_NO_DATA_FOUND;
         }
 
+#if UNICODE
+        // Resolve the OdbcHelper for wrapper-generated output conversion
+        std::shared_ptr<OdbcHelper> odbc_helper;
+        if (dbc && dbc->plugin_service) {
+            odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        } else if (env && !env->dbc_list.empty()) {
+            const DBC* env_dbc = env->dbc_list.front();
+            if (env_dbc->plugin_service) {
+                odbc_helper = env_dbc->plugin_service->GetOdbcHelper();
+            }
+        }
+#endif
+
         ret = SQL_SUCCESS;
         if (SQLState) {
 #ifdef UNICODE
             CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(SQLState), MAX_SQL_STATE_LEN, err->sqlstate);
+            if (odbc_helper) {
+                odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, SQLState, MAX_SQL_STATE_LEN - 1, MAX_SQL_STATE_LEN * 2);
+            }
 #else
             snprintf(reinterpret_cast<char*>(SQLState), MAX_SQL_STATE_LEN, "%s", err->sqlstate);
 #endif
@@ -1584,6 +1677,9 @@ SQLRETURN RDS_SQLGetDiagRec(
         if (MessageText && (BufferLength > 0) && err->error_msg) {
 #ifdef UNICODE
             const SQLLEN written = CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(MessageText), static_cast<size_t>(BufferLength) / sizeof(uint16_t), err->error_msg);
+            if (odbc_helper) {
+                odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, MessageText, written, BufferLength);
+            }
 #else
             const SQLLEN written = snprintf(reinterpret_cast<char*>(MessageText), static_cast<size_t>(BufferLength) / sizeof(SQLTCHAR), "%s", err->error_msg);
 #endif
@@ -1604,6 +1700,21 @@ SQLRETURN RDS_SQLGetDiagRec(
         if (SQLState) {
 #ifdef UNICODE
             CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(SQLState), MAX_SQL_STATE_LEN, NO_DATA_SQL_STATE);
+            // Expand to 4-byte if user app expects it
+            {
+                std::shared_ptr<OdbcHelper> odbc_helper;
+                if (dbc && dbc->plugin_service) {
+                    odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                } else if (env && !env->dbc_list.empty()) {
+                    const DBC* env_dbc = env->dbc_list.front();
+                    if (env_dbc->plugin_service) {
+                        odbc_helper = env_dbc->plugin_service->GetOdbcHelper();
+                    }
+                }
+                if (odbc_helper) {
+                    odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, SQLState, MAX_SQL_STATE_LEN - 1, MAX_SQL_STATE_LEN * 2);
+                }
+            }
 #else
             snprintf(reinterpret_cast<char*>(SQLState), MAX_SQL_STATE_LEN, "%s", NO_DATA_SQL_STATE);
 #endif
@@ -1811,6 +1922,23 @@ SQLRETURN RDS_SQLNativeSql(
 
     const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
     auto stmt_converted = odbc_helper->ConvertInput(InStatementText, TextLength1);
+
+#if UNICODE
+    {
+        if (odbc_helper->NeedsConversion(false)) {
+            auto out_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+            SQLTCHAR* out_ptr = OutStatementText ? out_buf.data() : nullptr;
+
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLNativeSql, RDS_STR_SQLNativeSql,
+                dbc->wrapped_dbc, stmt_converted.tchar_ptr, TextLength1, out_ptr, BufferLength, TextLength2Ptr
+            );
+            if (OutStatementText && out_ptr) {
+                odbc_helper->ConvertDriverOutputToTarget(false, out_ptr, OutStatementText, BufferLength);
+            }
+            return RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+        }
+    }
+#endif
 
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLNativeSql, RDS_STR_SQLNativeSql,
         dbc->wrapped_dbc,

--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -42,6 +42,21 @@
     #include "gui/setup.h"
 #endif
 
+#if UNICODE
+std::shared_ptr<OdbcHelper> RDS_GetOdbcHelper(const DBC* dbc, const ENV* env) {
+    if (dbc && dbc->plugin_service) {
+        return dbc->plugin_service->GetOdbcHelper();
+    }
+    if (env && !env->dbc_list.empty()) {
+        const DBC* env_dbc = env->dbc_list.front();
+        if (env_dbc && env_dbc->plugin_service) {
+            return env_dbc->plugin_service->GetOdbcHelper();
+        }
+    }
+    return nullptr;
+}
+#endif
+
 SQLRETURN RDS_ProcessLibRes(
     SQLSMALLINT         HandleType,
     SQLHANDLE           InputHandle,
@@ -460,10 +475,24 @@ SQLRETURN RDS_GetConnectAttr(
 
     // If already connected, query value from underlying DBC
     if (dbc->wrapped_dbc) {
-        const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetConnectAttr, RDS_STR_SQLGetConnectAttr,
-            dbc->wrapped_dbc, Attribute, ValuePtr, BufferLength, StringLengthPtr
-        );
-        ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+#if UNICODE
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        if (odbc_helper->NeedsConversion() && ValuePtr && BufferLength > 0
+            && OdbcHelper::IsStringConnectAttr(Attribute)) {
+            auto attr_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetConnectAttr, RDS_STR_SQLGetConnectAttr,
+                dbc->wrapped_dbc, Attribute, attr_buf.data(), BufferLength, StringLengthPtr
+            );
+            odbc_helper->ConvertDriverOutputToTarget(attr_buf.data(), static_cast<SQLTCHAR*>(ValuePtr), static_cast<size_t>(BufferLength));
+            ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+        } else
+#endif
+        {
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetConnectAttr, RDS_STR_SQLGetConnectAttr,
+                dbc->wrapped_dbc, Attribute, ValuePtr, BufferLength, StringLengthPtr
+            );
+            ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+        }
     }
     // Otherwise get from the DBC's attribute map
     else if (dbc->attr_map.contains(Attribute)) {
@@ -500,10 +529,24 @@ SQLRETURN RDS_SQLSetConnectAttr(
 
     // If already connected, apply value to underlying DBC, otherwise track and apply on connect
     if (dbc->wrapped_dbc) {
-        const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLSetConnectAttr, RDS_STR_SQLSetConnectAttr,
-            dbc->wrapped_dbc, Attribute, ValuePtr, StringLength
-        );
-        ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+#if UNICODE
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        if (odbc_helper->NeedsConversion() && ValuePtr
+            && OdbcHelper::IsStringConnectAttr(Attribute)
+            && (StringLength == SQL_NTS || StringLength > 0)) {
+            auto value_converted = odbc_helper->ConvertInput(static_cast<SQLTCHAR*>(ValuePtr), StringLength);
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLSetConnectAttr, RDS_STR_SQLSetConnectAttr,
+                dbc->wrapped_dbc, Attribute, value_converted.tchar_ptr, StringLength
+            );
+            ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+        } else
+#endif
+        {
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLSetConnectAttr, RDS_STR_SQLSetConnectAttr,
+                dbc->wrapped_dbc, Attribute, ValuePtr, StringLength
+            );
+            ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+        }
     }
     dbc->attr_map.insert_or_assign(Attribute, std::make_pair(ValuePtr, StringLength));
 
@@ -819,11 +862,13 @@ SQLRETURN RDS_SQLDescribeCol(
     {
         const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
         if (odbc_helper->NeedsConversion()) {
-            auto name_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+            // Bufferlength is in char count not bytes for SQLDescribeCol
+            const size_t buf_bytes = static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR);
+            auto name_buf = odbc_helper->AllocateConversionBuffer(buf_bytes);
             const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLDescribeCol, RDS_STR_SQLDescribeCol,
                 stmt->wrapped_stmt, ColumnNumber, name_buf.data(), BufferLength, NameLengthPtr, DataTypePtr, ColumnSizePtr, DecimalDigitsPtr, NullablePtr
             );
-            odbc_helper->ConvertDriverOutputToTarget(name_buf.data(), ColumnName, BufferLength);
+            odbc_helper->ConvertDriverOutputToTarget(name_buf.data(), ColumnName, buf_bytes);
             return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
         }
     }
@@ -1140,11 +1185,13 @@ SQLRETURN RDS_SQLGetCursorName(
 #if UNICODE
         const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
         if (odbc_helper->NeedsConversion()) {
-            auto name_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+            // Bufferlength is in char count not bytes for SQLGetCursorName
+            const size_t buf_bytes = static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR);
+            auto name_buf = odbc_helper->AllocateConversionBuffer(buf_bytes);
             const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetCursorName, RDS_STR_SQLGetCursorName,
                 stmt->wrapped_stmt, name_buf.data(), BufferLength, NameLengthPtr
             );
-            odbc_helper->ConvertDriverOutputToTarget(name_buf.data(), CursorName, BufferLength);
+            odbc_helper->ConvertDriverOutputToTarget(name_buf.data(), CursorName, buf_bytes);
             ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
         } else {
 #endif
@@ -1165,7 +1212,8 @@ SQLRETURN RDS_SQLGetCursorName(
 #ifdef UNICODE
             const SQLLEN written = CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(CursorName), static_cast<size_t>(BufferLength), name.c_str());
             if (dbc->plugin_service) {
-                dbc->plugin_service->GetOdbcHelper()->ConvertWrapperOutputToTarget(CursorName, written, BufferLength);
+                const size_t buf_bytes = static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR);
+                dbc->plugin_service->GetOdbcHelper()->ConvertWrapperOutputToTarget(CursorName, written, buf_bytes);
             }
 #else
             snprintf(reinterpret_cast<char*>(CursorName), static_cast<size_t>(BufferLength) / sizeof(SQLTCHAR), "%s", name.c_str());
@@ -1198,6 +1246,20 @@ SQLRETURN RDS_SQLGetDescField(
     const std::lock_guard<std::recursive_mutex> lock_guard(desc->lock);
 
     CHECK_WRAPPED_DESC(desc);
+#if UNICODE
+    {
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        if (odbc_helper->NeedsConversion() && ValuePtr && BufferLength > 0
+            && OdbcHelper::IsStringDescField(FieldIdentifier)) {
+            auto field_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDescField, RDS_STR_SQLGetDescField,
+                desc->wrapped_desc, RecNumber, FieldIdentifier, field_buf.data(), BufferLength, StringLengthPtr
+            );
+            odbc_helper->ConvertDriverOutputToTarget(field_buf.data(), static_cast<SQLTCHAR*>(ValuePtr), static_cast<size_t>(BufferLength));
+            return RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
+        }
+    }
+#endif
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDescField, RDS_STR_SQLGetDescField,
         desc->wrapped_desc, RecNumber, FieldIdentifier, ValuePtr, BufferLength, StringLengthPtr
     );
@@ -1229,11 +1291,13 @@ SQLRETURN RDS_SQLGetDescRec(
     {
         const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
         if (odbc_helper->NeedsConversion()) {
-            auto name_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+            // Bufferlength is in char count not bytes for SQLGetDescRec
+            const size_t buf_bytes = static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR);
+            auto name_buf = odbc_helper->AllocateConversionBuffer(buf_bytes);
             const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDescRec, RDS_STR_SQLGetDescRec,
                 desc->wrapped_desc, RecNumber, name_buf.data(), BufferLength, StringLengthPtr, TypePtr, SubTypePtr, LengthPtr, PrecisionPtr, ScalePtr, NullablePtr
             );
-            odbc_helper->ConvertDriverOutputToTarget(name_buf.data(), Name, BufferLength);
+            odbc_helper->ConvertDriverOutputToTarget(name_buf.data(), Name, buf_bytes);
             return RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
         }
     }
@@ -1270,10 +1334,27 @@ SQLRETURN RDS_SQLGetDiagField(
                 env = static_cast<ENV*>(Handle);
                 const std::lock_guard<std::recursive_mutex> lock_guard(env->lock);
                 if (env->wrapped_env) {
-                    res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
-                        HandleType, env->wrapped_env, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
-                    );
-                    ret = RDS_ProcessLibRes(SQL_HANDLE_ENV, env, res);
+#if UNICODE
+                    const auto odbc_helper = RDS_GetOdbcHelper(nullptr, env);
+                    if (odbc_helper && odbc_helper->NeedsConversion() && DiagInfoPtr && BufferLength > 0
+                        && OdbcHelper::IsStringDiagField(DiagIdentifier)) {
+                        auto diag_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, env->wrapped_env, RecNumber, DiagIdentifier, diag_buf.data(), BufferLength, StringLengthPtr
+                        );
+                        odbc_helper->ConvertDriverOutputToTarget(
+                            diag_buf.data(),
+                            static_cast<SQLTCHAR*>(DiagInfoPtr),
+                            static_cast<size_t>(BufferLength));
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_ENV, env, res);
+                    } else
+#endif
+                    {
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, env->wrapped_env, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
+                        );
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_ENV, env, res);
+                    }
                 } else if (env->err) {
                     err = new ERR_INFO(*env->err);
                 }
@@ -1286,10 +1367,27 @@ SQLRETURN RDS_SQLGetDiagField(
                 env = dbc->env;
                 const std::lock_guard<std::recursive_mutex> lock_guard(dbc->lock);
                 if (dbc->wrapped_dbc) {
-                    res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
-                        HandleType, dbc->wrapped_dbc, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
-                    );
-                    ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+#if UNICODE
+                    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                    if (odbc_helper->NeedsConversion() && DiagInfoPtr && BufferLength > 0
+                        && OdbcHelper::IsStringDiagField(DiagIdentifier)) {
+                        auto diag_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, dbc->wrapped_dbc, RecNumber, DiagIdentifier, diag_buf.data(), BufferLength, StringLengthPtr
+                        );
+                        odbc_helper->ConvertDriverOutputToTarget(
+                            diag_buf.data(),
+                            static_cast<SQLTCHAR*>(DiagInfoPtr),
+                            static_cast<size_t>(BufferLength));
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+                    } else
+#endif
+                    {
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, dbc->wrapped_dbc, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
+                        );
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+                    }
                 } else if (dbc->err) {
                     err = new ERR_INFO(*dbc->err);
                 }
@@ -1303,10 +1401,27 @@ SQLRETURN RDS_SQLGetDiagField(
                 env = dbc->env;
                 const std::lock_guard<std::recursive_mutex> lock_guard(stmt->lock);
                 if (stmt->wrapped_stmt) {
-                    res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
-                        HandleType, stmt->wrapped_stmt, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
-                    );
-                    ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+#if UNICODE
+                    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                    if (odbc_helper->NeedsConversion() && DiagInfoPtr && BufferLength > 0
+                        && OdbcHelper::IsStringDiagField(DiagIdentifier)) {
+                        auto diag_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, stmt->wrapped_stmt, RecNumber, DiagIdentifier, diag_buf.data(), BufferLength, StringLengthPtr
+                        );
+                        odbc_helper->ConvertDriverOutputToTarget(
+                            diag_buf.data(),
+                            static_cast<SQLTCHAR*>(DiagInfoPtr),
+                            static_cast<size_t>(BufferLength));
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+                    } else
+#endif
+                    {
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, stmt->wrapped_stmt, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
+                        );
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
+                    }
                 } else if (stmt->err) {
                     err = new ERR_INFO(*stmt->err);
                 }
@@ -1322,10 +1437,24 @@ SQLRETURN RDS_SQLGetDiagField(
                 const std::lock_guard<std::recursive_mutex> lock_guard(desc->lock);
 
                 if (desc->wrapped_desc) {
-                    res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
-                        HandleType, desc->wrapped_desc, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
-                    );
-                    ret = RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
+#if UNICODE
+                    const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                    if (odbc_helper->NeedsConversion() && DiagInfoPtr && BufferLength > 0
+                        && OdbcHelper::IsStringDiagField(DiagIdentifier)) {
+                        auto diag_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, desc->wrapped_desc, RecNumber, DiagIdentifier, diag_buf.data(), BufferLength, StringLengthPtr
+                        );
+                        odbc_helper->ConvertDriverOutputToTarget(diag_buf.data(), static_cast<SQLTCHAR*>(DiagInfoPtr), static_cast<size_t>(BufferLength));
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
+                    } else
+#endif
+                    {
+                        res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagField, RDS_STR_SQLGetDiagField,
+                            HandleType, desc->wrapped_desc, RecNumber, DiagIdentifier, DiagInfoPtr, BufferLength, StringLengthPtr
+                        );
+                        ret = RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
+                    }
                 } else if (desc->err) {
                     err = new ERR_INFO(*desc->err);
                 }
@@ -1497,6 +1626,9 @@ SQLRETURN RDS_SQLGetDiagRec(
     bool has_underlying_data = false;
 
 #if UNICODE
+    const size_t state_bytes = MAX_SQL_STATE_LEN * sizeof(SQLTCHAR);
+    // Bufferlength is in char count not bytes for SQLGetDiagRec
+    const size_t msg_bytes = static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR);
     SQLTCHAR new_state_buffer[MAX_SQL_STATE_LEN * 2] = {0};
     std::vector<SQLTCHAR> new_msg_vector(static_cast<size_t>(BufferLength) * 2, '\0');
     SQLTCHAR* new_msg_buffer = new_msg_vector.data();
@@ -1522,11 +1654,10 @@ SQLRETURN RDS_SQLGetDiagRec(
                     );
                     ret = RDS_ProcessLibRes(SQL_HANDLE_ENV, env, res);
 
-                    if (!env->dbc_list.empty()) {
-                        const DBC* dbc = env->dbc_list.front();
-                        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
-                        odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
-                        odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, BufferLength);
+                    const auto odbc_helper = RDS_GetOdbcHelper(nullptr, env);
+                    if (odbc_helper) {
+                        odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, state_bytes);
+                        odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, msg_bytes);
                     }
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
@@ -1556,8 +1687,8 @@ SQLRETURN RDS_SQLGetDiagRec(
                     ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
 
                     const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
-                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
-                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, BufferLength);
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, state_bytes);
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, msg_bytes);
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
                         HandleType, dbc->wrapped_dbc, RecNumber, SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
@@ -1587,8 +1718,8 @@ SQLRETURN RDS_SQLGetDiagRec(
                     ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 
                     const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
-                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
-                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, BufferLength);
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, state_bytes);
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, msg_bytes);
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
                         HandleType, stmt->wrapped_stmt, RecNumber, SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
@@ -1618,8 +1749,8 @@ SQLRETURN RDS_SQLGetDiagRec(
                     ret = RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
 
                     const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
-                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, MAX_SQL_STATE_LEN);
-                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, BufferLength);
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, state_bytes);
+                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, msg_bytes);
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
                         HandleType, desc->wrapped_desc, RecNumber, SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
@@ -1643,15 +1774,7 @@ SQLRETURN RDS_SQLGetDiagRec(
 
 #if UNICODE
         // Resolve the OdbcHelper for wrapper-generated output conversion
-        std::shared_ptr<OdbcHelper> odbc_helper;
-        if (dbc && dbc->plugin_service) {
-            odbc_helper = dbc->plugin_service->GetOdbcHelper();
-        } else if (env && !env->dbc_list.empty()) {
-            const DBC* env_dbc = env->dbc_list.front();
-            if (env_dbc->plugin_service) {
-                odbc_helper = env_dbc->plugin_service->GetOdbcHelper();
-            }
-        }
+        const auto odbc_helper = RDS_GetOdbcHelper(dbc, env);
 #endif
 
         ret = SQL_SUCCESS;
@@ -1659,7 +1782,7 @@ SQLRETURN RDS_SQLGetDiagRec(
 #ifdef UNICODE
             CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(SQLState), MAX_SQL_STATE_LEN, err->sqlstate);
             if (odbc_helper) {
-                odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, SQLState, MAX_SQL_STATE_LEN - 1, MAX_SQL_STATE_LEN * 2);
+                odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, SQLState, MAX_SQL_STATE_LEN - 1, MAX_SQL_STATE_LEN * 2 * sizeof(SQLTCHAR));
             }
 #else
             snprintf(reinterpret_cast<char*>(SQLState), MAX_SQL_STATE_LEN, "%s", err->sqlstate);
@@ -1676,9 +1799,9 @@ SQLRETURN RDS_SQLGetDiagRec(
         }
         if (MessageText && (BufferLength > 0) && err->error_msg) {
 #ifdef UNICODE
-            const SQLLEN written = CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(MessageText), static_cast<size_t>(BufferLength) / sizeof(uint16_t), err->error_msg);
+            const SQLLEN written = CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(MessageText), static_cast<size_t>(BufferLength), err->error_msg);
             if (odbc_helper) {
-                odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, MessageText, written, BufferLength);
+                odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, MessageText, written, msg_bytes);
             }
 #else
             const SQLLEN written = snprintf(reinterpret_cast<char*>(MessageText), static_cast<size_t>(BufferLength) / sizeof(SQLTCHAR), "%s", err->error_msg);
@@ -1702,17 +1825,9 @@ SQLRETURN RDS_SQLGetDiagRec(
             CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(SQLState), MAX_SQL_STATE_LEN, NO_DATA_SQL_STATE);
             // Expand to 4-byte if user app expects it
             {
-                std::shared_ptr<OdbcHelper> odbc_helper;
-                if (dbc && dbc->plugin_service) {
-                    odbc_helper = dbc->plugin_service->GetOdbcHelper();
-                } else if (env && !env->dbc_list.empty()) {
-                    const DBC* env_dbc = env->dbc_list.front();
-                    if (env_dbc->plugin_service) {
-                        odbc_helper = env_dbc->plugin_service->GetOdbcHelper();
-                    }
-                }
+                const auto odbc_helper = RDS_GetOdbcHelper(dbc, env);
                 if (odbc_helper) {
-                    odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, SQLState, MAX_SQL_STATE_LEN - 1, MAX_SQL_STATE_LEN * 2);
+                    odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, SQLState, MAX_SQL_STATE_LEN - 1, MAX_SQL_STATE_LEN * 2 * sizeof(SQLTCHAR));
                 }
             }
 #else
@@ -1772,6 +1887,24 @@ SQLRETURN RDS_SQLGetInfo(
             if (dbc->wrapped_dbc) {
                 const ENV* env = dbc->env;
                 CLEAR_DBC_ERROR(dbc);
+#if UNICODE
+                const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+                if (odbc_helper->NeedsConversion() && InfoValuePtr && BufferLength > 0) {
+                    auto info_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+                    const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetInfo, RDS_STR_SQLGetInfo,
+                        dbc->wrapped_dbc, InfoType, info_buf.data(), BufferLength, StringLengthPtr
+                    );
+                    if (StringLengthPtr && *StringLengthPtr > 0) {
+                        odbc_helper->ConvertDriverOutputToTarget(
+                            info_buf.data(),
+                            static_cast<SQLTCHAR*>(InfoValuePtr),
+                            static_cast<size_t>(BufferLength));
+                    } else {
+                        std::memcpy(InfoValuePtr, info_buf.data(), static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR));
+                    }
+                    return RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
+                }
+#endif
                 const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetInfo, RDS_STR_SQLGetInfo,
                     dbc->wrapped_dbc, InfoType, InfoValuePtr, BufferLength, StringLengthPtr
                 );
@@ -1808,7 +1941,11 @@ SQLRETURN RDS_SQLGetInfo(
         len = strlen(char_value);
         if (InfoValuePtr) {
 #ifdef UNICODE
-            CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(InfoValuePtr), BufferLength / sizeof(uint16_t), char_value);
+            const SQLLEN written = CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(InfoValuePtr), static_cast<size_t>(BufferLength), char_value);
+            if (dbc->plugin_service) {
+                dbc->plugin_service->GetOdbcHelper()->ConvertWrapperOutputToTarget(
+                    static_cast<SQLTCHAR*>(InfoValuePtr), written, static_cast<size_t>(BufferLength));
+            }
 #else
             snprintf(static_cast<char*>(InfoValuePtr), static_cast<size_t>(BufferLength) / sizeof(SQLTCHAR), "%s", char_value);
 #endif
@@ -1926,14 +2063,16 @@ SQLRETURN RDS_SQLNativeSql(
 #if UNICODE
     {
         if (odbc_helper->NeedsConversion()) {
-            auto out_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
+            // Bufferlength is in char count not bytes for SQLNativeSQL
+            const size_t buf_bytes = static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR);
+            auto out_buf = odbc_helper->AllocateConversionBuffer(buf_bytes);
             SQLTCHAR* out_ptr = OutStatementText ? out_buf.data() : nullptr;
 
             const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLNativeSql, RDS_STR_SQLNativeSql,
                 dbc->wrapped_dbc, stmt_converted.tchar_ptr, TextLength1, out_ptr, BufferLength, TextLength2Ptr
             );
             if (OutStatementText && out_ptr) {
-                odbc_helper->ConvertDriverOutputToTarget(out_ptr, OutStatementText, BufferLength);
+                odbc_helper->ConvertDriverOutputToTarget(out_ptr, OutStatementText, buf_bytes);
             }
             return RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
         }
@@ -2156,6 +2295,20 @@ SQLRETURN RDS_SQLSetDescField(
     const std::lock_guard<std::recursive_mutex> lock_guard(desc->lock);
 
     CHECK_WRAPPED_DESC(desc);
+#if UNICODE
+    {
+        const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
+        if (odbc_helper->NeedsConversion() && ValuePtr
+            && OdbcHelper::IsStringDescField(FieldIdentifier)
+            && (BufferLength == SQL_NTS || BufferLength > 0)) {
+            auto value_converted = odbc_helper->ConvertInput(static_cast<SQLTCHAR*>(ValuePtr), BufferLength);
+            const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLSetDescField, RDS_STR_SQLSetDescField,
+                desc->wrapped_desc, RecNumber, FieldIdentifier, value_converted.tchar_ptr, BufferLength
+            );
+            return RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
+        }
+    }
+#endif
     const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLSetDescField, RDS_STR_SQLSetDescField,
         desc->wrapped_desc, RecNumber, FieldIdentifier, ValuePtr, BufferLength
     );

--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -554,13 +554,13 @@ SQLRETURN RDS_SQLColAttribute(
 #if UNICODE
     const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
 
-    if (odbc_helper->NeedsConversion(false) && CharacterAttributePtr && BufferLength > 0) {
+    if (odbc_helper->NeedsConversion() && CharacterAttributePtr && BufferLength > 0) {
         auto attr_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
         const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLColAttribute, RDS_STR_SQLColAttribute,
             stmt->wrapped_stmt, ColumnNumber, FieldIdentifier, attr_buf.data(), BufferLength, StringLengthPtr, NumericAttributePtr
         );
         if (StringLengthPtr && *StringLengthPtr > 0) {
-            odbc_helper->ConvertDriverOutputToTarget(false, attr_buf.data(), static_cast<SQLTCHAR*>(CharacterAttributePtr), static_cast<size_t>(BufferLength));
+            odbc_helper->ConvertDriverOutputToTarget(attr_buf.data(), static_cast<SQLTCHAR*>(CharacterAttributePtr), static_cast<size_t>(BufferLength));
         } else {
             std::memcpy(CharacterAttributePtr, attr_buf.data(), static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR));
         }
@@ -593,14 +593,14 @@ SQLRETURN RDS_SQLColAttributes(
 #if UNICODE
     const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
 
-    if (odbc_helper->NeedsConversion(false) && CharacterAttributePtr && BufferLength > 0) {
+    if (odbc_helper->NeedsConversion() && CharacterAttributePtr && BufferLength > 0) {
         auto attr_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
         const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLColAttributes, RDS_STR_SQLColAttributes,
             stmt->wrapped_stmt, ColumnNumber, FieldIdentifier, attr_buf.data(), BufferLength, StringLengthPtr, NumericAttributePtr
         );
         if (StringLengthPtr && *StringLengthPtr > 0) {
             // String data
-            odbc_helper->ConvertDriverOutputToTarget(false, attr_buf.data(), static_cast<SQLTCHAR*>(CharacterAttributePtr), static_cast<size_t>(BufferLength));
+            odbc_helper->ConvertDriverOutputToTarget(attr_buf.data(), static_cast<SQLTCHAR*>(CharacterAttributePtr), static_cast<size_t>(BufferLength));
         } else {
             // Numeric data
             std::memcpy(CharacterAttributePtr, attr_buf.data(), static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR));
@@ -818,12 +818,12 @@ SQLRETURN RDS_SQLDescribeCol(
 #if UNICODE
     {
         const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
-        if (odbc_helper->NeedsConversion(false)) {
+        if (odbc_helper->NeedsConversion()) {
             auto name_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
             const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLDescribeCol, RDS_STR_SQLDescribeCol,
                 stmt->wrapped_stmt, ColumnNumber, name_buf.data(), BufferLength, NameLengthPtr, DataTypePtr, ColumnSizePtr, DecimalDigitsPtr, NullablePtr
             );
-            odbc_helper->ConvertDriverOutputToTarget(false, name_buf.data(), ColumnName, BufferLength);
+            odbc_helper->ConvertDriverOutputToTarget(name_buf.data(), ColumnName, BufferLength);
             return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
         }
     }
@@ -940,7 +940,7 @@ SQLRETURN RDS_SQLDriverConnect(
 #ifdef UNICODE
     const SQLULEN written = CopyUTF8ToUTF16Buffer(OutConnectionString, MAX_KEY_SIZE, conn_out_str_utf8);
     if (dbc->plugin_service) {
-        dbc->plugin_service->GetOdbcHelper()->ConvertWrapperOutputToTarget(false, OutConnectionString, written, BufferLength);
+        dbc->plugin_service->GetOdbcHelper()->ConvertWrapperOutputToTarget(OutConnectionString, written, BufferLength);
     }
 #else
         const SQLULEN written = snprintf(AS_CHAR(OutConnectionString), MAX_KEY_SIZE, "%s", conn_out_str_utf8.c_str());
@@ -1139,12 +1139,12 @@ SQLRETURN RDS_SQLGetCursorName(
     if (stmt->wrapped_stmt) {
 #if UNICODE
         const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
-        if (odbc_helper->NeedsConversion(false)) {
+        if (odbc_helper->NeedsConversion()) {
             auto name_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
             const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetCursorName, RDS_STR_SQLGetCursorName,
                 stmt->wrapped_stmt, name_buf.data(), BufferLength, NameLengthPtr
             );
-            odbc_helper->ConvertDriverOutputToTarget(false, name_buf.data(), CursorName, BufferLength);
+            odbc_helper->ConvertDriverOutputToTarget(name_buf.data(), CursorName, BufferLength);
             ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
         } else {
 #endif
@@ -1165,7 +1165,7 @@ SQLRETURN RDS_SQLGetCursorName(
 #ifdef UNICODE
             const SQLLEN written = CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(CursorName), static_cast<size_t>(BufferLength), name.c_str());
             if (dbc->plugin_service) {
-                dbc->plugin_service->GetOdbcHelper()->ConvertWrapperOutputToTarget(false, CursorName, written, BufferLength);
+                dbc->plugin_service->GetOdbcHelper()->ConvertWrapperOutputToTarget(CursorName, written, BufferLength);
             }
 #else
             snprintf(reinterpret_cast<char*>(CursorName), static_cast<size_t>(BufferLength) / sizeof(SQLTCHAR), "%s", name.c_str());
@@ -1228,12 +1228,12 @@ SQLRETURN RDS_SQLGetDescRec(
 #if UNICODE
     {
         const auto odbc_helper = dbc->plugin_service->GetOdbcHelper();
-        if (odbc_helper->NeedsConversion(false)) {
+        if (odbc_helper->NeedsConversion()) {
             auto name_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
             const RdsLibResult res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDescRec, RDS_STR_SQLGetDescRec,
                 desc->wrapped_desc, RecNumber, name_buf.data(), BufferLength, StringLengthPtr, TypePtr, SubTypePtr, LengthPtr, PrecisionPtr, ScalePtr, NullablePtr
             );
-            odbc_helper->ConvertDriverOutputToTarget(false, name_buf.data(), Name, BufferLength);
+            odbc_helper->ConvertDriverOutputToTarget(name_buf.data(), Name, BufferLength);
             return RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
         }
     }
@@ -1925,7 +1925,7 @@ SQLRETURN RDS_SQLNativeSql(
 
 #if UNICODE
     {
-        if (odbc_helper->NeedsConversion(false)) {
+        if (odbc_helper->NeedsConversion()) {
             auto out_buf = odbc_helper->AllocateConversionBuffer(static_cast<size_t>(BufferLength));
             SQLTCHAR* out_ptr = OutStatementText ? out_buf.data() : nullptr;
 
@@ -1933,7 +1933,7 @@ SQLRETURN RDS_SQLNativeSql(
                 dbc->wrapped_dbc, stmt_converted.tchar_ptr, TextLength1, out_ptr, BufferLength, TextLength2Ptr
             );
             if (OutStatementText && out_ptr) {
-                odbc_helper->ConvertDriverOutputToTarget(false, out_ptr, OutStatementText, BufferLength);
+                odbc_helper->ConvertDriverOutputToTarget(out_ptr, OutStatementText, BufferLength);
             }
             return RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
         }

--- a/driver/odbcapi_rds_helper.h
+++ b/driver/odbcapi_rds_helper.h
@@ -397,4 +397,10 @@ SQLRETURN RDS_SQLTables(
 
 SQLRETURN RDS_InitializeConnection(DBC* dbc, const std::string& conn_str);
 
+#if UNICODE
+// Forward declaration for RDS_GetOdbcHelper
+class OdbcHelper;
+std::shared_ptr<OdbcHelper> RDS_GetOdbcHelper(const DBC* dbc, const ENV* env);
+#endif
+
 #endif // ODBCAPI_RDS_HELPER_H_

--- a/driver/util/odbc_helper.cpp
+++ b/driver/util/odbc_helper.cpp
@@ -177,9 +177,9 @@ std::string OdbcHelper::GetSqlStateAndLogMessage(DBC* dbc) {
 void OdbcHelper::ConvertDriverOutputToTarget(
     const SQLTCHAR* src,
     SQLTCHAR* dst,
-    const size_t dst_char_count) const
+    const size_t dst_byte_count) const
 {
-    ConvertDriverOutputToTarget(false, src, dst, dst_char_count);
+    ConvertDriverOutputToTarget(false, src, dst, dst_byte_count);
 }
 
 // codechecker_suppress [readability-convert-member-functions-to-static]
@@ -187,25 +187,26 @@ void OdbcHelper::ConvertDriverOutputToTarget(
     const bool wrapper_call,
     const SQLTCHAR* src,
     SQLTCHAR* dst,
-    const size_t dst_char_count) const
+    const size_t dst_byte_count) const
 {
 #if UNICODE
+    const size_t dst_char_count = dst_byte_count / sizeof(SQLTCHAR);
     const bool user_4_byte = !wrapper_call && use_4_bytes_user_app_;
 
     if (user_4_byte && use_4_bytes_base_driver_) {
         // Both the client application and the base driver use 4-byte data.
         // Copy the data as-is.
-        std::memcpy(dst, src, dst_char_count * 2 * sizeof(SQLTCHAR));
+        std::memcpy(dst, src, dst_byte_count);
     } else if (user_4_byte) {
         // Expand the driver output from 2-byte to 4-byte for the client application.
-        ConvertUTF16ToUTF32(src, dst, dst_char_count > 0 ? dst_char_count - 1 : 0, dst_char_count * 2);
+        ConvertUTF16ToUTF32(src, dst, dst_char_count > 0 ? dst_char_count - 1 : 0, dst_char_count);
     } else {
         // Narrow driver output from 4-byte to 2-byte for the client application.
         // Or copy as-is if both are 2-byte.
         Convert4To2ByteString(use_4_bytes_base_driver_, const_cast<SQLTCHAR*>(src), dst, dst_char_count);
     }
 #else
-    std::memcpy(dst, src, dst_char_count * sizeof(SQLTCHAR));
+    std::memcpy(dst, src, dst_byte_count);
 #endif
 }
 
@@ -213,21 +214,22 @@ void OdbcHelper::ConvertDriverOutputToTarget(
 void OdbcHelper::ConvertWrapperOutputToTarget(
     SQLTCHAR* buf,
     const size_t char_count,
-    const size_t buf_elements) const
+    const size_t buf_byte_count) const
 {
-    ConvertWrapperOutputToTarget(false, buf, char_count, buf_elements);
+    ConvertWrapperOutputToTarget(false, buf, char_count, buf_byte_count);
 }
 
 void OdbcHelper::ConvertWrapperOutputToTarget(
     const bool wrapper_call,
     SQLTCHAR* buf,
     const size_t char_count,
-    const size_t buf_elements) const
+    const size_t buf_byte_count) const
 {
 #if UNICODE
     // Wrapper output is already in 2-bytes. Only need to expand if client application requires 4-bytes.
     if (!wrapper_call && use_4_bytes_user_app_) {
-        ExpandUTF16ToUTF32InPlace(buf, char_count, buf_elements);
+        const size_t buf_char_count = buf_byte_count / sizeof(SQLTCHAR);
+        ExpandUTF16ToUTF32InPlace(buf, char_count, buf_char_count);
     }
 #endif
 }
@@ -241,9 +243,55 @@ bool OdbcHelper::NeedsConversion() const {
 #endif
 }
 
-std::vector<SQLTCHAR> OdbcHelper::AllocateConversionBuffer(const size_t char_count) const {
+std::vector<SQLTCHAR> OdbcHelper::AllocateConversionBuffer(const size_t byte_count) const {
+    const size_t char_count = byte_count / sizeof(SQLTCHAR);
     const size_t local_buf_size = use_4_bytes_base_driver_
         ? char_count * 2
         : char_count;
     return std::vector<SQLTCHAR>(local_buf_size, 0);
+}
+
+bool OdbcHelper::IsStringConnectAttr(const SQLINTEGER attribute) {
+    switch (attribute) {
+        case SQL_ATTR_CURRENT_CATALOG:
+        case SQL_ATTR_TRACEFILE:
+        case SQL_ATTR_TRANSLATE_LIB:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool OdbcHelper::IsStringDescField(const SQLSMALLINT field_identifier) {
+    switch (field_identifier) {
+        case SQL_DESC_BASE_COLUMN_NAME:
+        case SQL_DESC_BASE_TABLE_NAME:
+        case SQL_DESC_CATALOG_NAME:
+        case SQL_DESC_LABEL:
+        case SQL_DESC_LITERAL_PREFIX:
+        case SQL_DESC_LITERAL_SUFFIX:
+        case SQL_DESC_LOCAL_TYPE_NAME:
+        case SQL_DESC_NAME:
+        case SQL_DESC_SCHEMA_NAME:
+        case SQL_DESC_TABLE_NAME:
+        case SQL_DESC_TYPE_NAME:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool OdbcHelper::IsStringDiagField(const SQLSMALLINT diag_identifier) {
+    switch (diag_identifier) {
+        case SQL_DIAG_CLASS_ORIGIN:
+        case SQL_DIAG_CONNECTION_NAME:
+        case SQL_DIAG_DYNAMIC_FUNCTION:
+        case SQL_DIAG_MESSAGE_TEXT:
+        case SQL_DIAG_SERVER_NAME:
+        case SQL_DIAG_SQLSTATE:
+        case SQL_DIAG_SUBCLASS_ORIGIN:
+            return true;
+        default:
+            return false;
+    }
 }

--- a/driver/util/odbc_helper.cpp
+++ b/driver/util/odbc_helper.cpp
@@ -174,6 +174,14 @@ std::string OdbcHelper::GetSqlStateAndLogMessage(DBC* dbc) {
 }
 
 // Convert base driver output to either 2-byte or 4-byte output for the client application
+void OdbcHelper::ConvertDriverOutputToTarget(
+    const SQLTCHAR* src,
+    SQLTCHAR* dst,
+    const size_t dst_char_count) const
+{
+    ConvertDriverOutputToTarget(false, src, dst, dst_char_count);
+}
+
 // codechecker_suppress [readability-convert-member-functions-to-static]
 void OdbcHelper::ConvertDriverOutputToTarget(
     const bool wrapper_call,
@@ -203,6 +211,14 @@ void OdbcHelper::ConvertDriverOutputToTarget(
 
 // Convert wrapper output to either 2-byte or 4-byte output for the client application
 void OdbcHelper::ConvertWrapperOutputToTarget(
+    SQLTCHAR* buf,
+    const size_t char_count,
+    const size_t buf_elements) const
+{
+    ConvertWrapperOutputToTarget(false, buf, char_count, buf_elements);
+}
+
+void OdbcHelper::ConvertWrapperOutputToTarget(
     const bool wrapper_call,
     SQLTCHAR* buf,
     const size_t char_count,
@@ -217,10 +233,9 @@ void OdbcHelper::ConvertWrapperOutputToTarget(
 }
 
 // codechecker_suppress [readability-convert-member-functions-to-static]
-bool OdbcHelper::NeedsConversion(const bool wrapper_call) const {
+bool OdbcHelper::NeedsConversion() const {
 #if UNICODE
-    const bool user_4_byte = !wrapper_call && use_4_bytes_user_app_;
-    return user_4_byte != use_4_bytes_base_driver_;
+    return use_4_bytes_user_app_ != use_4_bytes_base_driver_;
 #else
     return false;
 #endif

--- a/driver/util/odbc_helper.cpp
+++ b/driver/util/odbc_helper.cpp
@@ -172,3 +172,63 @@ std::string OdbcHelper::GetSqlStateAndLogMessage(DBC* dbc) {
     LOG(WARNING) << "SQL State: " << AS_UTF8_CSTR(sql_state) << ". Message: " << AS_UTF8_CSTR(message);
     return AS_UTF8_CSTR(sql_state);
 }
+
+// Convert base driver output to either 2-byte or 4-byte output for the client application
+// codechecker_suppress [readability-convert-member-functions-to-static]
+void OdbcHelper::ConvertDriverOutputToTarget(
+    const bool wrapper_call,
+    const SQLTCHAR* src,
+    SQLTCHAR* dst,
+    const size_t dst_char_count) const
+{
+#if UNICODE
+    const bool user_4_byte = !wrapper_call && use_4_bytes_user_app_;
+
+    if (user_4_byte && use_4_bytes_base_driver_) {
+        // Both the client application and the base driver use 4-byte data.
+        // Copy the data as-is.
+        std::memcpy(dst, src, dst_char_count * 2 * sizeof(SQLTCHAR));
+    } else if (user_4_byte) {
+        // Expand the driver output from 2-byte to 4-byte for the client application.
+        ConvertUTF16ToUTF32(src, dst, dst_char_count > 0 ? dst_char_count - 1 : 0, dst_char_count * 2);
+    } else {
+        // Narrow driver output from 4-byte to 2-byte for the client application.
+        // Or copy as-is if both are 2-byte.
+        Convert4To2ByteString(use_4_bytes_base_driver_, const_cast<SQLTCHAR*>(src), dst, dst_char_count);
+    }
+#else
+    std::memcpy(dst, src, dst_char_count * sizeof(SQLTCHAR));
+#endif
+}
+
+// Convert wrapper output to either 2-byte or 4-byte output for the client application
+void OdbcHelper::ConvertWrapperOutputToTarget(
+    const bool wrapper_call,
+    SQLTCHAR* buf,
+    const size_t char_count,
+    const size_t buf_elements) const
+{
+#if UNICODE
+    // Wrapper output is already in 2-bytes. Only need to expand if client application requires 4-bytes.
+    if (!wrapper_call && use_4_bytes_user_app_) {
+        ExpandUTF16ToUTF32InPlace(buf, char_count, buf_elements);
+    }
+#endif
+}
+
+// codechecker_suppress [readability-convert-member-functions-to-static]
+bool OdbcHelper::NeedsConversion(const bool wrapper_call) const {
+#if UNICODE
+    const bool user_4_byte = !wrapper_call && use_4_bytes_user_app_;
+    return user_4_byte != use_4_bytes_base_driver_;
+#else
+    return false;
+#endif
+}
+
+std::vector<SQLTCHAR> OdbcHelper::AllocateConversionBuffer(const size_t char_count) const {
+    const size_t local_buf_size = use_4_bytes_base_driver_
+        ? char_count * 2
+        : char_count;
+    return std::vector<SQLTCHAR>(local_buf_size, 0);
+}

--- a/driver/util/odbc_helper.h
+++ b/driver/util/odbc_helper.h
@@ -65,6 +65,16 @@ public:
 
     virtual std::string GetSqlStateAndLogMessage(DBC *dbc);
 
+    void ConvertDriverOutputToTarget(bool wrapper_call, const SQLTCHAR* src, SQLTCHAR* dst, size_t dst_char_count) const;
+    void ConvertWrapperOutputToTarget(bool wrapper_call, SQLTCHAR* buf, size_t char_count, size_t buf_elements) const;
+
+    // Returns true if driver and user app character widths differ and conversion is needed.
+    bool NeedsConversion(bool wrapper_call) const;
+
+    // Returns an appropriately sized intermediate buffer for driver output conversion.
+    // Caller should check NeedsConversion() first.
+    std::vector<SQLTCHAR> AllocateConversionBuffer(size_t char_count) const;
+
 private:
     std::shared_ptr<RdsLibLoader> lib_loader_;
     bool use_4_bytes_base_driver_ = false;

--- a/driver/util/odbc_helper.h
+++ b/driver/util/odbc_helper.h
@@ -65,18 +65,22 @@ public:
 
     virtual std::string GetSqlStateAndLogMessage(DBC *dbc);
 
-    void ConvertDriverOutputToTarget(const SQLTCHAR* src, SQLTCHAR* dst, size_t dst_char_count) const;
-    void ConvertDriverOutputToTarget(bool wrapper_call, const SQLTCHAR* src, SQLTCHAR* dst, size_t dst_char_count) const;
+    void ConvertDriverOutputToTarget(const SQLTCHAR* src, SQLTCHAR* dst, size_t dst_byte_count) const;
+    void ConvertDriverOutputToTarget(bool wrapper_call, const SQLTCHAR* src, SQLTCHAR* dst, size_t dst_byte_count) const;
 
-    void ConvertWrapperOutputToTarget(SQLTCHAR* buf, size_t char_count, size_t buf_elements) const;
-    void ConvertWrapperOutputToTarget(bool wrapper_call, SQLTCHAR* buf, size_t char_count, size_t buf_elements) const;
+    void ConvertWrapperOutputToTarget(SQLTCHAR* buf, size_t char_count, size_t buf_byte_count) const;
+    void ConvertWrapperOutputToTarget(bool wrapper_call, SQLTCHAR* buf, size_t char_count, size_t buf_byte_count) const;
 
     // Returns true if driver and user app character widths differ and conversion is needed.
     bool NeedsConversion() const;
 
     // Returns an appropriately sized intermediate buffer for driver output conversion.
     // Caller should check NeedsConversion() first.
-    std::vector<SQLTCHAR> AllocateConversionBuffer(size_t char_count) const;
+    std::vector<SQLTCHAR> AllocateConversionBuffer(size_t byte_count) const;
+
+    static bool IsStringConnectAttr(SQLINTEGER attribute);
+    static bool IsStringDescField(SQLSMALLINT field_identifier);
+    static bool IsStringDiagField(SQLSMALLINT diag_identifier);
 
 private:
     std::shared_ptr<RdsLibLoader> lib_loader_;

--- a/driver/util/odbc_helper.h
+++ b/driver/util/odbc_helper.h
@@ -65,11 +65,14 @@ public:
 
     virtual std::string GetSqlStateAndLogMessage(DBC *dbc);
 
+    void ConvertDriverOutputToTarget(const SQLTCHAR* src, SQLTCHAR* dst, size_t dst_char_count) const;
     void ConvertDriverOutputToTarget(bool wrapper_call, const SQLTCHAR* src, SQLTCHAR* dst, size_t dst_char_count) const;
+
+    void ConvertWrapperOutputToTarget(SQLTCHAR* buf, size_t char_count, size_t buf_elements) const;
     void ConvertWrapperOutputToTarget(bool wrapper_call, SQLTCHAR* buf, size_t char_count, size_t buf_elements) const;
 
     // Returns true if driver and user app character widths differ and conversion is needed.
-    bool NeedsConversion(bool wrapper_call) const;
+    bool NeedsConversion() const;
 
     // Returns an appropriately sized intermediate buffer for driver output conversion.
     // Caller should check NeedsConversion() first.


### PR DESCRIPTION
### Summary

Added new methods to ensure wrapper outputs results to user application in the correct encoding

### Description

Added methods
- NeedsConversion - check if base driver and user application has the same encoding
- AllocateConversionBuffer - allocate an intermediate buffer in case we need to shrink or expand src from 2-bytes to dst's 4 bytes and vice version
- ConvertDriverOutputToTarget - converts the base driver output to the target encoding
- ConvertWrapperOutputToTarget - converts the wrapper output to the target encoding


### Testing

Tested the following methods in the listed env on MacOS:

| API                       | Wrapper                | Community              | Match
| ------------------------- | ---------------------- | ---------------------- | -----
| SQLColumns                | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLTables                 | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLColumnPrivileges       | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLPrimaryKeys            | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLForeignKeys            | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLStatistics             | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLSpecialColumns         | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLTablePrivileges        | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLProcedures             | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLProcedureColumns       | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLPrepare                | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLSetCursorName          | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLNativeSql              | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLGetConnectAttr(CATALOG) | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLGetConnectAttr(AUTOCOMMIT) | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLSetConnectAttr(CATALOG) | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLGetStmtAttr(QUERY_TIMEOUT) | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLSetStmtAttr(QUERY_TIMEOUT) | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLGetDescField(COUNT)    | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLSetDescField(ARRAY_SIZE) | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLGetInfo(DBMS_NAME)     | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLGetInfo(DBMS_VER)      | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLGetInfo(DRIVER_NAME)   | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLGetInfo(MAX_COLS_SELECT) | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLGetDiagField(SQLSTATE) | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLGetDiagField(MSG_TEXT) | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLGetDiagField(CLASS_ORIGIN) | SUCCESS (0)            | SUCCESS (0)            | OK
| SQLGetDiagField(NUMBER)   | SUCCESS (0)            | SUCCESS (0)            | OK

|                    |                            | **Underlying Driver**      |                                        |
|--------------------|----------------------------|----------------------------|----------------------------------------|
|                    |                            | psqlodbc (2-byte SQLWCHAR) | mysql-odbc-connector (4-byte SQLWCHAR) |
| **Driver Manager** | UnixODBC (2-Byte SQLWCHAR) | ✅                          | ✅                                      |
|                    | iodbc (4-Byte SQLWCHAR)    | ✅                          | ✅                                      |


### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
