### PR TITLE
chore: add MariaDB connector for Aurora MySQL IAM integration tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -36,6 +36,9 @@ env:
   DRIVER_NAME_ANSI: 'AWS Advanced ODBC Wrapper Ansi'
   DRIVER_NAME_UNICODE: 'AWS Advanced ODBC Wrapper Unicode'
 
+  # Alternate Aurora MySQL base driver; unlike MySQL Connector it supports RDS IAM auth.
+  MARIADB_ODBC_VERSION: '3.2.8'
+
 concurrency:
   group: integration-test-${{ github.ref }}
   cancel-in-progress: true
@@ -222,10 +225,34 @@ jobs:
             -L "https://dev.mysql.com/get/Downloads/Connector-ODBC/9.5/mysql-connector-odbc_9.5.0-1ubuntu24.04_amd64.deb" \
             --output mysql-connector_x64.deb
 
+  build-win-mariadb:
+    name: Windows - Get MariaDB Connector ODBC
+    runs-on: windows-latest
+    steps:
+      - name: Retrieve mariadb-connector Cache
+        id: cache-mariadb-connector
+        uses: actions/cache@v5
+        with:
+          path: mariadb-connector
+          key: ${{ runner.os }}-mariadb-driver-${{ env.MARIADB_ODBC_VERSION }}
+      - name: Download mariadb-connector
+        if: ${{steps.cache-mariadb-connector.outputs.cache-hit != 'true'}}
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path mariadb-connector | Out-Null
+          $url = "https://dlm.mariadb.com/Connectors/odbc/connector-odbc-${{ env.MARIADB_ODBC_VERSION }}/mariadb-connector-odbc-${{ env.MARIADB_ODBC_VERSION }}-win64.msi"
+          $out = "mariadb-connector/mariadb-connector_x64.msi"
+          # --fail: error on HTTP >=400 instead of saving an HTML error page.
+          curl.exe --fail --location --retry 3 --retry-delay 5 "$url" --output $out
+          if ($LASTEXITCODE -ne 0) { Write-Error "MariaDB ODBC MSI download failed from $url"; exit 1 }
+          $size = (Get-Item $out).Length
+          Write-Host "Downloaded $out ($size bytes)"
+          if ($size -lt 100000) { Write-Error "Downloaded MSI is suspiciously small ($size bytes); likely not a valid MSI."; exit 1 }
+
 # Integration - General
   windows-integration-tests:
     name: Windows - Integration Tests
-    needs: [build-win-psqlodbc, build-win-mysql]
+    needs: [build-win-psqlodbc, build-win-mysql, build-win-mariadb]
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -282,7 +309,7 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: odbc-wrapper-win-inte
-          role-duration-seconds: 14400
+          role-duration-seconds: 43200
       - name: Setup Python virtual environment
         shell: bash
         run: |
@@ -326,12 +353,21 @@ jobs:
             echo "driver_path_unicode=C:\\Program Files\\MySQL\\MySQL Connector ODBC 9.5\\myodbc9w.dll" >> $GITHUB_OUTPUT
             echo "dialect_default_port=3306" >> $GITHUB_OUTPUT
             echo "database_dialect=${{ matrix.database_dialect }}" >> $GITHUB_OUTPUT
+            echo "mariadb_cache_key=${{ runner.os }}-mariadb-driver-${{ env.MARIADB_ODBC_VERSION }}" >> $GITHUB_OUTPUT
+            echo "maodbc_path=C:\\Program Files\\MariaDB\\MariaDB ODBC Driver 64-bit\\maodbc.dll" >> $GITHUB_OUTPUT
           fi
       - name: Retrieve Base Driver
         uses: actions/cache@v5
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
+          fail-on-cache-miss: true
+      - name: Retrieve MariaDB Connector
+        if: (matrix.rds_engine == 'aurora-mysql')
+        uses: actions/cache@v5
+        with:
+          path: mariadb-connector
+          key: ${{steps.base_driver_info.outputs.mariadb_cache_key}}
           fail-on-cache-miss: true
       - name: Log base driver location
         shell: pwsh
@@ -367,6 +403,24 @@ jobs:
         working-directory: ${{steps.base_driver_info.outputs.cache_path}}
         run: |
           Start-Process msiexec "/i mysql-connector_x64.msi /quiet /norestart" -Wait;
+      - name: Install MariaDB Connector ODBC
+        if: (matrix.rds_engine == 'aurora-mysql')
+        shell: pwsh
+        working-directory: mariadb-connector
+        run: |
+          Start-Process msiexec "/i mariadb-connector_x64.msi /quiet /norestart" -Wait;
+          if (-not (Test-Path "${{steps.base_driver_info.outputs.maodbc_path}}")) {
+            Write-Host "MariaDB ODBC driver not found at expected path."
+            Get-ChildItem "C:\Program Files\MariaDB" -Recurse -ErrorAction SilentlyContinue | Format-Table FullName
+            exit 1
+          }
+      - name: Download RDS CA bundle (MariaDB TLS)
+        if: (matrix.rds_engine == 'aurora-mysql')
+        shell: pwsh
+        run: |
+          $caPath = "$env:RUNNER_TEMP\rds-global-bundle.pem"
+          curl.exe -L "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" --output $caPath
+          echo "RDS_CA_BUNDLE=$caPath" >> $env:GITHUB_ENV
       - name: Resolve Driver Paths
         id: resolved_drivers
         shell: pwsh
@@ -402,6 +456,31 @@ jobs:
               "Port=${{steps.base_driver_info.outputs.dialect_default_port}}", `
               "SSLMode=prefer", `
               "BASE_DRIVER=${{steps.resolved_drivers.outputs.driver_path_unicode}}")
+      - name: Install MariaDB DSNs
+        if: (matrix.rds_engine == 'aurora-mysql')
+        shell: pwsh
+        run: |
+            # SSLCA (RDS CA bundle) gives verified TLS so the IAM token is sent encrypted.
+            Add-OdbcDsn -Name "AWS-ODBC-MARIADB-ANSI" `
+              -DriverName "${{ env.DRIVER_NAME_ANSI }}" `
+              -DsnType User `
+              -SetPropertyValue `
+              @("RDS_AUTH_TYPE=database", `
+              "Server=${{ env.AURORA_CLUSTER_ENDPOINT }}", `
+              "Port=${{steps.base_driver_info.outputs.dialect_default_port}}", `
+              "SSLMode=prefer", `
+              "SSLCA=$env:RDS_CA_BUNDLE", `
+              "BASE_DRIVER=${{steps.base_driver_info.outputs.maodbc_path}}")
+            Add-OdbcDsn -Name "AWS-ODBC-MARIADB-UNICODE" `
+              -DriverName "${{ env.DRIVER_NAME_UNICODE }}" `
+              -DsnType User `
+              -SetPropertyValue `
+              @("RDS_AUTH_TYPE=database", `
+              "Server=${{ env.AURORA_CLUSTER_ENDPOINT }}", `
+              "Port=${{steps.base_driver_info.outputs.dialect_default_port}}", `
+              "SSLMode=prefer", `
+              "SSLCA=$env:RDS_CA_BUNDLE", `
+              "BASE_DRIVER=${{steps.base_driver_info.outputs.maodbc_path}}")
       - name: Verify DSN Configuration
         shell: pwsh
         run: |
