### PR TITLE
fix: bounds and length adjustments

### DIFF
--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -510,6 +510,7 @@ SQLRETURN RDS_GetConnectAttr(
                 dbc->wrapped_dbc, Attribute, attr_buf.data(), BufferLength, StringLengthPtr
             );
             odbc_helper->ConvertDriverOutputToTarget(attr_buf.data(), static_cast<SQLTCHAR*>(ValuePtr), attr_buf.size() * sizeof(SQLTCHAR), static_cast<size_t>(BufferLength));
+            odbc_helper->AdjustByteLength(StringLengthPtr);
             ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
         } else
 #endif
@@ -630,6 +631,7 @@ SQLRETURN RDS_SQLColAttribute(
         );
         if (StringLengthPtr && *StringLengthPtr > 0) {
             odbc_helper->ConvertDriverOutputToTarget(attr_buf.data(), static_cast<SQLTCHAR*>(CharacterAttributePtr), attr_buf.size() * sizeof(SQLTCHAR), static_cast<size_t>(BufferLength));
+            odbc_helper->AdjustByteLength(StringLengthPtr);
         } else {
             std::memcpy(CharacterAttributePtr, attr_buf.data(), static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR));
         }
@@ -670,6 +672,7 @@ SQLRETURN RDS_SQLColAttributes(
         if (StringLengthPtr && *StringLengthPtr > 0) {
             // String data
             odbc_helper->ConvertDriverOutputToTarget(attr_buf.data(), static_cast<SQLTCHAR*>(CharacterAttributePtr), attr_buf.size() * sizeof(SQLTCHAR), static_cast<size_t>(BufferLength));
+            odbc_helper->AdjustByteLength(StringLengthPtr);
         } else {
             // Numeric data
             std::memcpy(CharacterAttributePtr, attr_buf.data(), static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR));
@@ -984,15 +987,15 @@ SQLRETURN RDS_SQLDriverConnect(
     // codechecker_suppress [misc-const-correctness]
     bool use_4_bytes_user_app = false;
 #if UNICODE && !defined(_WIN32)
-     if (!dbc->conn_attr.contains(KEY_DRIVER) && !dbc->conn_attr.contains(KEY_DSN)) {
+    if (!dbc->conn_attr.contains(KEY_DRIVER) && !dbc->conn_attr.contains(KEY_DSN)) {
+        dbc->conn_attr.clear();
+        const std::string conn_str_utf8_w = Convert4ByteSqlWChar(InConnectionString, StringLength1);
+        ConnectionStringHelper::ParseConnectionString(conn_str_utf8_w, dbc->conn_attr);
 
-         const std::string conn_str_utf8_w = Convert4ByteSqlWChar(InConnectionString, BufferLength);
-         ConnectionStringHelper::ParseConnectionString(conn_str_utf8_w, dbc->conn_attr);
-
-         if (dbc->conn_attr.contains(KEY_DRIVER) || dbc->conn_attr.contains(KEY_DSN)) {
-             use_4_bytes_user_app = true;
-         }
-     }
+        if (dbc->conn_attr.contains(KEY_DRIVER) || dbc->conn_attr.contains(KEY_DSN)) {
+           use_4_bytes_user_app = true;
+        }
+    }
 #endif
 
     // Load DSN information into map
@@ -1022,12 +1025,12 @@ SQLRETURN RDS_SQLDriverConnect(
     if (OutConnectionString && StringLength2Ptr) {
         const SQLULEN len = conn_out_str_utf8.length();
 #ifdef UNICODE
-    const SQLULEN written = CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(OutConnectionString), MAX_KEY_SIZE, conn_out_str_utf8);
+    const SQLULEN written = CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(OutConnectionString), BufferLength, conn_out_str_utf8);
     if (dbc->plugin_service) {
         dbc->plugin_service->GetOdbcHelper()->ConvertWrapperOutputToTarget(OutConnectionString, written, BufferLength);
     }
 #else
-        const SQLULEN written = snprintf(AS_CHAR(OutConnectionString), MAX_KEY_SIZE, "%s", conn_out_str_utf8.c_str());
+        const SQLULEN written = snprintf(AS_CHAR(OutConnectionString), BufferLength, "%s", conn_out_str_utf8.c_str());
 #endif
         if (len >= BufferLength && SQL_SUCCEEDED(ret)) {
             ret = SQL_SUCCESS_WITH_INFO;
@@ -1295,6 +1298,7 @@ SQLRETURN RDS_SQLGetDescField(
                 desc->wrapped_desc, RecNumber, FieldIdentifier, field_buf.data(), BufferLength, StringLengthPtr
             );
             odbc_helper->ConvertDriverOutputToTarget(field_buf.data(), static_cast<SQLTCHAR*>(ValuePtr), field_buf.size() * sizeof(SQLTCHAR), static_cast<size_t>(BufferLength));
+            odbc_helper->AdjustByteLength(StringLengthPtr);
             return RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
         }
     }
@@ -1386,6 +1390,7 @@ SQLRETURN RDS_SQLGetDiagField(
                             static_cast<SQLTCHAR*>(DiagInfoPtr),
                             diag_buf.size() * sizeof(SQLTCHAR),
                             static_cast<size_t>(BufferLength));
+                        odbc_helper->AdjustByteLength(StringLengthPtr);
                         ret = RDS_ProcessLibRes(SQL_HANDLE_ENV, env, res);
                     } else
 #endif
