### PR TITLE
fix: proper lifetime of monitor dbc

### DIFF
--- a/driver/plugin/blue_green/blue_green_monitor.cpp
+++ b/driver/plugin/blue_green/blue_green_monitor.cpp
@@ -20,6 +20,8 @@
 
 #include "../../util/plugin_chain_builder.h"
 
+#include "../../driver.h"
+
 #include "../../util/rds_utils.h"
 
 #include <algorithm>
@@ -79,6 +81,8 @@ BlueGreenMonitor::~BlueGreenMonitor() {
 
     odbc_helper_->DisconnectAndFree(&hdbc_);
     odbc_helper_->FreeEnv(&henv_);
+    host_list_provider_ = nullptr;
+    delete monitor_dbc_;
 }
 
 void BlueGreenMonitor::StartMonitoring() {
@@ -578,8 +582,11 @@ void BlueGreenMonitor::InitHostListProvider() {
     host_list_provider_conn_attr.insert_or_assign(KEY_CLUSTER_ID, custom_cluster_id);
     host_list_provider_conn_attr.insert_or_assign(KEY_SERVER, this->connecting_host_info_.GetHost());
     host_list_provider_conn_attr.insert_or_assign(KEY_PORT, std::to_string(this->connecting_host_info_.GetPort()));
+    delete monitor_dbc_;
+    monitor_dbc_ = new DBC();
+    monitor_dbc_->conn_attr = host_list_provider_conn_attr;
     const std::shared_ptr<PluginService> monitor_plugin_service = std::make_shared<PluginService>(odbc_helper_->GetLibLoader(), host_list_provider_conn_attr);
-    const std::shared_ptr<BasePlugin> plugin_head = PluginChainBuilder::MonitoringBuild(host_list_provider_conn_attr, monitor_plugin_service);
+    const std::shared_ptr<BasePlugin> plugin_head = PluginChainBuilder::MonitoringBuild(monitor_dbc_, monitor_plugin_service);
     monitor_plugin_service->SetPluginChain(plugin_head);
     this->host_list_provider_ = std::make_shared<RdsHostListProvider>(
         monitor_plugin_service->GetTopologyUtil(),

--- a/driver/plugin/blue_green/blue_green_monitor.h
+++ b/driver/plugin/blue_green/blue_green_monitor.h
@@ -140,6 +140,7 @@ private:
     std::condition_variable sleep_cv_;
     std::mutex sleep_mutex_;
     std::shared_ptr<HostListProvider> host_list_provider_;
+    DBC* monitor_dbc_ = nullptr;
     std::shared_ptr<std::thread> monitoring_thread_;
     SQLHENV henv_ = SQL_NULL_HENV;
     std::mutex hdbc_mutex_;

--- a/driver/plugin/blue_green/blue_green_plugin.cpp
+++ b/driver/plugin/blue_green/blue_green_plugin.cpp
@@ -42,6 +42,7 @@ BlueGreenPlugin::BlueGreenPlugin(DBC* dbc, std::shared_ptr<BasePlugin> next_plug
 
 BlueGreenPlugin::~BlueGreenPlugin() {
     CleanUpStatusProvider();
+    delete monitor_dbc_;
 }
 
 SQLRETURN BlueGreenPlugin::Connect(
@@ -311,8 +312,11 @@ std::shared_ptr<BlueGreenStatusProvider> BlueGreenPlugin::GetOrCreateProvider() 
         std::string monitoring_cluster_id = MapUtils::GetStringValue(monitoring_map, KEY_CLUSTER_ID, "<empty>");
         monitoring_cluster_id = monitoring_cluster_id + "-bg-monitor";
         monitoring_map.insert_or_assign(KEY_CLUSTER_ID, monitoring_cluster_id);
+        delete monitor_dbc_;
+        monitor_dbc_ = new DBC();
+        monitor_dbc_->conn_attr = monitoring_map;
         const std::shared_ptr<PluginService> monitor_plugin_service = std::make_shared<PluginService>(this->odbc_helper_->GetLibLoader(), monitoring_map);
-        const std::shared_ptr<BasePlugin> plugin_head = PluginChainBuilder::MonitoringBuild(monitoring_map, monitor_plugin_service);
+        const std::shared_ptr<BasePlugin> plugin_head = PluginChainBuilder::MonitoringBuild(monitor_dbc_, monitor_plugin_service);
         monitor_plugin_service->SetPluginChain(plugin_head);
         provider = std::make_shared<BlueGreenStatusProvider>(
             monitor_plugin_service,

--- a/driver/plugin/blue_green/blue_green_plugin.h
+++ b/driver/plugin/blue_green/blue_green_plugin.h
@@ -67,6 +67,7 @@ private:
     std::map<std::string, std::string> conn_attr_;
     std::weak_ptr<PluginService> plugin_service_;
     std::shared_ptr<OdbcHelper> odbc_helper_;
+    DBC* monitor_dbc_ = nullptr;
 
     BlueGreenStatus blue_green_status_;
 

--- a/driver/plugin/limitless/limitless_router_service.cpp
+++ b/driver/plugin/limitless/limitless_router_service.cpp
@@ -21,6 +21,7 @@
 
 #include "../../util/logger_wrapper.h"
 #include "../../util/plugin_chain_builder.h"
+#include "../../driver.h"
 #include "../../util/plugin_service.h"
 #include "../../util/rds_utils.h"
 #include "../../util/sliding_cache_map.h"
@@ -59,18 +60,22 @@ LimitlessRouterService::~LimitlessRouterService() {
             LOG(INFO) << "Decremented Limitless Monitor count for: " << router_monitor_key_ << ", to: " << pair.first;
         }
     }
+    delete monitor_dbc_;
 }
 
 std::shared_ptr<LimitlessRouterMonitor> LimitlessRouterService::CreateMonitor(
     const std::map<std::string, std::string> &conn_attr,
     std::shared_ptr<BasePlugin> plugin_head,
     DBC* dbc,
-    const std::shared_ptr<DialectLimitless>& dialect) const
+    const std::shared_ptr<DialectLimitless>& dialect)
 {
+    delete monitor_dbc_;
+    monitor_dbc_ = new DBC();
+    monitor_dbc_->conn_attr = conn_attr;
     const std::shared_ptr<PluginService> monitor_plugin_service =
         std::make_shared<PluginService>(dbc->env->driver_lib_loader, conn_attr);
     const std::shared_ptr<BasePlugin> monitoring_plugin_head =
-        PluginChainBuilder::MonitoringBuild(conn_attr, monitor_plugin_service);
+        PluginChainBuilder::MonitoringBuild(monitor_dbc_, monitor_plugin_service);
     monitor_plugin_service->SetPluginChain(monitoring_plugin_head);
 
     std::shared_ptr<LimitlessRouterMonitor> monitor = std::make_shared<LimitlessRouterMonitor>(monitoring_plugin_head, dialect, odbc_helper_, limitless_query_helper_);

--- a/driver/plugin/limitless/limitless_router_service.h
+++ b/driver/plugin/limitless/limitless_router_service.h
@@ -48,7 +48,7 @@ public:
         const std::map<std::string, std::string>& conn_attr,
         std::shared_ptr<BasePlugin> plugin_head,
         DBC* dbc,
-        const std::shared_ptr<DialectLimitless>& dialect) const;
+        const std::shared_ptr<DialectLimitless>& dialect);
     virtual SQLRETURN EstablishConnection(std::shared_ptr<BasePlugin> plugin_head, DBC* dbc);
     virtual void StartMonitoring(DBC* dbc, const std::shared_ptr<DialectLimitless> &dialect);
 
@@ -64,6 +64,7 @@ private:
     int host_port_;
     std::shared_ptr<OdbcHelper> odbc_helper_;
     std::shared_ptr<LimitlessQueryHelper> limitless_query_helper_;
+    DBC* monitor_dbc_ = nullptr;
 };
 
 #endif // LIMITLESS_ROUTER_SERVICE_H_

--- a/driver/util/plugin_chain_builder.cpp
+++ b/driver/util/plugin_chain_builder.cpp
@@ -23,31 +23,29 @@
 #include "../plugin/iam/iam_auth_plugin.h"
 #include "../plugin/secrets_manager/secrets_manager_plugin.h"
 
-std::shared_ptr<BasePlugin> PluginChainBuilder::MonitoringBuild(std::map<std::string, std::string> conn_attr, std::shared_ptr<PluginService> plugin_service) {
-    DBC dbc;
-    dbc.conn_attr = conn_attr;
-    dbc.plugin_service = plugin_service;
-    std::shared_ptr<BasePlugin> plugin_head = std::make_shared<DefaultPlugin>(&dbc);
+std::shared_ptr<BasePlugin> PluginChainBuilder::MonitoringBuild(DBC* dbc, std::shared_ptr<PluginService> plugin_service) {
+    dbc->plugin_service = plugin_service;
+    std::shared_ptr<BasePlugin> plugin_head = std::make_shared<DefaultPlugin>(dbc);
     std::shared_ptr<BasePlugin> next_plugin;
 
     // Auth Plugins
-    if (dbc.conn_attr.contains(KEY_AUTH_TYPE)) {
-        const AuthType type = AuthProvider::AuthTypeFromString(dbc.conn_attr.at(KEY_AUTH_TYPE));
+    if (dbc->conn_attr.contains(KEY_AUTH_TYPE)) {
+        const AuthType type = AuthProvider::AuthTypeFromString(dbc->conn_attr.at(KEY_AUTH_TYPE));
         switch (type) {
                 case AuthType::IAM:
-                    next_plugin = std::make_shared<IamAuthPlugin>(&dbc, plugin_head);
+                    next_plugin = std::make_shared<IamAuthPlugin>(dbc, plugin_head);
                     plugin_head = next_plugin;
                     break;
                 case AuthType::SECRETS_MANAGER:
-                    next_plugin = std::make_shared<SecretsManagerPlugin>(&dbc, plugin_head);
+                    next_plugin = std::make_shared<SecretsManagerPlugin>(dbc, plugin_head);
                     plugin_head = next_plugin;
                     break;
                 case AuthType::ADFS:
-                    next_plugin = std::make_shared<AdfsAuthPlugin>(&dbc, plugin_head);
+                    next_plugin = std::make_shared<AdfsAuthPlugin>(dbc, plugin_head);
                     plugin_head = next_plugin;
                     break;
                 case AuthType::OKTA:
-                    next_plugin = std::make_shared<OktaAuthPlugin>(&dbc, plugin_head);
+                    next_plugin = std::make_shared<OktaAuthPlugin>(dbc, plugin_head);
                     plugin_head = next_plugin;
                     break;
                 case AuthType::DATABASE:

--- a/driver/util/plugin_chain_builder.h
+++ b/driver/util/plugin_chain_builder.h
@@ -21,12 +21,12 @@
 
 #include "../plugin/base_plugin.h"
 
-#include <map>
 #include <memory>
-#include <string>
+
+struct DBC;
 
 namespace PluginChainBuilder {
-    std::shared_ptr<BasePlugin> MonitoringBuild(std::map<std::string, std::string> conn_attr, std::shared_ptr<PluginService> plugin_service);
+    std::shared_ptr<BasePlugin> MonitoringBuild(DBC* dbc, std::shared_ptr<PluginService> plugin_service);
 }  // namespace PluginChainBuilder
 
-#endif PLUGIN_CHAIN_BUILDER_H_
+#endif // PLUGIN_CHAIN_BUILDER_H_

--- a/driver/util/plugin_service.cpp
+++ b/driver/util/plugin_service.cpp
@@ -16,6 +16,8 @@
 
 #include "plugin_service.h"
 
+
+#include "../driver.h"
 #include "map_utils.h"
 #include "rds_utils.h"
 
@@ -64,6 +66,7 @@ PluginService::~PluginService()
     dialect_ = nullptr;
     host_selector_ = nullptr;
     plugin_chain_ = nullptr;
+    delete monitor_dbc_;
 }
 
 std::string PluginService::GetClusterId() {
@@ -208,8 +211,11 @@ void PluginService::InitHostListProvider() {
             monitoring_cluster_id = monitoring_cluster_id + "-monitor";
             monitoring_map.insert_or_assign(KEY_CLUSTER_ID, monitoring_cluster_id);
 
+            delete monitor_dbc_;
+            monitor_dbc_ = new DBC();
+            monitor_dbc_->conn_attr = monitoring_map;
             const std::shared_ptr<PluginService> monitor_plugin_service = std::make_shared<PluginService>(this->odbc_helper_->GetLibLoader(), monitoring_map);
-            const std::shared_ptr<BasePlugin> plugin_head = PluginChainBuilder::MonitoringBuild(monitoring_map, monitor_plugin_service);
+            const std::shared_ptr<BasePlugin> plugin_head = PluginChainBuilder::MonitoringBuild(monitor_dbc_, monitor_plugin_service);
             monitor_plugin_service->SetPluginChain(plugin_head);
             this->host_list_provider_ = std::make_shared<RdsHostListProvider>(
                 monitor_plugin_service->GetTopologyUtil(),
@@ -224,6 +230,8 @@ void PluginService::InitHostListProvider() {
 
 void PluginService::ReleaseHostListProvider() {
     host_list_provider_ = nullptr;
+    delete monitor_dbc_;
+    monitor_dbc_ = nullptr;
 }
 
 std::shared_ptr<HostSelector> PluginService::InitHostSelector(const std::map<std::string, std::string>& conn_info) {

--- a/driver/util/plugin_service.cpp
+++ b/driver/util/plugin_service.cpp
@@ -16,7 +16,6 @@
 
 #include "plugin_service.h"
 
-
 #include "../driver.h"
 #include "map_utils.h"
 #include "rds_utils.h"

--- a/driver/util/plugin_service.h
+++ b/driver/util/plugin_service.h
@@ -95,6 +95,7 @@ class PluginService {
     std::shared_ptr<TopologyUtil> topology_util_;
     std::shared_ptr<HostListProvider> host_list_provider_;
     std::shared_ptr<BasePlugin> plugin_chain_;
+    DBC* monitor_dbc_ = nullptr;
 
     mutable std::mutex lock_;
 

--- a/test/unit_test/limitless_mock_objects.h
+++ b/test/unit_test/limitless_mock_objects.h
@@ -48,7 +48,7 @@ public:
         const std::map<std::string, std::string>& conn_attr,
         std::shared_ptr<BasePlugin> plugin_head,
         DBC* dbc,
-        const std::shared_ptr<DialectLimitless>& dialect) const override {
+        const std::shared_ptr<DialectLimitless>& dialect) override {
         return std::make_shared<MockLimitlessRouterMonitor>(plugin_head, std::make_shared<OdbcHelper>(nullptr), dialect);
     };
 };


### PR DESCRIPTION
### Summary

Fixes Monitor DBC's Lifetime

### Description

Moved the lifetime management of the monitoring DBC into the caller instead of using local stack

### Testing

<!-- What did you test and how did you test it -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