@@ -419,7 +498,7 @@ jobs:
       - name: Build and Run Ansi Integration Tests
         id: ansi_tests
         shell: pwsh
-        if: ${{steps.AuroraClusterSetup.outcome == 'success'}}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_ansi -D CMAKE_BUILD_TYPE="${{env.BUILD_CONFIG}}" `
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF
@@ -441,6 +520,7 @@ jobs:
           TEST_PORT: ${{steps.base_driver_info.outputs.dialect_default_port}}
           TEST_DIALECT: "${{ steps.base_driver_info.outputs.database_dialect }}"
           TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
+          TEST_SKIP_IAM: "${{ (matrix.rds_engine == 'aurora-mysql' || matrix.rds_engine == 'multi-az-mysql') && '1' || '' }}"
       - name: Stabilize cluster between test runs
         shell: bash
         if: ${{ steps.AuroraClusterSetup.outcome == 'success' && (success() || failure()) }}
@@ -452,7 +532,7 @@ jobs:
       - name: Build and Run Unicode Integration Tests
         id: unicode_tests
         shell: pwsh
-        if: ${{ steps.AuroraClusterSetup.outcome == 'success' && (success() || failure()) }}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_unicode -D CMAKE_BUILD_TYPE="${{env.BUILD_CONFIG}}" `
             -D BUILD_UNICODE=ON -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF
@@ -464,6 +544,52 @@ jobs:
           if ($unicodeNonFailoverRc -ne 0 -or $unicodeFailoverRc -ne 0) { exit 1 }
         env:
           TEST_DSN: ${{ env.TEST_DSN_UNICODE }}
+          TEST_DATABASE: ${{ env.TEST_DATABASE }}
+          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+          TEST_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}
+          TEST_SECRET_ARN: ${{ env.AURORA_CLUSTER_SECRETS_ARN }}
+          TEST_SERVER: ${{ env.AURORA_CLUSTER_ENDPOINT }}
+          TEST_PORT: ${{steps.base_driver_info.outputs.dialect_default_port}}
+          TEST_DIALECT: "${{ steps.base_driver_info.outputs.database_dialect }}"
+          TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
+          TEST_SKIP_IAM: "${{ (matrix.rds_engine == 'aurora-mysql' || matrix.rds_engine == 'multi-az-mysql') && '1' || '' }}"
+      # ---- MariaDB Connector/ODBC on the SAME Aurora MySQL cluster (IAM runs here) ----
+      - name: Build and Run MariaDB Ansi Integration Tests
+        shell: pwsh
+        if: ${{ !cancelled() && matrix.rds_engine == 'aurora-mysql' && steps.AuroraClusterSetup.outcome == 'success' }}
+        run: |
+          cmake -S test/integration -B build_mariadb_ansi -D CMAKE_BUILD_TYPE="${{env.BUILD_CONFIG}}" `
+            -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF
+          cmake --build build_mariadb_ansi --config ${{env.BUILD_CONFIG}}
+          echo "MariaDB Ansi Test Built"
+          @(".symfix+", 'sxe -c ".echo --- CRASH STACK ---;~* kvn;.echo --- END CRASH STACK ---;g" av', "g") | Set-Content -Path cdb_cmd.txt
+          & "${{env.CDB_PATH}}" -G -lines -y ".\build_mariadb_ansi\${{env.BUILD_CONFIG}}" -cf cdb_cmd.txt .\build_mariadb_ansi\${{env.BUILD_CONFIG}}\integration-test.exe
+        env:
+          TEST_DSN: "AWS-ODBC-MARIADB-ANSI"
+          TEST_DATABASE: ${{ env.TEST_DATABASE }}
+          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+          TEST_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}
+          TEST_SECRET_ARN: ${{ env.AURORA_CLUSTER_SECRETS_ARN }}
+          TEST_SERVER: ${{ env.AURORA_CLUSTER_ENDPOINT }}
+          TEST_PORT: ${{steps.base_driver_info.outputs.dialect_default_port}}
+          TEST_DIALECT: "${{ steps.base_driver_info.outputs.database_dialect }}"
+          TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
+      - name: Build and Run MariaDB Unicode Integration Tests
+        shell: pwsh
+        if: ${{ !cancelled() && matrix.rds_engine == 'aurora-mysql' && steps.AuroraClusterSetup.outcome == 'success' }}
+        run: |
+          cmake -S test/integration -B build_mariadb_unicode -D CMAKE_BUILD_TYPE="${{env.BUILD_CONFIG}}" `
+            -D BUILD_UNICODE=ON -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF
+          cmake --build build_mariadb_unicode --config ${{env.BUILD_CONFIG}}
+          echo "MariaDB Unicode Test Built"
+          @(".symfix+", 'sxe -c ".echo --- CRASH STACK ---;~* kvn;.echo --- END CRASH STACK ---;g" av', "g") | Set-Content -Path cdb_cmd.txt
+          & "${{env.CDB_PATH}}" -G -lines -y ".\build_mariadb_unicode\${{env.BUILD_CONFIG}}" -cf cdb_cmd.txt .\build_mariadb_unicode\${{env.BUILD_CONFIG}}\integration-test.exe
+        env:
+          TEST_DSN: "AWS-ODBC-MARIADB-UNICODE"
           TEST_DATABASE: ${{ env.TEST_DATABASE }}
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
@@ -586,7 +712,7 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: odbc-wrapper-macos-inte
-          role-duration-seconds: 14400
+          role-duration-seconds: 43200
       - name: Setup Python virtual environment
         shell: bash
         run: |
@@ -643,6 +769,7 @@ jobs:
             echo "driver_path_unicode='${{ github.workspace }}/mysql-connector/lib/libmyodbc9w.so'" >> $GITHUB_OUTPUT
             echo "dialect_default_port=3306" >> $GITHUB_OUTPUT
             echo "database_dialect=${{ matrix.env.database_dialect }}" >> $GITHUB_OUTPUT
+            echo "MARIADB_DRIVER_PATH=/opt/homebrew/Cellar/mariadb-connector-odbc/3.2.8/lib/mariadb/libmaodbc.dylib" >> $GITHUB_ENV
           fi
       - name: Retrieve Base Driver
         uses: actions/cache@v5
@@ -657,10 +784,15 @@ jobs:
           echo "--- ODBC DSN config ---"
           odbcinst -j 2>/dev/null || true
           cat $ODBCINST 2>/dev/null || cat /etc/odbcinst.ini 2>/dev/null || true
