### PR TITLE
fix: monitor skip plugins

### DIFF
--- a/driver/plugin/custom_endpoint/custom_endpoint_plugin.cpp
+++ b/driver/plugin/custom_endpoint/custom_endpoint_plugin.cpp
@@ -92,6 +92,9 @@ SQLRETURN CustomEndpointPlugin::Connect(
 {
     LOG(INFO) << "Entering Connect";
     const DBC* dbc = static_cast<DBC*>(ConnectionHandle);
+    if (dbc->conn_attr.contains(KEY_MONITORING_CONN_UUID)) {
+        return next_plugin->Connect(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
+    }
 
     const std::string host = MapUtils::GetStringValue(dbc->conn_attr, KEY_SERVER, "");
 

--- a/driver/plugin/limitless/limitless_plugin.cpp
+++ b/driver/plugin/limitless/limitless_plugin.cpp
@@ -58,6 +58,10 @@ SQLRETURN LimitlessPlugin::Connect(
 {
     LOG(INFO) << "Entering Connect";
     DBC* dbc = static_cast<DBC*>(ConnectionHandle);
+    if (dbc->conn_attr.contains(KEY_MONITORING_CONN_UUID)) {
+        return next_plugin->Connect(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLengthPtr, DriverCompletion);
+    }
+
     const std::shared_ptr<DialectLimitless> limitless_dialect = std::dynamic_pointer_cast<DialectLimitless>(this->dialect_);
     if (!limitless_dialect) {
         LOG(ERROR) << "The limitless connection plugin does not support the current dialect or database";


### PR DESCRIPTION
### Summary

Add Plugin Checks for Monitor Skippable

### Description

Additional defensive step to ensure monitoring connections don't use unnecessary plugins 

### Testing

<!-- What did you test and how did you test it -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
