### PR TITLE
fix: integration null checks

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -351,10 +351,13 @@ jobs:
             Get-OdbcDsn | Format-Table Name, DriverName, DsnType, Platform
             Write-Host "Ansi DSN properties:"
             Get-OdbcDsn -Name ${{ env.TEST_DSN_ANSI }} | Select-Object -ExpandProperty PropertyValue
-      - name: Setup GDB
+      - name: Setup Debugger
+        shell: pwsh
         run: |
-          choco install mingw
-          echo "set auto-load safe-path /" > "$HOME/.gdbinit"
+          $cdb = (Get-ChildItem "C:\Program Files (x86)\Windows Kits\*\Debuggers\x64\cdb.exe" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
+          if (-not $cdb) { Write-Error "cdb.exe not found"; exit 1 }
+          echo "CDB_PATH=$cdb" >> $env:GITHUB_ENV
+          Write-Host "Found cdb at: $cdb"
       - name: Build and Run Ansi Integration Tests
         shell: pwsh
         if: ${{steps.AuroraClusterSetup.outcome == 'success'}}
@@ -363,7 +366,8 @@ jobs:
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF
           cmake --build build_ansi --config ${{env.BUILD_CONFIG}}
           echo "Ansi Test Built"
-          gdb -q -x ./.gdbinit .\build_ansi\${{env.BUILD_CONFIG}}\integration-test.exe
+          @(".symfix+", 'sxe -c ".echo --- CRASH STACK ---;~* kvn;.echo --- END CRASH STACK ---;g" av', "g") | Set-Content -Path cdb_cmd.txt
+          & "${{env.CDB_PATH}}" -G -lines -y ".\build_ansi\${{env.BUILD_CONFIG}}" -cf cdb_cmd.txt .\build_ansi\${{env.BUILD_CONFIG}}\integration-test.exe
         env:
           TEST_DSN: ${{ env.TEST_DSN_ANSI }}
           TEST_DATABASE: ${{ env.TEST_DATABASE }}
@@ -384,7 +388,8 @@ jobs:
             -D BUILD_UNICODE=ON -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF
           cmake --build build_unicode --config ${{env.BUILD_CONFIG}}
           echo "Unicode Test Built"
-          gdb -q -x ./.gdbinit .\build_unicode\${{env.BUILD_CONFIG}}\integration-test.exe
+          @(".symfix+", 'sxe -c ".echo --- CRASH STACK ---;~* kvn;.echo --- END CRASH STACK ---;g" av', "g") | Set-Content -Path cdb_cmd.txt
+          & "${{env.CDB_PATH}}" -G -lines -y ".\build_unicode\${{env.BUILD_CONFIG}}" -cf cdb_cmd.txt .\build_unicode\${{env.BUILD_CONFIG}}\integration-test.exe
         env:
           TEST_DSN: ${{ env.TEST_DSN_UNICODE }}
           TEST_DATABASE: ${{ env.TEST_DATABASE }}
@@ -931,10 +936,13 @@ jobs:
             Get-OdbcDsn | Format-Table Name, DriverName, DsnType, Platform
             Write-Host "Ansi DSN properties:"
             Get-OdbcDsn -Name ${{ env.TEST_DSN_ANSI }} | Select-Object -ExpandProperty PropertyValue
-      - name: Setup GDB
+      - name: Setup Debugger
+        shell: pwsh
         run: |
-          choco install mingw
-          echo "set auto-load safe-path /" > "$HOME/.gdbinit"
+          $cdb = (Get-ChildItem "C:\Program Files (x86)\Windows Kits\*\Debuggers\x64\cdb.exe" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1).FullName
+          if (-not $cdb) { Write-Error "cdb.exe not found"; exit 1 }
+          echo "CDB_PATH=$cdb" >> $env:GITHUB_ENV
+          Write-Host "Found cdb at: $cdb"
       - name: Build and Run Limitless Ansi Integration Tests
         shell: pwsh
         if: ${{steps.AuroraClusterSetup.outcome == 'success'}}
@@ -943,7 +951,8 @@ jobs:
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=OFF -D BUILD_LIMITLESS=ON 
           cmake --build build_limitless_ansi --config ${{env.BUILD_CONFIG}}
           echo "Limitless Ansi Test Built"
-          gdb -q -x ./.gdbinit .\build_limitless_ansi\${{env.BUILD_CONFIG}}\integration-test.exe
+          @(".symfix+", 'sxe -c ".echo --- CRASH STACK ---;~* kvn;.echo --- END CRASH STACK ---;g" av', "g") | Set-Content -Path cdb_cmd.txt
+          & "${{env.CDB_PATH}}" -G -lines -y ".\build_limitless_ansi\${{env.BUILD_CONFIG}}" -cf cdb_cmd.txt .\build_limitless_ansi\${{env.BUILD_CONFIG}}\integration-test.exe
         env:
           TEST_DSN: ${{ env.TEST_DSN_ANSI }}
           TEST_DATABASE: ${{ env.TEST_LIMITLESS_DATABASE }}
@@ -963,7 +972,8 @@ jobs:
             -D BUILD_UNICODE=ON -D BUILD_FAILOVER=OFF -D BUILD_LIMITLESS=ON 
           cmake --build build_limitless_unicode --config ${{env.BUILD_CONFIG}}
           echo "Limitless Unicode Test Built"
-          gdb -q -x ./.gdbinit .\build_limitless_unicode\${{env.BUILD_CONFIG}}\integration-test.exe
+          @(".symfix+", 'sxe -c ".echo --- CRASH STACK ---;~* kvn;.echo --- END CRASH STACK ---;g" av', "g") | Set-Content -Path cdb_cmd.txt
+          & "${{env.CDB_PATH}}" -G -lines -y ".\build_limitless_unicode\${{env.BUILD_CONFIG}}" -cf cdb_cmd.txt .\build_limitless_unicode\${{env.BUILD_CONFIG}}\integration-test.exe
         env:
           TEST_DSN: ${{ env.TEST_DSN_UNICODE }}
           TEST_DATABASE: ${{ env.TEST_LIMITLESS_DATABASE }}

--- a/test/common/base_connection_test.h
+++ b/test/common/base_connection_test.h
@@ -45,8 +45,8 @@ protected:
 
     std::string conn_str = "";
 
-    SQLHENV env = nullptr;
-    SQLHDBC dbc = nullptr;
+    SQLHENV env = SQL_NULL_HENV;
+    SQLHDBC dbc = SQL_NULL_HDBC;
 
     static void SetUpTestSuite() {}
     static void TearDownTestSuite() {}

--- a/test/common/connection_string_builder.h
+++ b/test/common/connection_string_builder.h
@@ -20,157 +20,157 @@
 class ConnectionStringBuilder {
 public:
     ConnectionStringBuilder(const std::string& dsn, const std::string& server, int port) {
-        length += sprintf(conn_in, "DSN=%s;SERVER=%s;PORT=%d;SSLMODE=prefer;COMMLOG=1;DEBUG=1;LOGDIR=logs/;", dsn.c_str(), server.c_str(), port);
+        conn_str_ = "DSN=" + dsn + ";SERVER=" + server + ";PORT=" + std::to_string(port) + ";SSLMODE=prefer;COMMLOG=1;DEBUG=1;LOGDIR=logs/;";
     }
 
-    ConnectionStringBuilder(const std::string& str) { length += sprintf(conn_in, "%s", str.c_str()); }
+    ConnectionStringBuilder(const std::string& str) : conn_str_(str) {}
 
     ConnectionStringBuilder& withUID(const std::string& uid) {
-        length += sprintf(conn_in + length, "UID=%s;", uid.c_str());
+        conn_str_ += "UID=" + uid + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withPWD(const std::string& pwd) {
-        length += sprintf(conn_in + length, "PWD=%s;", pwd.c_str());
+        conn_str_ += "PWD=" + pwd + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withDatabase(const std::string& db) {
-        length += sprintf(conn_in + length, "DATABASE=%s;", db.c_str());
+        conn_str_ += "DATABASE=" + db + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withBaseDriver(const std::string& driver) {
-        length += sprintf(conn_in + length, "BASE_DRIVER=%s;", driver.c_str());
+        conn_str_ += "BASE_DRIVER=" + driver + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withBaseDSN(const std::string& dsn) {
-        length += sprintf(conn_in + length, "BASE_DSN=%s;", dsn.c_str());
+        conn_str_ += "BASE_DSN=" + dsn + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withDatabaseDialect(const std::string& dialect) {
-        length += sprintf(conn_in + length, "DATABASE_DIALECT=%s;", dialect.c_str());
+        conn_str_ += "DATABASE_DIALECT=" + dialect + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withEnableClusterFailover(const bool& enable_cluster_failover) {
-        length += sprintf(conn_in + length, "ENABLE_CLUSTER_FAILOVER=%d;", enable_cluster_failover ? 1 : 0);
+        conn_str_ += "ENABLE_CLUSTER_FAILOVER=" + std::to_string(enable_cluster_failover ? 1 : 0) + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withFailoverMode(const std::string& failover_mode) {
-        length += sprintf(conn_in + length, "FAILOVER_MODE=%s;", failover_mode.c_str());
+        conn_str_ += "FAILOVER_MODE=" + failover_mode + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withReaderHostSelectorStrategy(const std::string& strategy) {
-        length += sprintf(conn_in + length, "HOST_SELECTOR_STRATEGY=%s;", strategy.c_str());
+        conn_str_ += "HOST_SELECTOR_STRATEGY=" + strategy + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withIgnoreTopologyRequest(const int& ignore_topology_request) {
-        length += sprintf(conn_in + length, "IGNORE_TOPOLOGY_REQUEST_MS=%d;", ignore_topology_request);
+        conn_str_ += "IGNORE_TOPOLOGY_REQUEST_MS=" + std::to_string(ignore_topology_request) + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withTopologyHighRefreshRate(const int& topology_high_refresh_rate) {
-        length += sprintf(conn_in + length, "TOPOLOGY_HIGH_REFRESH_RATE_MS=%d;", topology_high_refresh_rate);
+        conn_str_ += "TOPOLOGY_HIGH_REFRESH_RATE_MS=" + std::to_string(topology_high_refresh_rate) + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withTopologyRefreshRate(const int& topology_refresh_rate) {
-        length += sprintf(conn_in + length, "TOPOLOGY_REFRESH_RATE_MS=%d;", topology_refresh_rate);
+        conn_str_ += "TOPOLOGY_REFRESH_RATE_MS=" + std::to_string(topology_refresh_rate) + ";";
         return *this;
     }
+
     ConnectionStringBuilder& withFailoverTimeout(const int& failover_t) {
-        length += sprintf(conn_in + length, "FAILOVER_TIMEOUT_MS=%d;", failover_t);
+        conn_str_ += "FAILOVER_TIMEOUT_MS=" + std::to_string(failover_t) + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withHostPattern(const std::string& host_pattern) {
-        length += sprintf(conn_in + length, "HOST_PATTERN=%s;", host_pattern.c_str());
+        conn_str_ += "HOST_PATTERN=" + host_pattern + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withAuthMode(const std::string& auth_mode) {
-        length += sprintf(conn_in + length, "RDS_AUTH_TYPE=%s;", auth_mode.c_str());
+        conn_str_ += "RDS_AUTH_TYPE=" + auth_mode + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withAuthRegion(const std::string& auth_region) {
-        length += sprintf(conn_in + length, "REGION=%s;", auth_region.c_str());
+        conn_str_ += "REGION=" + auth_region + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withAuthExpiration(const int& auth_expiration) {
-        length += sprintf(conn_in + length, "TOKEN_EXPIRATION=%d;", auth_expiration);
+        conn_str_ += "TOKEN_EXPIRATION=" + std::to_string(auth_expiration) + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withIamHost(const std::string& iam_host) {
-        length += sprintf(conn_in + length, "IAM_HOST=%s;", iam_host.c_str());
+        conn_str_ += "IAM_HOST=" + iam_host + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withSecretId(const std::string& secret_id) {
-        length += sprintf(conn_in + length, "SECRET_ID=%s;", secret_id.c_str());
+        conn_str_ += "SECRET_ID=" + secret_id + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withLimitlessEnabled(const bool& limitless_enabled) {
-        length += sprintf(conn_in + length, "ENABLE_LIMITLESS=%d;", limitless_enabled ? 1 : 0);
+        conn_str_ += "ENABLE_LIMITLESS=" + std::to_string(limitless_enabled ? 1 : 0) + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withLimitlessMode(const std::string& limitless_mode) {
-        length += sprintf(conn_in + length, "LIMITLESS_MODE=%s;", limitless_mode.c_str());
+        conn_str_ += "LIMITLESS_MODE=" + limitless_mode + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withLimitlessMonitorIntervalMs(const int& interval) {
-        length += sprintf(conn_in + length, "LIMITLESS_MONITOR_INTERVAL_MS=%d;", interval);
+        conn_str_ += "LIMITLESS_MONITOR_INTERVAL_MS=" + std::to_string(interval) + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withExtraUrlEncode(const bool& with_encode) {
-        length += sprintf(conn_in + length, "EXTRA_URL_ENCODE=%d;", with_encode ? 1 : 0);
+        conn_str_ += "EXTRA_URL_ENCODE=" + std::to_string(with_encode ? 1 : 0) + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withSslMode(const std::string& ssl_mode) {
-        length += sprintf(conn_in + length, "SSLMODE=%s;", ssl_mode.c_str());
+        conn_str_ += "SSLMODE=" + ssl_mode + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withCustomEndpoint(const bool& custom_endpoint_enabled) {
-        length += sprintf(conn_in + length, "ENABLE_CUSTOM_ENDPOINT=%d;", custom_endpoint_enabled ? 1 : 0);
+        conn_str_ += "ENABLE_CUSTOM_ENDPOINT=" + std::to_string(custom_endpoint_enabled ? 1 : 0) + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withAuroraInitialConnectionStrategy(const bool& aurora_initial_connection_strategy_enabled) {
-        length += sprintf(conn_in + length, "ENABLE_AURORA_INITIAL_CONNECTION_STRATEGY=%d;", aurora_initial_connection_strategy_enabled ? 1 : 0);
+        conn_str_ += "ENABLE_AURORA_INITIAL_CONNECTION_STRATEGY=" + std::to_string(aurora_initial_connection_strategy_enabled ? 1 : 0) + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withVerifyInitialConnectionType(const std::string& connection_type) {
-        length += sprintf(conn_in + length, "VERIFY_INITIAL_CONNECTION_TYPE=%s;", connection_type.c_str());
+        conn_str_ += "VERIFY_INITIAL_CONNECTION_TYPE=" + connection_type + ";";
         return *this;
     }
 
     ConnectionStringBuilder& withClusterId(const std::string& cluster_id) {
-        length += sprintf(conn_in + length, "CLUSTER_ID=%s;", cluster_id.c_str());
+        conn_str_ += "CLUSTER_ID=" + cluster_id + ";";
         return *this;
     }
 
     std::string getString() const {
-        return conn_in;
+        return conn_str_;
     }
 
 private:
-    char conn_in[4096] = {0};
-    int length = 0;
+    std::string conn_str_;
 };
 
 #endif  // CONNECTION_STRING_BUILDER_H_

--- a/test/common/odbc_helper.cpp
+++ b/test/common/odbc_helper.cpp
@@ -26,6 +26,10 @@
 #include "../common/string_helper.h"
 
 SQLRETURN ODBC_HELPER::DriverConnect(SQLHDBC hdbc, std::string conn_str) {
+    if (hdbc == SQL_NULL_HDBC) {
+        std::cout << "DriverConnect: null hdbc handle" << std::endl;
+        return SQL_INVALID_HANDLE;
+    }
     std::cout << "Connecting to: " << conn_str << std::endl;
 
     SQLTCHAR conn_str_in[STRING_HELPER::MAX_SQLCHAR] = { 0 };
@@ -75,6 +79,10 @@ void ODBC_HELPER::CleanUpHandles(SQLHENV henv, SQLHDBC hdbc, SQLHSTMT hstmt) {
 }
 
 SQLRETURN ODBC_HELPER::ExecuteQuery(SQLHSTMT stmt, std::string query) {
+    if (stmt == SQL_NULL_HSTMT) {
+        std::cout << "ExecuteQuery: null stmt handle" << std::endl;
+        return SQL_INVALID_HANDLE;
+    }
     SQLTCHAR buffer[STRING_HELPER::MAX_SQLCHAR] = { 0 };
     STRING_HELPER::AnsiToUnicode(query.c_str(), buffer);
 
@@ -96,7 +104,7 @@ void ODBC_HELPER::PrintHandleError(SQLHANDLE handle, int32_t handle_type) {
 
     do {
         recno++;
-        ret = SQLGetDiagRec(handle_type, handle, recno, sqlstate, &native_error, message, sizeof(message), &textlen);
+        ret = SQLGetDiagRec(handle_type, handle, recno, sqlstate, &native_error, message, sizeof(message) / sizeof(SQLTCHAR), &textlen);
         if (ret == SQL_INVALID_HANDLE) {
             std::cout << "Invalid handle" << std::endl;
         } else if (SQL_SUCCEEDED(ret)) {

--- a/test/common/string_helper.cpp
+++ b/test/common/string_helper.cpp
@@ -24,7 +24,7 @@
 
 void STRING_HELPER::AnsiToUnicode(const char* in, SQLTCHAR* out) {
     int i;
-    for (i = 0; in[i]; i++) {
+    for (i = 0; in[i] && i < MAX_SQLCHAR - 1; i++) {
         out[i] = in[i];
     }
     out[i] = 0;

--- a/test/common/test_utils.cpp
+++ b/test/common/test_utils.cpp
@@ -37,8 +37,8 @@
 
 std::string TEST_UTILS::GetEnvVar(const char* key, const char* default_value) {
     char* value = std::getenv(key);
-    if (value == nullptr || value == "") {
-        if (default_value == "") {
+    if (value == nullptr || value[0] == '\0') {
+        if (default_value[0] != '\0') {
             std::cout << "Unable to get environment variable for: " << key << ", using default: " << default_value << std::endl;
         }
 
@@ -64,7 +64,7 @@ std::string TEST_UTILS::HostToIp(std::string hostname) {
     struct addrinfo hints;
     struct addrinfo* servinfo;
     struct addrinfo* p;
-    char ipstr[INET_ADDRSTRLEN];
+    char ipstr[INET_ADDRSTRLEN] = {0};
 
     ClearMemory(&hints, sizeof(hints));
     hints.ai_family = AF_INET; //IPv4

--- a/test/compatibility/odbc_api_test.cpp
+++ b/test/compatibility/odbc_api_test.cpp
@@ -108,7 +108,7 @@ auto GetErrorMessage = [](SQLSMALLINT handle_type, SQLHANDLE handle, SQLRETURN o
     SQLTCHAR sql_state[MAX_SQL_STATE_LEN], message[MAX_SQL_MESSAGE_LEN];
     SQLINTEGER native_error;
     SQLSMALLINT msg_len;
-    SQLRETURN diag_ret = SQLGetDiagRec(handle_type, handle, 1, sql_state, &native_error, message, sizeof(message), &msg_len);
+    SQLRETURN diag_ret = SQLGetDiagRec(handle_type, handle, 1, sql_state, &native_error, message, sizeof(message) / sizeof(SQLTCHAR), &msg_len);
     if (SQL_SUCCESS == diag_ret) {
         return std::string("Error: ") + STRING_HELPER::SqltcharToAnsi(sql_state) + " - " + STRING_HELPER::SqltcharToAnsi(message);
     }

--- a/test/integration/aurora_initial_connection_strategy_integration_test.cpp
+++ b/test/integration/aurora_initial_connection_strategy_integration_test.cpp
@@ -52,6 +52,9 @@ protected:
         rds_client = Aws::RDS::RDSClient(credentials, client_config);
 
         cluster_instances = GetTopologyViaSdk(rds_client, cluster_id);
+        if (cluster_instances.empty()) {
+            GTEST_SKIP() << "No cluster instances found";
+        }
     }
 
     void TearDown() override {

--- a/test/integration/base_failover_integration_test.h
+++ b/test/integration/base_failover_integration_test.h
@@ -62,11 +62,10 @@ constexpr auto MAX_SQLSTATE_LENGTH = 6;
 class BaseFailoverIntegrationTest : public BaseConnectionTest {
 protected:
     std::string cluster_prefix = ".cluster-";
-    std::string cluster_id = test_server.substr(0, test_server.find('.'));
-    std::string instance_endpoint =
-        test_server.substr(test_server.find(cluster_prefix) + cluster_prefix.size(), test_server.size());
-    std::string db_conn_str_suffix = "." + instance_endpoint;
-    std::string cluster_ro_url = ".cluster-ro-" + instance_endpoint;
+    std::string cluster_id;
+    std::string instance_endpoint;
+    std::string db_conn_str_suffix;
+    std::string cluster_ro_url;
 
     std::vector<std::string> cluster_instances;
     std::string writer_id;
@@ -158,28 +157,44 @@ protected:
 
     // ODBC Query Helpers
     void AssertQueryFail(const SQLHDBC dbc, std::string query, const std::string& expected_error) const {
-        SQLHSTMT hstmt;
+        SQLHSTMT hstmt = SQL_NULL_HSTMT;
         SQLSMALLINT stmt_length;
         SQLINTEGER native_err;
-        SQLTCHAR msg[MAX_CONN_LENGTH], state[MAX_SQLSTATE_LENGTH];
+        SQLTCHAR msg[MAX_CONN_LENGTH] = {0}, state[MAX_SQLSTATE_LENGTH] = {0};
 
-        EXPECT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_STMT, dbc, &hstmt));
+        SQLRETURN alloc_rc = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &hstmt);
+        if (alloc_rc != SQL_SUCCESS) {
+            ADD_FAILURE() << "AssertQueryFail: SQLAllocHandle failed with rc=" << alloc_rc;
+            return;
+        }
         EXPECT_EQ(SQL_ERROR, ODBC_HELPER::ExecuteQuery(hstmt, query));
-        EXPECT_EQ(SQL_SUCCESS, SQLError(nullptr, nullptr, hstmt, state, &native_err, msg, SQL_MAX_MESSAGE_LENGTH - 1, &stmt_length));
+        EXPECT_EQ(SQL_SUCCESS, SQLGetDiagRec(SQL_HANDLE_STMT, hstmt, 1, state, &native_err, msg, SQL_MAX_MESSAGE_LENGTH - 1, &stmt_length));
         EXPECT_STREQ(expected_error.c_str(), STRING_HELPER::SqltcharToAnsi(state));
         EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_STMT, hstmt));
     }
 
     std::string QueryInstanceId(SQLHDBC dbc) const {
-        SQLTCHAR buf[SQL_MAX_MESSAGE_LENGTH] = { 0 };
+        SQLTCHAR buf[SQL_MAX_MESSAGE_LENGTH] = {0};
         SQLLEN buflen;
-        SQLHSTMT hstmt;
-        EXPECT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_STMT, dbc, &hstmt));
-        EXPECT_EQ(SQL_SUCCESS, ODBC_HELPER::ExecuteQuery(hstmt, SERVER_ID_QUERY));
-        EXPECT_EQ(SQL_SUCCESS, SQLFetch(hstmt));
-        EXPECT_EQ(SQL_SUCCESS, SQLGetData(hstmt, 1, SQL_C_TCHAR, buf, SQL_MAX_MESSAGE_LENGTH, &buflen));
-        EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_STMT, hstmt));
-        return std::string(STRING_HELPER::SqltcharToAnsi(buf));
+        SQLHSTMT hstmt = SQL_NULL_HANDLE;
+        std::string result;
+
+        if (SQLAllocHandle(SQL_HANDLE_STMT, dbc, &hstmt) != SQL_SUCCESS) {
+            ADD_FAILURE() << "QueryInstanceId: SQLAllocHandle failed";
+            return result;
+        }
+
+        if (ODBC_HELPER::ExecuteQuery(hstmt, SERVER_ID_QUERY) == SQL_SUCCESS &&
+            SQLFetch(hstmt) == SQL_SUCCESS &&
+            SQLGetData(hstmt, 1, SQL_C_TCHAR, buf, sizeof(buf), &buflen) == SQL_SUCCESS)
+        {
+            result = STRING_HELPER::SqltcharToAnsi(buf);
+        } else {
+            ADD_FAILURE() << "QueryInstanceId: query failed";
+        }
+
+        SQLFreeHandle(SQL_HANDLE_STMT, hstmt);
+        return result;
     }
 
     int QueryCountTableRows(const SQLHSTMT handle) {
@@ -214,6 +229,9 @@ protected:
         }
 
         const auto result = outcome.GetResult();
+        if (result.GetDBClusters().empty()) {
+            throw std::runtime_error("GetTopologyViaSdk: No clusters returned");
+        }
         const Aws::RDS::Model::DBCluster cluster = result.GetDBClusters()[0];
 
         for (const auto& instance : cluster.GetDBClusterMembers()) {
@@ -236,7 +254,13 @@ protected:
         Aws::RDS::Model::DescribeDBClustersRequest rds_req;
         rds_req.WithDBClusterIdentifier(cluster_id);
         auto outcome = client.DescribeDBClusters(rds_req);
+        if (!outcome.IsSuccess()) {
+            throw std::runtime_error("GetDbCluster: DescribeDBClusters failed");
+        }
         const auto result = outcome.GetResult();
+        if (result.GetDBClusters().empty()) {
+            throw std::runtime_error("GetDbCluster: No clusters found");
+        }
         return result.GetDBClusters().at(0);
     }
 
@@ -253,7 +277,14 @@ protected:
         Aws::RDS::Model::DescribeDBClusterEndpointsRequest request;
         request.SetDBClusterEndpointIdentifier(endpoint_id);
         const auto response = client.DescribeDBClusterEndpoints(request);
-        return response.GetResult().GetDBClusterEndpoints()[0];
+        if (!response.IsSuccess()) {
+            throw std::runtime_error("GetCustomEndpointInfo: DescribeDBClusterEndpoints failed");
+        }
+        const auto& endpoints = response.GetResult().GetDBClusterEndpoints();
+        if (endpoints.empty()) {
+            throw std::runtime_error("Custom endpoint not found: " + endpoint_id);
+        }
+        return endpoints[0];
     }
 
     static Aws::RDS::Model::DBClusterMember GetDbClusterWriter(const Aws::RDS::RDSClient& client, const Aws::String& cluster_id) {
@@ -291,9 +322,12 @@ protected:
     }
 
     static Aws::String GetRandomDbReaderId(std::vector<std::string> readers) {
+        if (readers.empty()) {
+            throw std::runtime_error("GetRandomDbReaderId: readers list is empty");
+        }
         std::random_device rd;
         std::mt19937 generator(rd());
-        std::uniform_int_distribution<> distribution(0, readers.size() - 1); // define the range of random numbers
+        std::uniform_int_distribution<> distribution(0, static_cast<int>(readers.size()) - 1);
         return readers.at(distribution(generator));
     }
 

--- a/test/integration/custom_endpoint_integration_test.cpp
+++ b/test/integration/custom_endpoint_integration_test.cpp
@@ -56,11 +56,18 @@ protected:
         rds_client = Aws::RDS::RDSClient(credentials, client_config);
 
         cluster_instances = GetTopologyViaSdk(rds_client, cluster_id);
+        if (cluster_instances.empty()) {
+            GTEST_SKIP() << "No cluster instances found";
+        }
         writer_id = GetWriterId(cluster_instances);
 
-        const auto endpoint_info = GetCustomEndpointInfo(rds_client, custom_endpoint_id);
-        custom_endpoint_url = endpoint_info.GetEndpoint();
-        custom_endpoint_members = endpoint_info.GetStaticMembers();
+        try {
+            const auto endpoint_info = GetCustomEndpointInfo(rds_client, custom_endpoint_id);
+            custom_endpoint_url = endpoint_info.GetEndpoint();
+            custom_endpoint_members = endpoint_info.GetStaticMembers();
+        } catch (const std::runtime_error& e) {
+            GTEST_SKIP() << "Custom endpoint not available: " << e.what();
+        }
 
         // Check to see if cluster is available.
         WaitForDbReady(rds_client, cluster_id);

--- a/test/integration/failover_integration_test.cpp
+++ b/test/integration/failover_integration_test.cpp
@@ -51,8 +51,14 @@ protected:
         rds_client = Aws::RDS::RDSClient(credentials, client_config);
 
         cluster_instances = GetTopologyViaSdk(rds_client, cluster_id);
+        if (cluster_instances.empty()) {
+            GTEST_SKIP() << "No cluster instances found";
+        }
         writer_id = GetWriterId(cluster_instances);
         writer_endpoint = GetEndpoint(writer_id);
+        if (cluster_instances.size() < 2) {
+            GTEST_SKIP() << "Failover tests require at least 2 instances (1 writer + 1 reader)";
+        }
         readers = GetReaders(cluster_instances);
         reader_id = GetFirstReaderId(cluster_instances);
         target_writer_id = GetRandomDbReaderId(readers);
@@ -117,7 +123,7 @@ TEST_F(FailoverIntegrationTest, WriterFailWithinTransaction_DisableAutocommit) {
     EXPECT_EQ(SQL_SUCCESS, ODBC_HELPER::DriverConnect(dbc, conn_str));
 
     // Setup tests
-    SQLHSTMT handle;
+    SQLHSTMT handle = SQL_NULL_HSTMT;
     EXPECT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_STMT, dbc, &handle));
 
     // Execute setup query
@@ -167,7 +173,7 @@ TEST_F(FailoverIntegrationTest, WriterFailWithinTransaction_setAutoCommitFalse) 
     EXPECT_EQ(SQL_SUCCESS, ODBC_HELPER::DriverConnect(dbc, conn_str));
 
     // Setup tests
-    SQLHSTMT handle;
+    SQLHSTMT handle = SQL_NULL_HSTMT;
     EXPECT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_STMT, dbc, &handle));
 
     // Execute setup query

--- a/test/integration/limitless_integration_test.cpp
+++ b/test/integration/limitless_integration_test.cpp
@@ -76,6 +76,10 @@ public:
         SQLHSTMT hstmt = SQL_NULL_HSTMT;
 
         ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &hstmt);
+        if (!SQL_SUCCEEDED(ret)) {
+            ADD_FAILURE() << "QueryRouters: SQLAllocHandle failed";
+            return {};
+        }
         SQLTCHAR router_endpoint_value[ROUTER_ENDPOINT_LENGTH] = {0};
         SQLLEN ind_router_endpoint_value = 0;
 
@@ -118,11 +122,15 @@ public:
     }
 
     void LoadThreads(std::string conn_in) {
-        SQLHDBC local_dbc;
-        SQLAllocHandle(SQL_HANDLE_DBC, env, &local_dbc);
+        SQLHENV local_env = SQL_NULL_HENV;
+        SQLHDBC local_dbc = SQL_NULL_HDBC;
+        SQLHSTMT stmt = SQL_NULL_HSTMT;
+
+        SQLAllocHandle(SQL_HANDLE_ENV, nullptr, &local_env);
+        SQLSetEnvAttr(local_env, SQL_ATTR_ODBC_VERSION, reinterpret_cast<SQLPOINTER>(SQL_OV_ODBC3), 0);
+        SQLAllocHandle(SQL_HANDLE_DBC, local_env, &local_dbc);
         ODBC_HELPER::DriverConnect(local_dbc, conn_in);
 
-        SQLHSTMT stmt;
         SQLAllocHandle(SQL_HANDLE_STMT, local_dbc, &stmt);
 
         // Repeated queries within two monitor intervals
@@ -133,7 +141,7 @@ public:
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }
 
-        ODBC_HELPER::CleanUpHandles(SQL_NULL_HENV, local_dbc, stmt);
+        ODBC_HELPER::CleanUpHandles(local_env, local_dbc, stmt);
     }
 
 protected:
@@ -154,7 +162,10 @@ protected:
             .withDatabaseDialect("AURORA_POSTGRESQL_LIMITLESS")
             .withLimitlessEnabled(false)
             .getString();
-        ODBC_HELPER::DriverConnect(dbc, conn_str);
+        SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);
+        if (!SQL_SUCCEEDED(rc)) {
+            GTEST_SKIP() << "Limitless SetUp: Failed to connect to database";
+        }
     }
 
     void TearDown() override {
@@ -179,7 +190,7 @@ TEST_F(LimitlessIntegrationTest, LimitlessImmediate) {
         .withClusterId("LimitlessImmediate")
         .getString();
 
-    SQLHDBC local_dbc = nullptr;
+    SQLHDBC local_dbc = SQL_NULL_HDBC;
     SQLRETURN rc = SQLAllocHandle(SQL_HANDLE_DBC, env, &local_dbc);
     ASSERT_TRUE(SQL_SUCCEEDED(rc));
     rc = ODBC_HELPER::DriverConnect(local_dbc, conn_str);
@@ -204,7 +215,7 @@ TEST_F(LimitlessIntegrationTest, LimitlessLazy) {
         .withClusterId("LimitlessLazy")
         .getString();
 
-    SQLHDBC first_dbc = nullptr;
+    SQLHDBC first_dbc = SQL_NULL_HDBC;
     SQLRETURN rc = SQLAllocHandle(SQL_HANDLE_DBC, env, &first_dbc);
     ASSERT_TRUE(SQL_SUCCEEDED(rc));
     rc = ODBC_HELPER::DriverConnect(first_dbc, conn_str);
@@ -272,8 +283,11 @@ TEST_F(LimitlessIntegrationTest, HeavyLoadInitial) {
 
     std::vector<SQLHDBC> limitless_dbcs;
     int num_limitless_conn = 3;
-    ASSERT_TRUE(round_robin_hosts.size() >= num_limitless_conn);
-    for (int i = 0; num_limitless_conn < 3; i++) {
+    if (round_robin_hosts.size() < static_cast<size_t>(num_limitless_conn)) {
+        for (auto& thread : load_threads) { thread->join(); }
+        GTEST_SKIP() << "Not enough round_robin_hosts for test";
+    }
+    for (int i = 0; i < num_limitless_conn; i++) {
         SQLHDBC limitless_dbc = SQL_NULL_HDBC;
         SQLAllocHandle(SQL_HANDLE_DBC, env, &limitless_dbc);
         limitless_dbcs.push_back(limitless_dbc);


### PR DESCRIPTION
### Summary

Additional null checks for Utilities in Integration Tests

### Description

- Added handle null checks
- Changed connection string builder to a std::string rather than the limited character array to prevent stack corruptions
- Updated the error fetching to use `sizeof(buf) / sizeof(SQLTCHAR)` as `SQLGetDiagRec(..)` uses character count for its BufferLength arg
- On Windows Inte, use CDB (a MSVC debugger, also our compiler) instead of generic GDB for additional symbols in the stack trace
- Initialize various various to their null state.

### Testing

<!-- What did you test and how did you test it -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