+      - name: Download RDS CA bundle (MariaDB TLS)
+        if: (matrix.env.rds_engine == 'aurora-mysql')
+        shell: bash
+        run: |
+          curl -L "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" --output "${{ github.workspace }}/rds-global-bundle.pem"
       - name: Build and Run Ansi Integration Tests
         id: ansi_tests
         shell: bash
-        if: ${{steps.AuroraClusterSetup.outcome == 'success'}}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_ansi \
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF \
@@ -688,6 +820,7 @@ jobs:
           ODBCINI: "${{ github.workspace }}/test/resources/odbc.ini"
           ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
           TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
+          TEST_SKIP_IAM: "${{ (matrix.rds_engine == 'aurora-mysql' || matrix.rds_engine == 'multi-az-mysql') && '1' || '' }}"
       - name: Stabilize cluster between test runs
         shell: bash
         if: ${{ steps.AuroraClusterSetup.outcome == 'success' && (success() || failure()) }}
@@ -697,9 +830,8 @@ jobs:
             --cluster-id "${{ env.AURORA_CLUSTER_ID }}" \
             --region "${{ secrets.AWS_DEFAULT_REGION }}"
       - name: Build and Run Unicode Integration Tests
-        id: unicode_tests
         shell: bash
-        if: ${{ steps.AuroraClusterSetup.outcome == 'success' && (success() || failure()) }}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_unicode \
             -D BUILD_UNICODE=ON -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF \
@@ -727,6 +859,7 @@ jobs:
           ODBCINI: "${{ github.workspace }}/test/resources/odbc.ini"
           ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
           TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
+          TEST_SKIP_IAM: "${{ (matrix.rds_engine == 'aurora-mysql' || matrix.rds_engine == 'multi-az-mysql') && '1' || '' }}"
       - name: Dump RDS events on failure
         if: always()
         shell: bash
@@ -744,6 +877,65 @@ jobs:
               --source-type db-instance \
               --duration 120 || true
           done
+      # ---- MariaDB Connector/ODBC on the SAME Aurora MySQL cluster (IAM runs here) ----
+      - name: Build and Run MariaDB Ansi Integration Tests
+        shell: bash
+        if: ${{ !cancelled() && matrix.env.rds_engine == 'aurora-mysql' && steps.AuroraClusterSetup.outcome == 'success' }}
+        run: |
+          cmake -S test/integration -B build_mariadb_ansi \
+            -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF \
+            -D CMAKE_BUILD_TYPE=${{env.BUILD_CONFIG}} \
+            -D TEST_DRIVER_PATH="${{ github.workspace }}/build/driver/aws-advanced-odbc-wrapper-a.dylib" \
+            -D BASE_DRIVER_PATH="$MARIADB_DRIVER_PATH" \
+            -D TEST_SERVER="${{ env.AURORA_CLUSTER_ENDPOINT }}" \
+            -D TEST_DATABASE="${{ env.TEST_DATABASE }}" \
+            -D BASE_DRIVER_SSL_CA="${{ github.workspace }}/rds-global-bundle.pem"
+          cmake --build build_mariadb_ansi
+          echo "MariaDB Ansi Test Built"
+          ./build_mariadb_ansi/integration-test
+        env:
+          TEST_DSN: "inte-wrapper-dsn"
+          TEST_DATABASE: ${{ env.TEST_DATABASE }}
+          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+          TEST_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}
+          TEST_SECRET_ARN: ${{ env.AURORA_CLUSTER_SECRETS_ARN }}
+          TEST_SERVER: ${{ env.AURORA_CLUSTER_ENDPOINT }}
+          TEST_PORT: "${{ steps.base_driver_info.outputs.dialect_default_port }}"
+          TEST_DIALECT: "${{ steps.base_driver_info.outputs.database_dialect }}"
+          ODBCINI: "${{ github.workspace }}/test/resources/odbc.ini"
+          ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
+          TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
+      - name: Build and Run MariaDB Unicode Integration Tests
+        shell: bash
+        if: ${{ !cancelled() && matrix.env.rds_engine == 'aurora-mysql' && steps.AuroraClusterSetup.outcome == 'success' }}
+        run: |
+          cmake -S test/integration -B build_mariadb_unicode \
+            -D BUILD_UNICODE=ON -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF \
+            -D CMAKE_BUILD_TYPE=${{env.BUILD_CONFIG}} \
+            -D TEST_DRIVER_PATH="${{ github.workspace }}/build/driver/aws-advanced-odbc-wrapper-w.dylib" \
+            -D BASE_DRIVER_PATH="$MARIADB_DRIVER_PATH" \
+            -D TEST_SERVER="${{ env.AURORA_CLUSTER_ENDPOINT }}" \
+            -D TEST_DATABASE="${{ env.TEST_DATABASE }}" \
+            -D BASE_DRIVER_SSL_CA="${{ github.workspace }}/rds-global-bundle.pem"
+          cmake --build build_mariadb_unicode
+          echo "MariaDB Unicode Test Built"
+          ./build_mariadb_unicode/integration-test
+        env:
+          TEST_DSN: "inte-wrapper-dsn"
+          TEST_DATABASE: ${{ env.TEST_DATABASE }}
+          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+          TEST_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}
+          TEST_SECRET_ARN: ${{ env.AURORA_CLUSTER_SECRETS_ARN }}
+          TEST_SERVER: ${{ env.AURORA_CLUSTER_ENDPOINT }}
+          TEST_PORT: "${{ steps.base_driver_info.outputs.dialect_default_port }}"
+          TEST_DIALECT: "${{ steps.base_driver_info.outputs.database_dialect }}"
+          ODBCINI: "${{ github.workspace }}/test/resources/odbc.ini"
+          ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
+          TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
       - name: Get log location
         if: always()
         id: log_location
@@ -824,7 +1016,7 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: odbc-wrapper-linux-inte
-          role-duration-seconds: 14400
+          role-duration-seconds: 43200
       - name: Setup Python virtual environment
         shell: bash
         run: |
@@ -889,13 +1081,33 @@ jobs:
         shell: bash
         run: |
           sudo apt install ./mysql-connector/mysql-connector_x64.deb -y
