### PR TITLE
chore: reenable Aurora MySQL dialect in DSN

### DIFF
--- a/driver/gui/setup.cpp
+++ b/driver/gui/setup.cpp
@@ -219,7 +219,7 @@ const std::vector<std::pair<std::string, std::string>> DB_DIALECTS = {
     {"", ""},
     {"Aurora PostgreSQL", VALUE_DB_DIALECT_AURORA_POSTGRESQL},
     {"Aurora PostgreSQL Limitless", VALUE_DB_DIALECT_AURORA_POSTGRESQL_LIMITLESS},
-    // {"Aurora MySQL", VALUE_DB_DIALECT_AURORA_MYSQL}
+    {"Aurora MySQL", VALUE_DB_DIALECT_AURORA_MYSQL}
 };
 
 const std::vector<std::pair<std::string, std::string>> MFA_TYPES = {


### PR DESCRIPTION
### Summary
Enable the Aurora MySQL dialect option for Windows DSN

### Description

<!--- Details of what you changed -->

### Testing

<!-- What did you test and how did you test it -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