@@ -1420,6 +1425,7 @@ SQLRETURN RDS_SQLGetDiagField(
                             static_cast<SQLTCHAR*>(DiagInfoPtr),
                             diag_buf.size() * sizeof(SQLTCHAR),
                             static_cast<size_t>(BufferLength));
+                        odbc_helper->AdjustByteLength(StringLengthPtr);
                         ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
                     } else
 #endif
@@ -1455,6 +1461,7 @@ SQLRETURN RDS_SQLGetDiagField(
                             static_cast<SQLTCHAR*>(DiagInfoPtr),
                             diag_buf.size() * sizeof(SQLTCHAR),
                             static_cast<size_t>(BufferLength));
+                        odbc_helper->AdjustByteLength(StringLengthPtr);
                         ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
                     } else
 #endif
@@ -1492,6 +1499,7 @@ SQLRETURN RDS_SQLGetDiagField(
                             static_cast<SQLTCHAR*>(DiagInfoPtr),
                             diag_buf.size() * sizeof(SQLTCHAR),
                             static_cast<size_t>(BufferLength));
+                        odbc_helper->AdjustByteLength(StringLengthPtr);
                         ret = RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
                     } else
 #endif
@@ -1833,11 +1841,9 @@ SQLRETURN RDS_SQLGetDiagRec(
         }
         const SQLLEN err_len = err->error_msg != nullptr ? static_cast<SQLLEN>(strlen(err->error_msg)) : 0;
         if (TextLengthPtr) {
-            *TextLengthPtr = static_cast<SQLSMALLINT>(err_len * sizeof(SQLTCHAR));
+            *TextLengthPtr = static_cast<SQLSMALLINT>(err_len);
             if (BufferLength == 0) {
                 ret = SQL_SUCCESS_WITH_INFO;
-            } else if (err_len >= BufferLength) {
-                *TextLengthPtr = static_cast<SQLSMALLINT>((err_len - 1) * sizeof(SQLTCHAR));
             }
         }
         if (MessageText && (BufferLength > 0) && err->error_msg) {
@@ -1853,7 +1859,7 @@ SQLRETURN RDS_SQLGetDiagRec(
                 ret = SQL_SUCCESS_WITH_INFO;
             }
             if (TextLengthPtr) {
-                *TextLengthPtr = static_cast<SQLSMALLINT>(written * sizeof(SQLTCHAR));
+                *TextLengthPtr = static_cast<SQLSMALLINT>(written);
             }
         }
         if (NativeErrorPtr) {
@@ -1943,6 +1949,7 @@ SQLRETURN RDS_SQLGetInfo(
                             static_cast<SQLTCHAR*>(InfoValuePtr),
                             info_buf.size() * sizeof(SQLTCHAR),
                             static_cast<size_t>(BufferLength));
+                        odbc_helper->AdjustByteLength(StringLengthPtr);
                     } else {
                         std::memcpy(InfoValuePtr, info_buf.data(), static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR));
                     }

--- a/driver/util/odbc_helper.cpp
+++ b/driver/util/odbc_helper.cpp
@@ -313,3 +313,33 @@ bool OdbcHelper::IsStringDiagField(const SQLSMALLINT diag_identifier) {
             return false;
     }
 }