+      - name: Install MariaDB Connector ODBC
+        if: (matrix.rds_engine == 'aurora-mysql')
+        shell: bash
+        run: |
+          # Pinned official .deb (ubuntu-latest == noble, amd64); avoids the unpinned Ubuntu 'odbc-mariadb'.
+          DEB="mariadb-connector-odbc_${MARIADB_ODBC_VERSION}-1+maria~noble_amd64.deb"
+          URL="https://dlm.mariadb.com/Connectors/odbc/connector-odbc-${MARIADB_ODBC_VERSION}/${DEB}"
+          curl --fail --location --retry 3 --retry-delay 5 "$URL" --output "$RUNNER_TEMP/$DEB"
+          sudo apt-get update  # apt-get resolves the deb's runtime deps (unixodbc, etc.)
+          sudo apt-get install -y "$RUNNER_TEMP/$DEB"
+          # Discover the installed path rather than hardcoding it; export for the MariaDB test steps.
+          MARIADB_DRIVER_PATH="$(dpkg -L mariadb-connector-odbc | grep -E 'libmaodbc\.so$' | head -n1)"
+          test -n "$MARIADB_DRIVER_PATH" && test -f "$MARIADB_DRIVER_PATH"
+          echo "MARIADB_DRIVER_PATH=$MARIADB_DRIVER_PATH" >> "$GITHUB_ENV"
+          echo "Resolved MariaDB ODBC driver: $MARIADB_DRIVER_PATH"
+      - name: Download RDS CA bundle (MariaDB TLS)
+        if: (matrix.rds_engine == 'aurora-mysql')
+        shell: bash
+        run: |
+          curl -L "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" --output "${{ github.workspace }}/rds-global-bundle.pem"
       - name: Setup GDB
         run: |
           echo "set auto-load safe-path $PWD" > ~/.gdbinit
       - name: Build and Run Ansi Integration Tests
         id: ansi_tests
         shell: bash
-        if: ${{steps.AuroraClusterSetup.outcome == 'success'}}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_ansi \
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF  \
@@ -924,6 +1136,7 @@ jobs:
           ODBCINI: "${{ github.workspace }}/test/resources/odbc.ini"
           ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
           TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
+          TEST_SKIP_IAM: "${{ (matrix.rds_engine == 'aurora-mysql' || matrix.rds_engine == 'multi-az-mysql') && '1' || '' }}"
       - name: Stabilize cluster between test runs
         shell: bash
         if: ${{ steps.AuroraClusterSetup.outcome == 'success' && (success() || failure()) }}
@@ -933,9 +1146,8 @@ jobs:
             --cluster-id "${{ env.AURORA_CLUSTER_ID }}" \
             --region "${{ secrets.AWS_DEFAULT_REGION }}"
       - name: Build and Run Unicode Integration Tests
-        id: unicode_tests
         shell: bash
-        if: ${{ steps.AuroraClusterSetup.outcome == 'success' && (success() || failure()) }}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_unicode \
             -D BUILD_UNICODE=ON -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF \
@@ -950,6 +1162,68 @@ jobs:
           gdb -q -x ./.gdbinit --args ./build_unicode/integration-test --gtest_filter=-FailoverIntegrationTest.*:ReadWriteSplittingIntegrationTest.WriterFailoverReadOnly:ReadWriteSplittingIntegrationTest.FailoverToNewReaderReadOnly || UNICODE_NON_FAILOVER_RC=$?
           gdb -q -x ./.gdbinit --args ./build_unicode/integration-test --gtest_filter=FailoverIntegrationTest.*:ReadWriteSplittingIntegrationTest.WriterFailoverReadOnly:ReadWriteSplittingIntegrationTest.FailoverToNewReaderReadOnly || UNICODE_FAILOVER_RC=$?
           if [ "${UNICODE_NON_FAILOVER_RC:-0}" -ne 0 ] || [ "${UNICODE_FAILOVER_RC:-0}" -ne 0 ]; then exit 1; fi
+        env:
+          TEST_DSN: "inte-wrapper-dsn"
+          TEST_DATABASE: ${{ env.TEST_DATABASE }}
+          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+          TEST_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}
+          TEST_SECRET_ARN: ${{ env.AURORA_CLUSTER_SECRETS_ARN }}
+          TEST_SERVER: ${{ env.AURORA_CLUSTER_ENDPOINT }}
+          TEST_PORT: "${{ steps.base_driver_info.outputs.dialect_default_port }}"
+          TEST_DIALECT: "${{ steps.base_driver_info.outputs.database_dialect }}"
+          ODBCINI: "${{ github.workspace }}/test/resources/odbc.ini"
+          ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
+          TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
+          TEST_SKIP_IAM: "${{ (matrix.rds_engine == 'aurora-mysql' || matrix.rds_engine == 'multi-az-mysql') && '1' || '' }}"
+      # ---- MariaDB Connector/ODBC on the SAME Aurora MySQL cluster (IAM runs here) ----
+      - name: Build and Run MariaDB Ansi Integration Tests
+        shell: bash
+        if: ${{ !cancelled() && matrix.rds_engine == 'aurora-mysql' && steps.AuroraClusterSetup.outcome == 'success' }}
+        run: |
+          cmake -S test/integration -B build_mariadb_ansi \
+            -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF \
+            -D CMAKE_BUILD_TYPE=${{env.BUILD_CONFIG}} \
+            -D TEST_DRIVER_PATH="${{ github.workspace }}/build/driver/aws-advanced-odbc-wrapper-a.so" \
+            -D BASE_DRIVER_PATH="$MARIADB_DRIVER_PATH" \
+            -D TEST_SERVER="${{ env.AURORA_CLUSTER_ENDPOINT }}" \
+            -D TEST_DATABASE="${{ env.TEST_DATABASE }}" \
+            -D BASE_DRIVER_SSL_CA="${{ github.workspace }}/rds-global-bundle.pem"
+          cmake --build build_mariadb_ansi
+          echo "MariaDB Ansi Test Built"
+          ulimit -c unlimited
+          gdb -q -x ./.gdbinit ./build_mariadb_ansi/integration-test
+        env:
+          TEST_DSN: "inte-wrapper-dsn"
+          TEST_DATABASE: ${{ env.TEST_DATABASE }}
+          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+          TEST_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          TEST_IAM_USER: ${{ secrets.TEST_IAM_USER }}
+          TEST_SECRET_ARN: ${{ env.AURORA_CLUSTER_SECRETS_ARN }}
+          TEST_SERVER: ${{ env.AURORA_CLUSTER_ENDPOINT }}
+          TEST_PORT: "${{ steps.base_driver_info.outputs.dialect_default_port }}"
+          TEST_DIALECT: "${{ steps.base_driver_info.outputs.database_dialect }}"
+          ODBCINI: "${{ github.workspace }}/test/resources/odbc.ini"
+          ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
+          TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
+      - name: Build and Run MariaDB Unicode Integration Tests
+        shell: bash
+        if: ${{ !cancelled() && matrix.rds_engine == 'aurora-mysql' && steps.AuroraClusterSetup.outcome == 'success' }}
+        run: |
+          cmake -S test/integration -B build_mariadb_unicode \
+            -D BUILD_UNICODE=ON -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF \
+            -D CMAKE_BUILD_TYPE=${{env.BUILD_CONFIG}} \
+            -D TEST_DRIVER_PATH="${{ github.workspace }}/build/driver/aws-advanced-odbc-wrapper-w.so" \
+            -D BASE_DRIVER_PATH="$MARIADB_DRIVER_PATH" \
+            -D TEST_SERVER="${{ env.AURORA_CLUSTER_ENDPOINT }}" \
+            -D TEST_DATABASE="${{ env.TEST_DATABASE }}" \
+            -D BASE_DRIVER_SSL_CA="${{ github.workspace }}/rds-global-bundle.pem"
+          cmake --build build_mariadb_unicode
+          echo "MariaDB Unicode Test Built"
+          ulimit -c unlimited
+          gdb -q -x ./.gdbinit ./build_mariadb_unicode/integration-test
         env:
           TEST_DSN: "inte-wrapper-dsn"
           TEST_DATABASE: ${{ env.TEST_DATABASE }}
