### PR TITLE
refactor: move user byte flag to env

### DIFF
--- a/driver/driver.h
+++ b/driver/driver.h
@@ -55,6 +55,7 @@
 
 #include <sql.h>
 
+#include <atomic>
 #include <list>
 #include <map>
 #include <memory>
@@ -101,6 +102,7 @@ struct ENV {
     SQLHENV wrapped_env;
 
     std::shared_ptr<RdsLibLoader> driver_lib_loader;
+    std::atomic<bool> use_4_bytes_user_app = false;
 
     ~ENV();
 };  // ENV

--- a/driver/host_info.h
+++ b/driver/host_info.h
@@ -88,7 +88,8 @@ private:
 
 inline std::ostream& operator<<(std::ostream& str, const HostInfo& v) {
     char buf[HostInfo::MAX_HOST_INFO_BUFFER_SIZE];
-    sprintf(buf, "HostInfo[host=%s, port=%d, %s]",
+    snprintf(buf, HostInfo::MAX_HOST_INFO_BUFFER_SIZE,
+        "HostInfo[host=%s, port=%d, %s]",
         v.GetHost().c_str(),
         v.GetPort(),
         v.GetHostRole() == WRITER ? "WRITER" : "READER");

--- a/driver/host_list_providers/rds_host_list_provider.h
+++ b/driver/host_list_providers/rds_host_list_provider.h
@@ -32,7 +32,7 @@ class RdsHostListProvider : public HostListProvider {
 public:
     RdsHostListProvider(std::shared_ptr<TopologyUtil> topology_util, PluginService* plugin_service);
     ~RdsHostListProvider();
-    virtual std::vector<HostInfo> GetCurrentTopology(SQLHDBC hdbc, const HostInfo& initial_host);
+    virtual std::vector<HostInfo> GetCurrentTopology(SQLHDBC hdbc, const HostInfo& initial_host) override;
     virtual std::vector<HostInfo> Refresh() override;
     virtual std::vector<HostInfo> ForceRefresh(bool verify_writer, uint32_t timeout_ms) override;
     virtual HOST_ROLE GetConnectionRole(SQLHDBC hdbc) override;

--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -16,7 +16,6 @@
 
 #include "odbcapi_rds_helper.h"
 
-#include <cstdio>
 #include <unordered_set>
 
 #include "error.h"
@@ -42,6 +41,30 @@
 #ifdef WIN32
     #include "gui/setup.h"
 #endif
+
+ENV* RDS_GetEnvFromHandle(SQLSMALLINT HandleType, SQLHANDLE InputHandle) {
+    if (!InputHandle) {
+        return nullptr;
+    }
+    switch (HandleType) {
+        case SQL_HANDLE_ENV:
+            return static_cast<ENV*>(InputHandle);
+        case SQL_HANDLE_DBC: {
+            const DBC* dbc = static_cast<const DBC*>(InputHandle);
+            return dbc ? dbc->env : nullptr;
+        }
+        case SQL_HANDLE_STMT: {
+            const STMT* stmt = static_cast<const STMT*>(InputHandle);
+            return (stmt && stmt->dbc) ? stmt->dbc->env : nullptr;
+        }
+        case SQL_HANDLE_DESC: {
+            const DESC* desc = static_cast<const DESC*>(InputHandle);
+            return (desc && desc->dbc) ? desc->dbc->env : nullptr;
+        }
+        default:
+            return nullptr;
+    }
+}
 
 #if UNICODE
 std::shared_ptr<OdbcHelper> RDS_GetOdbcHelper(const DBC* dbc, const ENV* env) {
@@ -632,7 +655,7 @@ SQLRETURN RDS_SQLColAttribute(
         if (StringLengthPtr && *StringLengthPtr > 0) {
             odbc_helper->ConvertDriverOutputToTarget(attr_buf.data(), static_cast<SQLTCHAR*>(CharacterAttributePtr), attr_buf.size() * sizeof(SQLTCHAR), static_cast<size_t>(BufferLength));
             odbc_helper->AdjustByteLength(StringLengthPtr);
-        } else {
+        } else if (CharacterAttributePtr) {
             std::memcpy(CharacterAttributePtr, attr_buf.data(), static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR));
         }
         return RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
@@ -673,7 +696,7 @@ SQLRETURN RDS_SQLColAttributes(
             // String data
             odbc_helper->ConvertDriverOutputToTarget(attr_buf.data(), static_cast<SQLTCHAR*>(CharacterAttributePtr), attr_buf.size() * sizeof(SQLTCHAR), static_cast<size_t>(BufferLength));
             odbc_helper->AdjustByteLength(StringLengthPtr);
-        } else {
+        } else if (CharacterAttributePtr) {
             // Numeric data
             std::memcpy(CharacterAttributePtr, attr_buf.data(), static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR));
         }
@@ -794,26 +817,27 @@ SQLRETURN RDS_SQLConnect(
         return SQL_ERROR;
     }
 
-    bool use_4_bytes_user_app = false;
+    bool use_4_bytes_user_app = dbc->env->use_4_bytes_user_app.load();
     std::string conn_str_utf8;
     std::string current_utf8;
     size_t load_len = -1;
     if (ServerName) {
         // Load input DSN followed by Base DSN retrieved from input DSN
 #ifdef UNICODE
-        current_utf8 = ConvertUserAppToUTF8(false, ServerName, NameLength1);
+        current_utf8 = ConvertUserAppToUTF8(use_4_bytes_user_app, ServerName, NameLength1);
 #else
         current_utf8 = reinterpret_cast<const char *>(ServerName);
 #endif
         load_len = NameLength1 == SQL_NTS ? current_utf8.length() : NameLength1;
         OdbcDsnHelper::LoadAll(current_utf8.substr(0, load_len), dbc->conn_attr);
 #ifdef UNICODE
-        if (!dbc->conn_attr.contains(KEY_DRIVER) && !dbc->conn_attr.contains(KEY_DSN)) {
+        if (!use_4_bytes_user_app && !dbc->conn_attr.contains(KEY_DRIVER) && !dbc->conn_attr.contains(KEY_DSN)) {
             current_utf8 = ConvertUserAppToUTF8(true, ServerName, NameLength1);
             load_len = NameLength1 == SQL_NTS ? current_utf8.length() : NameLength1;
             OdbcDsnHelper::LoadAll(current_utf8.substr(0, load_len), dbc->conn_attr);
             if (dbc->conn_attr.contains(KEY_DRIVER) || dbc->conn_attr.contains(KEY_DSN)) {
                 use_4_bytes_user_app = true;
+                dbc->env->use_4_bytes_user_app.store(true);
             }
         }
 #endif
@@ -850,9 +874,6 @@ SQLRETURN RDS_SQLConnect(
 
     // Connect if initialization successful
     if (SQL_SUCCEEDED(RDS_InitializeConnection(dbc, conn_str_utf8))) {
-        if (use_4_bytes_user_app) {
-            dbc->plugin_service->GetOdbcHelper()->SetUse4BytesUserApp(true);
-        }
         ret = dbc->plugin_head->Connect(ConnectionHandle, nullptr, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
     }
 
@@ -935,6 +956,7 @@ SQLRETURN RDS_SQLDriverConnect(
     DBC* dbc = static_cast<DBC*>(ConnectionHandle);
     std::string conn_str_utf8;
     std::string conn_out_str_utf8;
+    bool use_4_bytes_user_app = dbc->env->use_4_bytes_user_app.load();
 
     if (DriverCompletion && WindowHandle) {
 #if _WIN32
@@ -963,7 +985,7 @@ SQLRETURN RDS_SQLDriverConnect(
 #endif
     } else {
 #ifdef UNICODE
-        conn_str_utf8 = ConvertUTF16ToUTF8(reinterpret_cast<uint16_t*>(InConnectionString));
+        conn_str_utf8 = ConvertUserAppToUTF8(use_4_bytes_user_app, InConnectionString, StringLength1);
 #else
         conn_str_utf8 = reinterpret_cast<const char *>(InConnectionString);
 #endif
@@ -984,8 +1006,6 @@ SQLRETURN RDS_SQLDriverConnect(
     // Parse connection string, load input DSN followed by Base DSN
     ConnectionStringHelper::ParseConnectionString(conn_str_utf8, dbc->conn_attr);
 
-    // codechecker_suppress [misc-const-correctness]
-    bool use_4_bytes_user_app = false;
 #if UNICODE && !defined(_WIN32)
     if (!dbc->conn_attr.contains(KEY_DRIVER) && !dbc->conn_attr.contains(KEY_DSN)) {
         dbc->conn_attr.clear();
@@ -993,7 +1013,8 @@ SQLRETURN RDS_SQLDriverConnect(
         ConnectionStringHelper::ParseConnectionString(conn_str_utf8_w, dbc->conn_attr);
 
         if (dbc->conn_attr.contains(KEY_DRIVER) || dbc->conn_attr.contains(KEY_DSN)) {
-           use_4_bytes_user_app = true;
+            use_4_bytes_user_app = true;
+            dbc->env->use_4_bytes_user_app.store(true);
         }
     }
 #endif
@@ -1012,9 +1033,6 @@ SQLRETURN RDS_SQLDriverConnect(
     ret = RDS_InitializeConnection(dbc, conn_str_utf8);
     // Connect if initialization successful
     if (SQL_SUCCEEDED(ret)) {
-        if (use_4_bytes_user_app) {
-            dbc->plugin_service->GetOdbcHelper()->SetUse4BytesUserApp(true);
-        }
         // Pass SQL_DRIVER_NOPROMPT to base driver, otherwise base driver may show its own dialog box when it's not needed.
         ret = dbc->plugin_head->Connect(ConnectionHandle, WindowHandle, OutConnectionString, BufferLength, StringLength2Ptr, SQL_DRIVER_NOPROMPT);
     }
@@ -1673,7 +1691,7 @@ SQLRETURN RDS_SQLGetDiagRec(
     DESC* desc = nullptr;
     STMT* stmt = nullptr;
     DBC* dbc = nullptr;
-    ENV* env = nullptr;
+    ENV* env = RDS_GetEnvFromHandle(HandleType, Handle);
     RdsLibResult res;
     SQLRETURN ret = SQL_ERROR;
     const ERR_INFO* err = nullptr;
@@ -1685,10 +1703,11 @@ SQLRETURN RDS_SQLGetDiagRec(
     SQLTCHAR* new_msg_buffer = new_msg_vector.data();
 
     const std::shared_ptr<OdbcHelper> odbc_helper = RDS_GetOdbcHelper(HandleType, Handle);
+    const bool user_4_byte = env && env->use_4_bytes_user_app.load();
 
     size_t app_state_bytes = MAX_SQL_STATE_LEN * sizeof(SQLTCHAR);
     size_t app_msg_bytes = BufferLength * sizeof(SQLTCHAR);
-    if (odbc_helper && odbc_helper->GetUse4BytesUserApp()) {
+    if (user_4_byte) {
         app_state_bytes *= 2;
         app_msg_bytes *= 2;
     }
@@ -1715,8 +1734,12 @@ SQLRETURN RDS_SQLGetDiagRec(
                     ret = RDS_ProcessLibRes(SQL_HANDLE_ENV, env, res);
 
                     if (odbc_helper) {
-                        odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, sizeof(new_state_buffer), app_state_bytes);
-                        odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, new_msg_vector.size() * sizeof(SQLTCHAR), app_msg_bytes);
+                        if (SQLState) {
+                            odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, sizeof(new_state_buffer), app_state_bytes);
+                        }
+                        if (MessageText) {
+                            odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, new_msg_vector.size() * sizeof(SQLTCHAR), app_msg_bytes);
+                        }
                     }
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
@@ -1744,9 +1767,14 @@ SQLRETURN RDS_SQLGetDiagRec(
                         HandleType, dbc->wrapped_dbc, RecNumber, new_state_buffer, NativeErrorPtr, new_msg_buffer, BufferLength, TextLengthPtr
                     );
                     ret = RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
-
-                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, sizeof(new_state_buffer), app_state_bytes);
-                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, new_msg_vector.size() * sizeof(SQLTCHAR), app_msg_bytes);
+                    if (odbc_helper) {
+                        if (SQLState) {
+                            odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, sizeof(new_state_buffer), app_state_bytes);
+                        }
+                        if (MessageText) {
+                            odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, new_msg_vector.size() * sizeof(SQLTCHAR), app_msg_bytes);
+                        }
+                    }
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
                         HandleType, dbc->wrapped_dbc, RecNumber, SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
@@ -1775,8 +1803,14 @@ SQLRETURN RDS_SQLGetDiagRec(
                     );
                     ret = RDS_ProcessLibRes(SQL_HANDLE_STMT, stmt, res);
 
-                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, sizeof(new_state_buffer), app_state_bytes);
-                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, new_msg_vector.size() * sizeof(SQLTCHAR), app_msg_bytes);
+                    if (odbc_helper) {
+                        if (SQLState) {
+                            odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, sizeof(new_state_buffer), app_state_bytes);
+                        }
+                        if (MessageText) {
+                            odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, new_msg_vector.size() * sizeof(SQLTCHAR), app_msg_bytes);
+                        }
+                    }
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
                         HandleType, stmt->wrapped_stmt, RecNumber, SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
@@ -1805,8 +1839,14 @@ SQLRETURN RDS_SQLGetDiagRec(
                     );
                     ret = RDS_ProcessLibRes(SQL_HANDLE_DESC, desc, res);
 
-                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, sizeof(new_state_buffer), app_state_bytes);
-                    odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, new_msg_vector.size() * sizeof(SQLTCHAR), app_msg_bytes);
+                    if (odbc_helper) {
+                        if (SQLState) {
+                            odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_state_buffer, SQLState, sizeof(new_state_buffer), app_state_bytes);
+                        }
+                        if (MessageText) {
+                            odbc_helper->ConvertDriverOutputToTarget(WrapperCall, new_msg_buffer, MessageText, new_msg_vector.size() * sizeof(SQLTCHAR), app_msg_bytes);
+                        }
+                    }
 #else
                     res = NULL_CHECK_CALL_LIB_FUNC(env->driver_lib_loader, RDS_FP_SQLGetDiagRec, RDS_STR_SQLGetDiagRec,
                         HandleType, desc->wrapped_desc, RecNumber, SQLState, NativeErrorPtr, MessageText, BufferLength, TextLengthPtr
@@ -1832,9 +1872,7 @@ SQLRETURN RDS_SQLGetDiagRec(
         if (SQLState) {
 #ifdef UNICODE
             CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(SQLState), MAX_SQL_STATE_LEN, err->sqlstate);
-            if (odbc_helper) {
-                odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, SQLState, MAX_SQL_STATE_LEN - 1, static_cast<size_t>(MAX_SQL_STATE_LEN) * 2 * sizeof(SQLTCHAR));
-            }
+            OdbcHelper::ConvertWrapperOutputToTarget(user_4_byte, WrapperCall, SQLState, MAX_SQL_STATE_LEN - 1, static_cast<size_t>(MAX_SQL_STATE_LEN) * 2 * sizeof(SQLTCHAR));
 #else
             snprintf(reinterpret_cast<char*>(SQLState), MAX_SQL_STATE_LEN, "%s", err->sqlstate);
 #endif
@@ -1849,9 +1887,7 @@ SQLRETURN RDS_SQLGetDiagRec(
         if (MessageText && (BufferLength > 0) && err->error_msg) {
 #ifdef UNICODE
             const SQLLEN written = CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(MessageText), static_cast<size_t>(BufferLength), err->error_msg);
-            if (odbc_helper) {
-                odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, MessageText, written, app_msg_bytes);
-            }
+            OdbcHelper::ConvertWrapperOutputToTarget(user_4_byte, WrapperCall, MessageText, written, app_msg_bytes);
 #else
             const SQLLEN written = snprintf(reinterpret_cast<char*>(MessageText), static_cast<size_t>(BufferLength) / sizeof(SQLTCHAR), "%s", err->error_msg);
 #endif
@@ -1872,13 +1908,8 @@ SQLRETURN RDS_SQLGetDiagRec(
         if (SQLState) {
 #ifdef UNICODE
             CopyUTF8ToUTF16Buffer(reinterpret_cast<uint16_t*>(SQLState), MAX_SQL_STATE_LEN, NO_DATA_SQL_STATE);
-            // Expand to 4-byte if user app expects it
-            {
-                const auto odbc_helper = RDS_GetOdbcHelper(dbc, env);
-                if (odbc_helper) {
-                    odbc_helper->ConvertWrapperOutputToTarget(WrapperCall, SQLState, MAX_SQL_STATE_LEN - 1, static_cast<size_t>(MAX_SQL_STATE_LEN) * 2 * sizeof(SQLTCHAR));
-                }
-            }
+            // Expand to 4-byte if user app expects it.
+            OdbcHelper::ConvertWrapperOutputToTarget(user_4_byte, WrapperCall, SQLState, MAX_SQL_STATE_LEN - 1, static_cast<size_t>(MAX_SQL_STATE_LEN) * 2 * sizeof(SQLTCHAR));
 #else
             snprintf(reinterpret_cast<char*>(SQLState), MAX_SQL_STATE_LEN, "%s", NO_DATA_SQL_STATE);
 #endif
@@ -1950,7 +1981,7 @@ SQLRETURN RDS_SQLGetInfo(
                             info_buf.size() * sizeof(SQLTCHAR),
                             static_cast<size_t>(BufferLength));
                         odbc_helper->AdjustByteLength(StringLengthPtr);
-                    } else {
+                    } else if (InfoValuePtr) {
                         std::memcpy(InfoValuePtr, info_buf.data(), static_cast<size_t>(BufferLength) * sizeof(SQLTCHAR));
                     }
                     return RDS_ProcessLibRes(SQL_HANDLE_DBC, dbc, res);
@@ -2640,7 +2671,7 @@ SQLRETURN RDS_InitializeConnection(DBC* dbc, const std::string& conn_str)
         if (!dbc->plugin_service) {
             // Create Plugin Service
             PluginService::InitClusterId(dbc->conn_attr);
-            dbc->plugin_service = std::make_shared<PluginService>(env->driver_lib_loader, dbc->conn_attr,
+            dbc->plugin_service = std::make_shared<PluginService>(env->driver_lib_loader, env, dbc->conn_attr,
                 conn_str.empty()
                 ? ConnectionStringHelper::BuildFullConnectionString(dbc->conn_attr)
                 : conn_str

--- a/driver/odbcapi_rds_helper.h
+++ b/driver/odbcapi_rds_helper.h
@@ -397,6 +397,8 @@ SQLRETURN RDS_SQLTables(
 
 SQLRETURN RDS_InitializeConnection(DBC* dbc, const std::string& conn_str);
 
+ENV* RDS_GetEnvFromHandle(SQLSMALLINT handle_type, SQLHANDLE handle);
+
 #if UNICODE
 // Forward declaration for RDS_GetOdbcHelper
 class OdbcHelper;

--- a/driver/util/odbc_helper.cpp
+++ b/driver/util/odbc_helper.cpp
@@ -19,8 +19,9 @@
 #include "rds_lib_loader.h"
 #include "rds_strings.h"
 
-OdbcHelper::OdbcHelper(const std::shared_ptr<RdsLibLoader> &lib_loader) {
+OdbcHelper::OdbcHelper(const std::shared_ptr<RdsLibLoader> &lib_loader, const ENV *env) {
     this->lib_loader_ = lib_loader;
+    this->env_ = env;
 }
 
 void OdbcHelper::Disconnect(const DBC* dbc) {
@@ -132,15 +133,11 @@ bool OdbcHelper::GetUse4BytesBaseDriver() const {
 }
 
 bool OdbcHelper::GetUse4BytesUserApp() const {
-    return this->use_4_bytes_user_app_;
+    return this->env_ != nullptr && this->env_->use_4_bytes_user_app.load();
 }
 
 void OdbcHelper::SetUse4BytesBaseDriver(const bool use_4_bytes) {
     this->use_4_bytes_base_driver_ = use_4_bytes;
-}
-
-void OdbcHelper::SetUse4BytesUserApp(const bool use_4_bytes) {
-    this->use_4_bytes_user_app_ = use_4_bytes;
 }
 
 // codechecker_suppress [readability-convert-member-functions-to-static]
@@ -152,7 +149,7 @@ ConvertedSqltchar OdbcHelper::ConvertInput(SQLTCHAR* in, SQLINTEGER in_length) c
         return result;
     }
     result.data = ConvertUserAppInputToBaseDriver(
-        use_4_bytes_user_app_,
+        GetUse4BytesUserApp(),
         use_4_bytes_base_driver_,
         in,
         in_length);
@@ -191,8 +188,11 @@ void OdbcHelper::ConvertDriverOutputToTarget(
     const size_t src_byte_count,
     const size_t dst_byte_count) const
 {
+    if (dst == nullptr || src == nullptr || dst_byte_count == 0) {
+        return;
+    }
 #if UNICODE
-    const bool user_4_byte = !wrapper_call && use_4_bytes_user_app_;
+    const bool user_4_byte = !wrapper_call && GetUse4BytesUserApp();
     const size_t src_char_count = use_4_bytes_base_driver_
         ? src_byte_count / sizeof(SQLTCHAR) / 2
         : src_byte_count / sizeof(SQLTCHAR);
@@ -238,9 +238,19 @@ void OdbcHelper::ConvertWrapperOutputToTarget(
     const size_t char_count,
     const size_t buf_byte_count) const
 {
+    ConvertWrapperOutputToTarget(GetUse4BytesUserApp(), wrapper_call, buf, char_count, buf_byte_count);
+}
+
+// codechecker_suppress [readability-convert-member-functions-to-static]
+void OdbcHelper::ConvertWrapperOutputToTarget(
+    const bool user_4_byte,
+    const bool wrapper_call,
+    SQLTCHAR* buf,
+    const size_t char_count,
+    const size_t buf_byte_count)
+{
 #if UNICODE
-    // Wrapper output is already in 2-bytes. Only need to expand if client application requires 4-bytes.
-    if (!wrapper_call && use_4_bytes_user_app_) {
+    if (!wrapper_call && user_4_byte) {
         const size_t buf_char_count = buf_byte_count / sizeof(SQLTCHAR);
         ExpandUTF16ToUTF32InPlace(buf, char_count, buf_char_count);
     }
@@ -250,7 +260,7 @@ void OdbcHelper::ConvertWrapperOutputToTarget(
 // codechecker_suppress [readability-convert-member-functions-to-static]
 bool OdbcHelper::NeedsConversion() const {
 #if UNICODE
-    return use_4_bytes_user_app_ != use_4_bytes_base_driver_;
+    return GetUse4BytesUserApp() != use_4_bytes_base_driver_;
 #else
     return false;
 #endif
@@ -265,7 +275,7 @@ std::vector<SQLTCHAR> OdbcHelper::AllocateConversionBuffer(const size_t byte_cou
 }
 
 size_t OdbcHelper::GetTargetByteCount(const bool wrapper_call, const size_t char_count) const {
-    const size_t multiplier = !wrapper_call && use_4_bytes_user_app_ ? 2 : 1;
+    const size_t multiplier = !wrapper_call && GetUse4BytesUserApp() ? 2 : 1;
     return char_count * multiplier * sizeof(SQLTCHAR);
 }
 
@@ -317,12 +327,13 @@ bool OdbcHelper::IsStringDiagField(const SQLSMALLINT diag_identifier) {
 void OdbcHelper::AdjustByteLength(SQLSMALLINT* length_ptr) const {
 #ifdef UNICODE
     if (length_ptr && *length_ptr > 0) {
+        const bool user_4_byte = GetUse4BytesUserApp();
         // Expanded, driver 2-byte -> user 4-byte
-        if (use_4_bytes_user_app_ && !use_4_bytes_base_driver_) {
+        if (user_4_byte && !use_4_bytes_base_driver_) {
             *length_ptr *= 2;
         }
         // Shrunk, driver 4-byte -> user 2-byte
-        if (!use_4_bytes_user_app_ && use_4_bytes_base_driver_) {
+        if (!user_4_byte && use_4_bytes_base_driver_) {
             *length_ptr /= 2;
         }
     }
@@ -332,12 +343,13 @@ void OdbcHelper::AdjustByteLength(SQLSMALLINT* length_ptr) const {
 void OdbcHelper::AdjustByteLength(SQLINTEGER* length_ptr) const {
     #ifdef UNICODE
         if (length_ptr && *length_ptr > 0) {
+            const bool user_4_byte = GetUse4BytesUserApp();
             // Expanded, driver 2-byte -> user 4-byte
-            if (use_4_bytes_user_app_ && !use_4_bytes_base_driver_) {
+            if (user_4_byte && !use_4_bytes_base_driver_) {
                 *length_ptr *= 2;
             }
             // Shrunk, driver 4-byte -> user 2-byte
-            if (!use_4_bytes_user_app_ && use_4_bytes_base_driver_) {
+            if (!user_4_byte && use_4_bytes_base_driver_) {
                 *length_ptr /= 2;
             }
         }

--- a/driver/util/odbc_helper.h
+++ b/driver/util/odbc_helper.h
@@ -31,7 +31,7 @@ struct ConvertedSqltchar {
 
 class OdbcHelper {
 public:
-    OdbcHelper(const std::shared_ptr<RdsLibLoader> &lib_loader);
+    OdbcHelper(const std::shared_ptr<RdsLibLoader>& lib_loader, const ENV* env);
 
     virtual void Disconnect(const DBC *dbc);
     virtual void Disconnect(SQLHDBC *hdbc);
@@ -55,7 +55,6 @@ public:
     bool GetUse4BytesBaseDriver() const;
     bool GetUse4BytesUserApp() const;
     void SetUse4BytesBaseDriver(bool use_4_bytes);
-    void SetUse4BytesUserApp(bool use_4_bytes);
 
     // Converts a user-app SQLTCHAR* input to the encoding expected by the base
     // driver, respecting the current user_4_byte / driver_4_byte flags.
@@ -70,6 +69,7 @@ public:
 
     void ConvertWrapperOutputToTarget(SQLTCHAR* buf, size_t char_count, size_t buf_byte_count) const;
     void ConvertWrapperOutputToTarget(bool wrapper_call, SQLTCHAR* buf, size_t char_count, size_t buf_byte_count) const;
+    static void ConvertWrapperOutputToTarget(bool user_4_byte, bool wrapper_call, SQLTCHAR* buf, size_t char_count, size_t buf_byte_count);
 
     // Returns true if driver and user app character widths differ and conversion is needed.
     bool NeedsConversion() const;
@@ -90,8 +90,8 @@ public:
 
 private:
     std::shared_ptr<RdsLibLoader> lib_loader_;
+    const ENV *env_ = nullptr;
     bool use_4_bytes_base_driver_ = false;
-    bool use_4_bytes_user_app_ = false;
 };
 
 #endif //ODBC_HELPER_H

--- a/driver/util/plugin_service.cpp
+++ b/driver/util/plugin_service.cpp
@@ -28,7 +28,7 @@
 #include "../host_list_providers/host_list_provider.h"
 #include "../host_list_providers/rds_host_list_provider.h"
 
-PluginService::PluginService(const std::shared_ptr<RdsLibLoader>& lib_loader, std::map<std::string, std::string> original_conn_attr, std::string original_conn_str) :
+PluginService::PluginService(const std::shared_ptr<RdsLibLoader>& lib_loader, const ENV* env, std::map<std::string, std::string> original_conn_attr, std::string original_conn_str) :
     original_conn_str_{ std::move(original_conn_str) },
     original_conn_attr_{ std::move(original_conn_attr) }
 {
@@ -45,7 +45,7 @@ PluginService::PluginService(const std::shared_ptr<RdsLibLoader>& lib_loader, st
     this->cluster_id_ = InitClusterId(original_conn_attr_);
     this->host_selector_ = InitHostSelector(original_conn_attr_);
     this->dialect_ = InitDialect(original_conn_attr_);
-    this->odbc_helper_ = std::make_shared<OdbcHelper>(lib_loader);
+    this->odbc_helper_ = std::make_shared<OdbcHelper>(lib_loader, env);
     this->topology_util_ = std::make_shared<AuroraTopologyUtil>(this->odbc_helper_, this->dialect_);
 }
 

--- a/driver/util/plugin_service.h
+++ b/driver/util/plugin_service.h
@@ -24,6 +24,7 @@
 #include <set>
 
 struct DBC;
+struct ENV;
 
 struct HostFilter {
     std::set<std::string> allowed_host_ids;
@@ -38,7 +39,7 @@ struct HostFilter {
 class PluginService {
    public:
     PluginService() = default;
-    PluginService(const std::shared_ptr<RdsLibLoader>& lib_loader, std::map<std::string, std::string> original_conn_attr, std::string original_conn_str);
+    PluginService(const std::shared_ptr<RdsLibLoader>& lib_loader, const ENV* env, std::map<std::string, std::string> original_conn_attr, std::string original_conn_str);
     ~PluginService();
 
     virtual std::string GetClusterId();

--- a/driver/util/rds_strings.h
+++ b/driver/util/rds_strings.h
@@ -132,7 +132,7 @@ inline std::wstring ConvertUTF8ToWString(std::string input) {
     return wstr;
 }
 
-inline std::vector<uint16_t>  ConvertUTF8ToUTF16(std::string input) {
+inline std::vector<uint16_t> ConvertUTF8ToUTF16(std::string input) {
     icu::StringPiece string_piece(input.c_str(), input.length());
     icu::UnicodeString string_utf16 = icu::UnicodeString::fromUTF8(string_piece);
     uint16_t *ushort_string = reinterpret_cast<uint16_t*>(const_cast<char16_t*>(string_utf16.getTerminatedBuffer()));

--- a/test/unit_test/common_mock_objects.h
+++ b/test/unit_test/common_mock_objects.h
@@ -53,7 +53,7 @@ public:
 
 class MOCK_ODBC_HELPER : public OdbcHelper {
 public:
-    MOCK_ODBC_HELPER() : OdbcHelper(std::make_shared<RdsLibLoader>()) {};
+    MOCK_ODBC_HELPER() : OdbcHelper(std::make_shared<RdsLibLoader>(), nullptr) {};
     MOCK_METHOD(void, Disconnect, (const DBC *dbc), ());
 };
 

--- a/test/unit_test/failover_mock_objects.h
+++ b/test/unit_test/failover_mock_objects.h
@@ -48,7 +48,7 @@ class MockHostSelector : public HostSelector {
 
 class MockPluginService : public PluginService {
     public:
-        MockPluginService() : PluginService(nullptr, {}, "") {}
+        MockPluginService() : PluginService(nullptr, nullptr, {}, "") {}
         std::vector<HostInfo> GetHosts() override { return {}; }
         void SetHosts(const std::vector<HostInfo>&) override {}
 };

--- a/test/unit_test/limitless_mock_objects.h
+++ b/test/unit_test/limitless_mock_objects.h
@@ -49,7 +49,7 @@ public:
         BasePlugin* plugin_head,
         DBC* dbc,
         const std::shared_ptr<DialectLimitless>& dialect) const override {
-        return std::make_shared<MockLimitlessRouterMonitor>(plugin_head, std::make_shared<OdbcHelper>(nullptr), dialect);
+        return std::make_shared<MockLimitlessRouterMonitor>(plugin_head, std::make_shared<OdbcHelper>(nullptr, nullptr), dialect);
     };
 };
 

--- a/test/unit_test/limitless_plugin_test.cpp
+++ b/test/unit_test/limitless_plugin_test.cpp
@@ -50,7 +50,7 @@ TEST_F(LimitlessPluginTest, Connect_Success) {
         .Times(testing::Exactly(0));
     dbc->conn_attr.insert_or_assign(KEY_ENABLE_LIMITLESS, VALUE_BOOL_TRUE);
     std::shared_ptr<DialectAuroraPostgresLimitless> dialect = std::make_shared<DialectAuroraPostgresLimitless>();
-    std::shared_ptr<MockLimitlessRouterService> mock_router_service = std::make_shared<MockLimitlessRouterService>(dialect, dbc->conn_attr, std::make_shared<OdbcHelper>(nullptr));
+    std::shared_ptr<MockLimitlessRouterService> mock_router_service = std::make_shared<MockLimitlessRouterService>(dialect, dbc->conn_attr, std::make_shared<OdbcHelper>(nullptr, nullptr));
     EXPECT_CALL(*mock_router_service, StartMonitoring(testing::_, testing::_)).Times(testing::Exactly(1));
     EXPECT_CALL(*mock_router_service, EstablishConnection(testing::_, testing::_)).Times(testing::Exactly(1)).WillOnce(testing::Return(SQL_SUCCESS));
     LimitlessPlugin plugin(dbc, mock_base_plugin, dialect, mock_router_service, nullptr);
@@ -66,7 +66,7 @@ TEST_F(LimitlessPluginTest, Connect_LimitlessDisabled) {
         .WillOnce(testing::Return(SQL_SUCCESS));
     dbc->conn_attr.insert_or_assign(KEY_ENABLE_LIMITLESS, VALUE_BOOL_FALSE);
     std::shared_ptr<DialectAuroraPostgresLimitless> dialect = std::make_shared<DialectAuroraPostgresLimitless>();
-    std::shared_ptr<MockLimitlessRouterService> mock_router_service = std::make_shared<MockLimitlessRouterService>(dialect, dbc->conn_attr, std::make_shared<OdbcHelper>(nullptr));
+    std::shared_ptr<MockLimitlessRouterService> mock_router_service = std::make_shared<MockLimitlessRouterService>(dialect, dbc->conn_attr, std::make_shared<OdbcHelper>(nullptr, nullptr));
     EXPECT_CALL(*mock_router_service, StartMonitoring(testing::_, testing::_)).Times(testing::Exactly(0));
     EXPECT_CALL(*mock_router_service, EstablishConnection(testing::_, testing::_)).Times(testing::Exactly(0));
     LimitlessPlugin plugin(dbc, mock_base_plugin, dialect, mock_router_service, nullptr);

--- a/test/unit_test/limitless_router_service_test.cpp
+++ b/test/unit_test/limitless_router_service_test.cpp
@@ -38,7 +38,7 @@ protected:
         mock_base_plugin = new MOCK_BASE_PLUGIN();
         dbc = new DBC();
         dbc->plugin_head = mock_base_plugin;
-        odbc_helper_ = std::make_shared<OdbcHelper>(nullptr);
+        odbc_helper_ = std::make_shared<OdbcHelper>(nullptr, nullptr);
     }
     void TearDown() override {
         // mock_base_plugin should be cleaned up by plugin chain

--- a/test/unit_test/plugin_service_test.cpp
+++ b/test/unit_test/plugin_service_test.cpp
@@ -41,7 +41,7 @@ protected:
         all_hosts.push_back(host_b);
         all_hosts.push_back(host_c);
         std::map<std::string, std::string> empty_map;
-        plugin_service = std::make_shared<PluginService>(nullptr, empty_map, "ClusterId");
+        plugin_service = std::make_shared<PluginService>(nullptr, nullptr, empty_map, "ClusterId");
         plugin_service->SetHosts(all_hosts);
     }
     void TearDown() override {}


### PR DESCRIPTION
### Summary

Refactor User's 4-Byte Flag to Env

### Description

Moving the user 4-byte flag from ODBC Helper into ENV to be able to be used when the connection did not successfully connect allows us to use the flag for error handling

### Testing

<!-- What did you test and how did you test it -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