+
+void OdbcHelper::AdjustByteLength(SQLSMALLINT* length_ptr) const {
+#ifdef UNICODE
+    if (length_ptr && *length_ptr > 0) {
+        // Expanded, driver 2-byte -> user 4-byte
+        if (use_4_bytes_user_app_ && !use_4_bytes_base_driver_) {
+            *length_ptr *= 2;
+        }
+        // Shrunk, driver 4-byte -> user 2-byte
+        if (!use_4_bytes_user_app_ && use_4_bytes_base_driver_) {
+            *length_ptr /= 2;
+        }
+    }
+#endif
+}
+
+void OdbcHelper::AdjustByteLength(SQLINTEGER* length_ptr) const {
+    #ifdef UNICODE
+        if (length_ptr && *length_ptr > 0) {
+            // Expanded, driver 2-byte -> user 4-byte
+            if (use_4_bytes_user_app_ && !use_4_bytes_base_driver_) {
+                *length_ptr *= 2;
+            }
+            // Shrunk, driver 4-byte -> user 2-byte
+            if (!use_4_bytes_user_app_ && use_4_bytes_base_driver_) {
+                *length_ptr /= 2;
+            }
+        }
+    #endif
+}

--- a/driver/util/odbc_helper.h
+++ b/driver/util/odbc_helper.h
@@ -84,6 +84,10 @@ public:
     static bool IsStringDescField(SQLSMALLINT field_identifier);
     static bool IsStringDiagField(SQLSMALLINT diag_identifier);
 
+    // Adjust StringLengthPtr due to potential manipulation by wrapper
+    void AdjustByteLength(SQLSMALLINT* length_ptr) const;
+    void AdjustByteLength(SQLINTEGER* length_ptr) const;
+
 private:
     std::shared_ptr<RdsLibLoader> lib_loader_;
     bool use_4_bytes_base_driver_ = false;

--- a/driver/util/rds_strings.h
+++ b/driver/util/rds_strings.h
@@ -184,11 +184,11 @@ inline size_t ConvertUTF16ToUTF32(const SQLTCHAR* src, SQLTCHAR* dst, const size
 }
 
 inline void ExpandUTF16ToUTF32InPlace(SQLTCHAR* buf, size_t src_chars, size_t buf_slots) {
-    if (buf == nullptr || src_chars == 0) {
+    if (buf == nullptr || src_chars == 0 || buf_slots < 2) {
         return;
     }
 
-    const size_t max_chars = (buf_slots >= 2) ? (buf_slots - 2) / 2 : 0;
+    const size_t max_chars = (buf_slots - 2) / 2;
     const size_t chars = src_chars < max_chars ? src_chars : max_chars;
 
     // Work backwards to avoid overwriting source data
@@ -203,7 +203,12 @@ inline void ExpandUTF16ToUTF32InPlace(SQLTCHAR* buf, size_t src_chars, size_t bu
 inline std::string Convert4ByteSqlWChar(
     SQLTCHAR *     InputStr,
     SQLINTEGER     BufferLength
-    ) {
+    )
+{
+    if (!InputStr) {
+        return "";
+    }
+
     std::vector<SQLTCHAR> conn_in_vector;
     int i = 0;
     while (true) {
@@ -223,6 +228,10 @@ inline std::string Convert4ByteSqlWChar(
 }
 
 inline std::string ConvertUserAppToUTF8(bool user_4_byte, SQLTCHAR* in, SQLINTEGER in_length) {
+    if (!in) {
+        return "";
+    }
+
     if (user_4_byte) {
         size_t length = GetLenOfSqltcharArray(in, in_length, user_4_byte);
         return Convert4ByteSqlWChar(in, length);


### PR DESCRIPTION
### Summary

Adds Additional Bounds Check & Return Length Adjustments

### Description

- Adjust StringLengthPtr for functions which return in byte size as we internally manipulate the buffer (it may shrink or grow)
- Return character count for [GetDiagRec](https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdiagrec-function?view=sql-server-ver17#arguments)
- Bound check for some rds_string utils
- Delete old DBC Conn Attr when attempting to reparse using wider encoding

### Testing

<!-- What did you test and how did you test it -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