@@ -1033,6 +1307,7 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: odbc-wrapper-win-limitless
+          role-duration-seconds: 43200
       - name: Setup Python virtual environment
         shell: bash
         run: |
@@ -1137,7 +1412,7 @@ jobs:
           Write-Host "Found cdb at: $cdb"
       - name: Build and Run Limitless Ansi Integration Tests
         shell: pwsh
-        if: ${{steps.AuroraClusterSetup.outcome == 'success'}}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_limitless_ansi -D CMAKE_BUILD_TYPE="${{env.BUILD_CONFIG}}" `
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=OFF -D BUILD_LIMITLESS=ON
@@ -1158,7 +1433,7 @@ jobs:
           TEST_DIALECT: "${{ steps.base_driver_info.outputs.database_dialect }}"
       - name: Build and Run Limitless Unicode Integration Tests
         shell: pwsh
-        if: ${{steps.AuroraClusterSetup.outcome == 'success'}}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_limitless_unicode -D CMAKE_BUILD_TYPE="${{env.BUILD_CONFIG}}" `
             -D BUILD_UNICODE=ON -D BUILD_FAILOVER=OFF -D BUILD_LIMITLESS=ON
@@ -1253,6 +1528,7 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: odbc-wrapper-macos-limitless
+          role-duration-seconds: 43200
       - name: Setup Python virtual environment
         shell: bash
         run: |
@@ -1302,7 +1578,7 @@ jobs:
           cat $ODBCINST 2>/dev/null || cat /etc/odbcinst.ini 2>/dev/null || true
       - name: Build and Run Limitless Ansi Integration Tests
         shell: bash
-        if: ${{steps.AuroraClusterSetup.outcome == 'success'}}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_limitless_ansi \
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=OFF -D BUILD_LIMITLESS=ON  \
@@ -1329,7 +1605,7 @@ jobs:
           ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
       - name: Build and Run Limitless Unicode Integration Tests
         shell: bash
-        if: ${{steps.AuroraClusterSetup.outcome == 'success'}}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_limitless_unicode \
             -D BUILD_UNICODE=ON -D BUILD_FAILOVER=OFF -D BUILD_LIMITLESS=ON  \
@@ -1415,6 +1691,7 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: odbc-wrapper-linux-limitless
+          role-duration-seconds: 43200
       - name: Setup Python virtual environment
         shell: bash
         run: |
@@ -1467,7 +1744,7 @@ jobs:
           echo "set auto-load safe-path $PWD" > ~/.gdbinit
       - name: Build and Run Limitless Ansi Integration Tests
         shell: bash
-        if: ${{steps.AuroraClusterSetup.outcome == 'success'}}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_limitless_ansi \
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=OFF -D BUILD_LIMITLESS=ON  \
@@ -1495,7 +1772,7 @@ jobs:
           ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
       - name: Build and Run Limitless Unicode Integration Tests
         shell: bash
-        if: ${{steps.AuroraClusterSetup.outcome == 'success'}}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_limitless_unicode \
             -D BUILD_UNICODE=ON -D BUILD_FAILOVER=OFF -D BUILD_LIMITLESS=ON  \
@@ -1713,7 +1990,7 @@ jobs:
           echo "set auto-load safe-path /" > "$HOME/.gdbinit"
       - name: Build and Run Blue/Green Ansi Integration Tests
         shell: pwsh
-        if: ${{steps.AuroraClusterSetup.outcome == 'success'}}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_bg_ansi -D CMAKE_BUILD_TYPE="${{env.BUILD_CONFIG}}" `
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=OFF -D BUILD_LIMITLESS=OFF -D BUILD_BLUE_GREEN=ON
@@ -1863,7 +2140,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Build and Run Blue/Green Ansi Integration Tests
         shell: bash
-        if: ${{steps.AuroraClusterSetup.outcome == 'success'}}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_bg_ansi \
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=OFF -D BUILD_LIMITLESS=OFF -D BUILD_BLUE_GREEN=ON \
@@ -2012,7 +2289,7 @@ jobs:
           echo "set auto-load safe-path $PWD" > ~/.gdbinit
       - name: Build and Run Blue/Green Ansi Integration Tests
         shell: bash
-        if: ${{steps.AuroraClusterSetup.outcome == 'success'}}
+        if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
           cmake -S test/integration -B build_bg_ansi \
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=OFF -D BUILD_LIMITLESS=OFF -D BUILD_BLUE_GREEN=ON \

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ AWS Authentication requires the proper region to be set to generate a proper cre
 
 The [IAM Authentication](./docs/using-the-aws-odbc-wrapper/plugins/iam-authentication-plugin.md), [ADFS Authentication](./docs/using-the-aws-odbc-wrapper/plugins/adfs-authentication-plugin.md), and [Okta Authentication](./docs/using-the-aws-odbc-wrapper/plugins/okta-authentication-plugin.md) plugins do not support MySQL Connector/ODBC due to a limitation in the connector. MySQL Connector/ODBC has a restricted connection string length that is exceeded once the IAM authentication token is appended, resulting in a segmentation fault. A bug fix has been requested upstream: [mysql-connector-odbc#14](https://github.com/mysql/mysql-connector-odbc/pull/14).
 
+For IAM-based authentication against Aurora MySQL, use [MariaDB Connector/ODBC](https://mariadb.com/downloads/connectors/connectors-data-access/odbc-connector/) as the underlying driver instead, or use the [AWS Secrets Manager plugin](./docs/using-the-aws-odbc-wrapper/plugins/secrets-manager-plugin.md). See [Underlying Driver Compatibility](./docs/using-the-aws-odbc-wrapper/using-the-aws-odbc-wrapper.md#underlying-driver-compatibility) for the full tested-driver matrix.
+
 ## Getting Help & Opening Issues
 
 If you encounter a bug with the AWS Advanced ODBC Wrapper, we would like to hear about it. Please search the [existing issues](https://github.com/aws/aws-advanced-odbc-wrapper/issues) to see if others are also experiencing the issue before reporting the problem in a new issue. GitHub issues are intended for bug reports and feature requests.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,8 @@ Before using the AWS Advanced ODBC Wrapper, you must install:
 - The AWS Advanced ODBC Wrapper
 - UnixODBC and ICU4C if using the pre-compiled artifacts on Mac (via Homebrew) or Linux (via APT)
 - and an underlying ODBC Driver of your choice
-    - To use the wrapper with Aurora with PostgreSQL compatibility, install the [psqlodbc PostgreSQL ODBC Driver](https://github.com/postgresql-interfaces/psqlodbc).
+    - To use the wrapper with Aurora or RDS with PostgreSQL compatibility, install the [psqlodbc PostgreSQL ODBC Driver](https://github.com/postgresql-interfaces/psqlodbc).
+    - To use the wrapper with Aurora or RDS with MySQL compatibility, install either [MySQL Connector/ODBC](https://dev.mysql.com/downloads/connector/odbc/) or [MariaDB Connector/ODBC](https://mariadb.com/downloads/connectors/connectors-data-access/odbc-connector/). See the [underlying driver compatibility](./using-the-aws-odbc-wrapper/using-the-aws-odbc-wrapper.md#underlying-driver-compatibility) notes - if you need IAM authentication with Aurora MySQL, use MariaDB Connector/ODBC, as MySQL Connector/ODBC has a connection string length limitation that prevents it from carrying an IAM token.
 
 ## Obtaining the AWS Advanced ODBC Wrapper
 

--- a/docs/using-the-aws-odbc-wrapper/plugins/adfs-authentication-plugin.md
+++ b/docs/using-the-aws-odbc-wrapper/plugins/adfs-authentication-plugin.md
@@ -4,6 +4,12 @@
 > This plugin does not support MySQL Connector/ODBC due to a limitation in the connector. ADFS authentication relies on IAM, and MySQL Connector/ODBC has a restricted connection string length that is exceeded once the IAM authentication token is appended.
 > Using this plugin with MySQL Connector/ODBC will cause a segmentation fault.
 > A bug fix has been requested upstream: [mysql-connector-odbc#14](https://github.com/mysql/mysql-connector-odbc/pull/14).
+>
+> **Alternatives for Aurora MySQL IAM authentication:**
+> - Use **MariaDB Connector/ODBC** as the underlying driver. It is wire-compatible with MySQL/Aurora MySQL and carries the IAM token without hitting the connection string length limit. This combination is validated in our integration tests. Because RDS IAM authentication requires the token to be sent over TLS, point `SSLCA` at the [RDS CA bundle](https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem) (e.g. `SSLCA=/path/to/global-bundle.pem`) — this enables a verified TLS connection so the token is transmitted securely. (Note: setting `FORCETLS=1` without `SSLCA` fails with a certificate-verification error, and is unnecessary when `SSLCA` is set.)
+> - Or use the [AWS Secrets Manager plugin](./secrets-manager-plugin.md) instead of IAM if you prefer to keep MySQL Connector/ODBC.
+>
+> See [Underlying Driver Compatibility](../using-the-aws-odbc-wrapper.md#underlying-driver-compatibility) for the full tested-driver matrix.
 
 The driver supports authentication via [Microsoft's Active Directory Federation Services (ADFS)](https://learn.microsoft.com/en-us/windows-server/identity/ad-fs/ad-fs-overview) federated identity and then database access via IAM.
 

--- a/docs/using-the-aws-odbc-wrapper/plugins/iam-authentication-plugin.md
+++ b/docs/using-the-aws-odbc-wrapper/plugins/iam-authentication-plugin.md
@@ -4,6 +4,12 @@
 > This plugin does not support MySQL Connector/ODBC due to a limitation in the connector. MySQL Connector/ODBC has a restricted connection string length, and the IAM authentication token causes the connection string to exceed this limit.
 > Using this plugin with MySQL Connector/ODBC will cause a segmentation fault.
 > A bug fix has been requested upstream: [mysql-connector-odbc#14](https://github.com/mysql/mysql-connector-odbc/pull/14).
+>
+> **Alternatives for Aurora MySQL IAM authentication:**
+> - Use **MariaDB Connector/ODBC** as the underlying driver. It is wire-compatible with MySQL/Aurora MySQL and carries the IAM token without hitting the connection string length limit. This combination is validated in our integration tests. Because RDS IAM authentication requires the token to be sent over TLS, point `SSLCA` at the [RDS CA bundle](https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem) (e.g. `SSLCA=/path/to/global-bundle.pem`) — this enables a verified TLS connection so the token is transmitted securely. (Note: setting `FORCETLS=1` without `SSLCA` fails with a certificate-verification error, and is unnecessary when `SSLCA` is set.)
+> - Or use the [AWS Secrets Manager plugin](./secrets-manager-plugin.md) instead of IAM if you prefer to keep MySQL Connector/ODBC.
+>
+> See [Underlying Driver Compatibility](../using-the-aws-odbc-wrapper.md#underlying-driver-compatibility) for the full tested-driver matrix.
 
 ### What is IAM?
 

--- a/docs/using-the-aws-odbc-wrapper/plugins/okta-authentication-plugin.md
+++ b/docs/using-the-aws-odbc-wrapper/plugins/okta-authentication-plugin.md
@@ -4,6 +4,12 @@
 > This plugin does not support MySQL Connector/ODBC due to a limitation in the connector. Okta authentication relies on IAM, and MySQL Connector/ODBC has a restricted connection string length that is exceeded once the IAM authentication token is appended.
 > Using this plugin with MySQL Connector/ODBC will cause a segmentation fault.
 > A bug fix has been requested upstream: [mysql-connector-odbc#14](https://github.com/mysql/mysql-connector-odbc/pull/14).
+>
+> **Alternatives for Aurora MySQL IAM authentication:**
+> - Use **MariaDB Connector/ODBC** as the underlying driver. It is wire-compatible with MySQL/Aurora MySQL and carries the IAM token without hitting the connection string length limit. This combination is validated in our integration tests. Because RDS IAM authentication requires the token to be sent over TLS, point `SSLCA` at the [RDS CA bundle](https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem) (e.g. `SSLCA=/path/to/global-bundle.pem`) — this enables a verified TLS connection so the token is transmitted securely. (Note: setting `FORCETLS=1` without `SSLCA` fails with a certificate-verification error, and is unnecessary when `SSLCA` is set.)
+> - Or use the [AWS Secrets Manager plugin](./secrets-manager-plugin.md) instead of IAM if you prefer to keep MySQL Connector/ODBC.
+>
+> See [Underlying Driver Compatibility](../using-the-aws-odbc-wrapper.md#underlying-driver-compatibility) for the full tested-driver matrix.
 
 The driver supports authentication via an [Okta](https://www.okta.com/) federated identity and then database access via IAM.
 

--- a/docs/using-the-aws-odbc-wrapper/using-the-aws-odbc-wrapper.md
+++ b/docs/using-the-aws-odbc-wrapper/using-the-aws-odbc-wrapper.md
@@ -1,6 +1,39 @@
 # Using the AWS Advanced ODBC Wrapper
 
-The AWS Advanced ODBC Wrapper leverages community ODBC Drivers and enables support of AWS and Aurora functionalities. Currently, the [PostgreSQL ODBC Wrapper, psqlodbc](https://github.com/postgresql-interfaces/psqlodbc) is supported.
+The AWS Advanced ODBC Wrapper leverages community ODBC Drivers and enables support of AWS and Aurora functionalities. It has been tested with the [PostgreSQL ODBC Driver (psqlodbc)](https://github.com/postgresql-interfaces/psqlodbc) for Aurora PostgreSQL, and with both [MySQL Connector/ODBC](https://dev.mysql.com/downloads/connector/odbc/) and [MariaDB Connector/ODBC](https://mariadb.com/downloads/connectors/connectors-data-access/odbc-connector/) for Aurora MySQL. See [Underlying Driver Compatibility](#underlying-driver-compatibility) for details and known limitations.
+
+## Underlying Driver Compatibility
+
+The wrapper delegates all database I/O to an underlying ODBC driver. The following drivers have been tested:
+
+### Aurora PostgreSQL
+
+[psqlodbc](https://github.com/postgresql-interfaces/psqlodbc) is the tested driver for Aurora PostgreSQL. It is validated across the unit, compatibility, and integration test suites and supports all features, including IAM authentication.
+
+### Aurora MySQL
+
+Both [MariaDB Connector/ODBC](https://mariadb.com/downloads/connectors/connectors-data-access/odbc-connector/) and [MySQL Connector/ODBC](https://dev.mysql.com/downloads/connector/odbc/) have been tested against Aurora MySQL. The table below summarizes feature support for each:
+
+| Feature | MariaDB Connector/ODBC | MySQL Connector/ODBC |
+|------------------------------------|:----------------------:|:--------------------:|
+| Failover | ✅ | ✅ |
+| IAM Authentication | ✅ | ❌ |
+| Secrets Manager Authentication | ✅ | ✅ |
+| Aurora Initial Connection Strategy | ✅ | ✅ |
+| Blue/Green Deployments | ✅ | ✅ |
+| Custom Endpoint | ✅ | ✅ |
+| Read/Write Splitting | ✅ | ✅ |
+
+MariaDB Connector/ODBC is recommended when IAM authentication is required for Aurora MySQL. MySQL Connector/ODBC works for all other scenarios but **does not support IAM authentication** - see the limitation below.
+
+> [!IMPORTANT]\
+> **IAM authentication with Aurora MySQL:** MySQL Connector/ODBC has a restricted connection string length. The IAM authentication token causes the connection string to exceed this limit, resulting in a segmentation fault. A fix has been requested upstream ([mysql-connector-odbc#14](https://github.com/mysql/mysql-connector-odbc/pull/14)).
+>
+> If you need IAM authentication with Aurora MySQL, use one of these alternatives:
+> - **MariaDB Connector/ODBC** (recommended) - it is wire-compatible with MySQL/Aurora MySQL, carries the IAM token without hitting the length limit, and is validated for IAM in our integration tests. Because IAM authentication requires the token to be sent over TLS, point `SSLCA` at the [RDS CA bundle](https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem) (e.g. `SSLCA=/path/to/global-bundle.pem`); this enables a verified TLS connection so the token is transmitted securely. Setting `FORCETLS=1` without `SSLCA` fails with a certificate-verification error and is unnecessary when `SSLCA` is set.
+> - **AWS Secrets Manager authentication** - use the [Secrets Manager plugin](./plugins/secrets-manager-plugin.md) instead of IAM if you prefer to keep MySQL Connector/ODBC.
+
+When choosing a driver, also confirm your `SSLMode`/TLS settings: IAM authentication requires SSL to be enabled regardless of the underlying driver.
 
 ## Using the AWS Advanced ODBC Wrapper with plain RDS databases
 

--- a/driver/dialect/dialect_aurora_mysql.h
+++ b/driver/dialect/dialect_aurora_mysql.h
@@ -105,7 +105,9 @@ private:
         "08",       // connection error
         "99",       // unexpected error
         "F0",       // configuration file error (backend)
-        "XX"        // internal error (backend)
+        "XX",       // internal error (backend)
+        "HYT00",    // connection/login timeout expired
+        "HY000"     // generic error class used for can't-connect / unknown-host failures
     };
 };
 

--- a/test/common/connection_string_builder.h
+++ b/test/common/connection_string_builder.h
@@ -173,6 +173,12 @@ public:
         return *this;
     }
 
+    // MySQL/MariaDB ODBC: SSLVERIFY=0 keeps TLS on but skips cert CN check (needed for IP hosts).
+    ConnectionStringBuilder& withSslVerify(const bool& ssl_verify) {
+        conn_str_ += "SSLVERIFY=" + std::to_string(ssl_verify ? 1 : 0) + ";";
+        return *this;
+    }
+
     ConnectionStringBuilder& withCustomEndpoint(const bool& custom_endpoint_enabled) {
         conn_str_ += "ENABLE_CUSTOM_ENDPOINT=" + std::to_string(custom_endpoint_enabled ? 1 : 0) + ";";
         return *this;

--- a/test/common/odbc_helper.h
+++ b/test/common/odbc_helper.h
@@ -26,6 +26,7 @@
 #define SQL_MAX_MESSAGE_LENGTH  512
 #define SQL_ERR_UNABLE_TO_CONNECT "08001"
 #define SQL_ERR_INVALID_PARAMETER "01S00"
+#define SQL_ERR_MYSQL_ACCESS_DENIED "28000"
 
 namespace ODBC_HELPER {
     SQLRETURN DriverConnect(SQLHDBC hdbc, std::string conn_str);

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -180,6 +180,13 @@ SET(THREADING "0")
 # -D MYSQL_SERVER
 # -D MYSQL_DATABASE
 
+# SSLCA (RDS CA bundle) gives verified TLS so RDS IAM tokens are sent encrypted. Only added when provided.
+# -D BASE_DRIVER_SSL_CA=/path/to/rds-global-bundle.pem
+SET(BASE_DRIVER_EXTRA_DSN_LINES "")
+IF(BASE_DRIVER_SSL_CA)
+    SET(BASE_DRIVER_EXTRA_DSN_LINES "SSLCA = ${BASE_DRIVER_SSL_CA}")
+ENDIF()
+
 CONFIGURE_FILE(
     ${ODBC_PATH}/odbcinst.ini.in
     ${ODBC_PATH}/odbcinst.ini

--- a/test/integration/iam_authentication_integration_test.cpp
+++ b/test/integration/iam_authentication_integration_test.cpp
@@ -35,6 +35,12 @@ class IamAuthenticationIntegrationTest : public BaseConnectionTest {
 protected:
     std::string auth_type = "IAM";
     std::string test_iam_user = TEST_UTILS::GetEnvVar("TEST_IAM_USER", "");
+    // Set TEST_SKIP_IAM=1 for drivers that can't do IAM (e.g. MySQL Connector/ODBC).
+    std::string test_skip_iam = TEST_UTILS::GetEnvVar("TEST_SKIP_IAM", "");
+    // psqlODBC needs the token's '%' double-encoded to survive its connection-string parse, but
+    // MySQL/MariaDB ODBC consume the password verbatim, so double-encoding corrupts the token and
+    // the server rejects it (28000). Only apply extra URL encoding for non-MySQL dialects.
+    bool extra_url_encode = (test_dialect != "AURORA_MYSQL");
 
     static void SetUpTestSuite() {
         BaseConnectionTest::SetUpTestSuite();
@@ -45,8 +51,9 @@ protected:
     }
 
     void SetUp() override {
-        if (test_dialect == "AURORA_MYSQL" || test_dialect == "MULTI_AZ_MYSQL") {
-            GTEST_SKIP() << "MySQL ODBC Connector does not support IAM with session tokens due to limitations on connection key-value pairs.";
+        if (test_skip_iam == "1" || test_skip_iam == "true") {
+            GTEST_SKIP() << "Skipping IAM tests: the configured underlying driver does not support "
+                            "IAM authentication (TEST_SKIP_IAM is set).";
         }
         BaseConnectionTest::SetUp();
     }
@@ -64,7 +71,7 @@ TEST_F(IamAuthenticationIntegrationTest, SimpleIamConnection) {
         .withAuthMode(auth_type)
         .withAuthRegion(test_region)
         .withAuthExpiration(900)
-        .withExtraUrlEncode(true)
+        .withExtraUrlEncode(extra_url_encode)
         .withSslMode("allow")
         .withClusterId("SimpleIamConnection")
         .getString();
@@ -81,17 +88,21 @@ TEST_F(IamAuthenticationIntegrationTest, SimpleIamConnection) {
 TEST_F(IamAuthenticationIntegrationTest, ConnectToIpAddress) {
     std::string ip_address = TEST_UTILS::HostToIp(test_server);
     ASSERT_FALSE(ip_address.empty()) << "Failed to resolve IP address for host: " << test_server;
-    conn_str = ConnectionStringBuilder(test_dsn, ip_address, test_port)
-        .withUID(test_iam_user)
+    ConnectionStringBuilder builder(test_dsn, ip_address, test_port);
+    builder.withUID(test_iam_user)
         .withDatabase(test_db)
         .withAuthMode(auth_type)
         .withAuthRegion(test_region)
         .withAuthExpiration(900)
-        .withExtraUrlEncode(true)
+        .withExtraUrlEncode(extra_url_encode)
         .withSslMode("allow")
         .withIamHost(test_server)
-        .withClusterId("ConnectToIpAddress")
-        .getString();
+        .withClusterId("ConnectToIpAddress");
+    // Connecting by IP can't match the cert CN, so skip CN verification on MySQL/MariaDB (TLS stays on).
+    if (test_dialect == "AURORA_MYSQL") {
+        builder.withSslVerify(false);
+    }
+    conn_str = builder.getString();
 
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, conn_str);
     EXPECT_EQ(SQL_SUCCESS, rc);
@@ -110,7 +121,7 @@ TEST_F(IamAuthenticationIntegrationTest, WrongPassword) {
         .withAuthMode(auth_type)
         .withAuthRegion(test_region)
         .withAuthExpiration(900)
-        .withExtraUrlEncode(true)
+        .withExtraUrlEncode(extra_url_encode)
         .withSslMode("allow")
         .withClusterId("WrongPassword")
         .getString();
@@ -130,7 +141,7 @@ TEST_F(IamAuthenticationIntegrationTest, WrongUser) {
         .withAuthMode(auth_type)
         .withAuthRegion(test_region)
         .withAuthExpiration(900)
-        .withExtraUrlEncode(true)
+        .withExtraUrlEncode(extra_url_encode)
         .withSslMode("allow")
         .withClusterId("WrongUser")
         .getString();
@@ -143,10 +154,16 @@ TEST_F(IamAuthenticationIntegrationTest, WrongUser) {
     SQLTCHAR msg[SQL_MAX_MESSAGE_LENGTH] = {0}, state[6] = {0};
     rc = SQLError(nullptr, dbc, nullptr, state, &native_err, msg, SQL_MAX_MESSAGE_LENGTH - 1, &stmt_length);
     EXPECT_EQ(SQL_SUCCESS, rc);
-    EXPECT_STREQ(SQL_ERR_UNABLE_TO_CONNECT, STRING_HELPER::SqltcharToAnsi(state));
+    // psqlODBC reports access failures as 08001; MySQL/MariaDB ODBC reports 28000.
+    const std::string actual_state = STRING_HELPER::SqltcharToAnsi(state);
+    if (test_dialect == "AURORA_MYSQL") {
+        EXPECT_EQ(SQL_ERR_MYSQL_ACCESS_DENIED, actual_state);
+    } else {
+        EXPECT_EQ(SQL_ERR_UNABLE_TO_CONNECT, actual_state);
+    }
 }
-
 // Tests that the IAM connection will fail when provided an empty user.
+// Rejected by the wrapper's pre-validation (08001) before the base driver, regardless of dialect.
 TEST_F(IamAuthenticationIntegrationTest, EmptyUser) {
     conn_str = ConnectionStringBuilder(test_dsn, test_server, test_port)
         .withUID("")
@@ -154,7 +171,7 @@ TEST_F(IamAuthenticationIntegrationTest, EmptyUser) {
         .withAuthMode(auth_type)
         .withAuthRegion(test_region)
         .withAuthExpiration(900)
-        .withExtraUrlEncode(true)
+        .withExtraUrlEncode(extra_url_encode)
         .withSslMode("allow")
         .withClusterId("EmptyUser")
         .getString();

--- a/test/resources/odbc.ini.in
+++ b/test/resources/odbc.ini.in
@@ -25,6 +25,7 @@ Driver          = @TEST_DRIVER_PATH@
 DATABASE        = @TEST_DATABASE@
 SERVER          = @TEST_SERVER@
 BASE_DRIVER     = @BASE_DRIVER_PATH@
+@BASE_DRIVER_EXTRA_DSN_LINES@
 
 [inte-base-dsn]
 Driver          = @BASE_DRIVER_PATH@


### PR DESCRIPTION
### Summary

Use MariaDB ODBC in addition to MySQL ODBC Connector

### Description

Adds MariaDB ODBC to test against MySQL instances as it is wire-compatible. MariaDB provides us an alternative to mysql-odbc-connector to use IAM-related functionality as it does allows for dynamically sized connection strings and their values.

### Testing

- Locally on Windows & Mac
- Setup GitHub CI

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
