### PR TITLE
fix: CI Resource Leak, Masked Failures, Build Warnings, & Writer Stablization

### DIFF
--- a/.github/workflows/compatibility_test.yaml
+++ b/.github/workflows/compatibility_test.yaml
@@ -301,10 +301,24 @@ jobs:
         run: |
           Start-Process msiexec "/i mysql-connector_x64.msi /quiet /norestart" -Wait;
       - name: Setup Local MySQL
+        shell: pwsh
         run: |
-          choco install mysql --version 9.2.0
+          # Retry the install with backoff: community.chocolatey.org intermittently
+          # returns 504s, which would otherwise fail the whole compatibility run.
+          $maxAttempts = 3
+          $installed = $false
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "Installing MySQL via Chocolatey (attempt $attempt/$maxAttempts)..."
+            choco install mysql --version 9.2.0 --no-progress
+            if ($LASTEXITCODE -eq 0) { $installed = $true; break }
+            Write-Warning "choco install mysql failed (exit $LASTEXITCODE). Retrying in 30s..."
+            Start-Sleep -Seconds 30
+          }
+          if (-not $installed) { Write-Error "Failed to install MySQL via Chocolatey after $maxAttempts attempts."; exit 1 }
           $mysqlExe = Get-ChildItem -Path "C:\tools\mysql" -Recurse -Filter "mysql.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $mysqlExe) { Write-Error "mysql.exe not found under C:\tools\mysql after install."; exit 1 }
           & $mysqlExe.FullName --protocol=TCP -u root -P 3306 --execute="source ${{ github.workspace }}/scripts/init_local_mysql_query.sql"
+          if ($LASTEXITCODE -ne 0) { Write-Error "Failed to initialize local MySQL database."; exit 1 }
       - name: Build Compatibility Tests
         run: |
           cmake -S test/compatibility -B build_test -DTEST_BASE_OUTPUT=ON
@@ -783,10 +797,24 @@ jobs:
         run: |
           Start-Process msiexec "/i mysql-connector_x64.msi /quiet /norestart" -Wait;
       - name: Setup Local MySQL
+        shell: pwsh
         run: |
-          choco install mysql --version 9.2.0
+          # Retry the install with backoff: community.chocolatey.org intermittently
+          # returns 504s, which would otherwise fail the whole compatibility run.
+          $maxAttempts = 3
+          $installed = $false
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "Installing MySQL via Chocolatey (attempt $attempt/$maxAttempts)..."
+            choco install mysql --version 9.2.0 --no-progress
+            if ($LASTEXITCODE -eq 0) { $installed = $true; break }
+            Write-Warning "choco install mysql failed (exit $LASTEXITCODE). Retrying in 30s..."
+            Start-Sleep -Seconds 30
+          }
+          if (-not $installed) { Write-Error "Failed to install MySQL via Chocolatey after $maxAttempts attempts."; exit 1 }
           $mysqlExe = Get-ChildItem -Path "C:\tools\mysql" -Recurse -Filter "mysql.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $mysqlExe) { Write-Error "mysql.exe not found under C:\tools\mysql after install."; exit 1 }
           & $mysqlExe.FullName --protocol=TCP -u root -P 3306 --execute="source ${{ github.workspace }}/scripts/init_local_mysql_query.sql"
+          if ($LASTEXITCODE -ne 0) { Write-Error "Failed to initialize local MySQL database."; exit 1 }
       - name: Build Compatibility Tests (Unicode)
         run: |
           cmake -S test/compatibility -B build_test_w -DUNICODE=ON -DTEST_BASE_OUTPUT=ON

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -503,6 +503,7 @@ jobs:
           cmake -S test/integration -B build_ansi -D CMAKE_BUILD_TYPE="${{env.BUILD_CONFIG}}" `
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF
           cmake --build build_ansi --config ${{env.BUILD_CONFIG}}
+          if ($LASTEXITCODE -ne 0) { Write-Error "Ansi integration test build failed"; exit 1 }
           echo "Ansi Test Built"
           @(".symfix+", 'sxe -c ".echo --- CRASH STACK ---;~* kvn;.echo --- END CRASH STACK ---;g" av', "g") | Set-Content -Path cdb_cmd.txt
           & "${{env.CDB_PATH}}" -G -lines -y ".\build_ansi\${{env.BUILD_CONFIG}}" -cf cdb_cmd.txt .\build_ansi\${{env.BUILD_CONFIG}}\integration-test.exe --gtest_filter=-FailoverIntegrationTest.*:ReadWriteSplittingIntegrationTest.WriterFailoverReadOnly:ReadWriteSplittingIntegrationTest.FailoverToNewReaderReadOnly; $ansiNonFailoverRc = $LASTEXITCODE
@@ -537,6 +538,7 @@ jobs:
           cmake -S test/integration -B build_unicode -D CMAKE_BUILD_TYPE="${{env.BUILD_CONFIG}}" `
             -D BUILD_UNICODE=ON -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF
           cmake --build build_unicode --config ${{env.BUILD_CONFIG}}
+          if ($LASTEXITCODE -ne 0) { Write-Error "Unicode integration test build failed"; exit 1 }
           echo "Unicode Test Built"
           @(".symfix+", 'sxe -c ".echo --- CRASH STACK ---;~* kvn;.echo --- END CRASH STACK ---;g" av', "g") | Set-Content -Path cdb_cmd.txt
           & "${{env.CDB_PATH}}" -G -lines -y ".\build_unicode\${{env.BUILD_CONFIG}}" -cf cdb_cmd.txt .\build_unicode\${{env.BUILD_CONFIG}}\integration-test.exe --gtest_filter=-FailoverIntegrationTest.*:ReadWriteSplittingIntegrationTest.WriterFailoverReadOnly:ReadWriteSplittingIntegrationTest.FailoverToNewReaderReadOnly; $unicodeNonFailoverRc = $LASTEXITCODE
@@ -563,6 +565,7 @@ jobs:
           cmake -S test/integration -B build_mariadb_ansi -D CMAKE_BUILD_TYPE="${{env.BUILD_CONFIG}}" `
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF
           cmake --build build_mariadb_ansi --config ${{env.BUILD_CONFIG}}
+          if ($LASTEXITCODE -ne 0) { Write-Error "MariaDB Ansi integration test build failed"; exit 1 }
           echo "MariaDB Ansi Test Built"
           @(".symfix+", 'sxe -c ".echo --- CRASH STACK ---;~* kvn;.echo --- END CRASH STACK ---;g" av', "g") | Set-Content -Path cdb_cmd.txt
           & "${{env.CDB_PATH}}" -G -lines -y ".\build_mariadb_ansi\${{env.BUILD_CONFIG}}" -cf cdb_cmd.txt .\build_mariadb_ansi\${{env.BUILD_CONFIG}}\integration-test.exe
@@ -585,6 +588,7 @@ jobs:
           cmake -S test/integration -B build_mariadb_unicode -D CMAKE_BUILD_TYPE="${{env.BUILD_CONFIG}}" `
             -D BUILD_UNICODE=ON -D BUILD_FAILOVER=ON -D BUILD_LIMITLESS=OFF
           cmake --build build_mariadb_unicode --config ${{env.BUILD_CONFIG}}
+          if ($LASTEXITCODE -ne 0) { Write-Error "MariaDB Unicode integration test build failed"; exit 1 }
           echo "MariaDB Unicode Test Built"
           @(".symfix+", 'sxe -c ".echo --- CRASH STACK ---;~* kvn;.echo --- END CRASH STACK ---;g" av', "g") | Set-Content -Path cdb_cmd.txt
           & "${{env.CDB_PATH}}" -G -lines -y ".\build_mariadb_unicode\${{env.BUILD_CONFIG}}" -cf cdb_cmd.txt .\build_mariadb_unicode\${{env.BUILD_CONFIG}}\integration-test.exe
@@ -1417,6 +1421,7 @@ jobs:
           cmake -S test/integration -B build_limitless_ansi -D CMAKE_BUILD_TYPE="${{env.BUILD_CONFIG}}" `
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=OFF -D BUILD_LIMITLESS=ON
           cmake --build build_limitless_ansi --config ${{env.BUILD_CONFIG}}
+          if ($LASTEXITCODE -ne 0) { Write-Error "Limitless Ansi integration test build failed"; exit 1 }
           echo "Limitless Ansi Test Built"
           @(".symfix+", 'sxe -c ".echo --- CRASH STACK ---;~* kvn;.echo --- END CRASH STACK ---;g" av', "g") | Set-Content -Path cdb_cmd.txt
           & "${{env.CDB_PATH}}" -G -lines -y ".\build_limitless_ansi\${{env.BUILD_CONFIG}}" -cf cdb_cmd.txt .\build_limitless_ansi\${{env.BUILD_CONFIG}}\integration-test.exe
@@ -1438,6 +1443,7 @@ jobs:
           cmake -S test/integration -B build_limitless_unicode -D CMAKE_BUILD_TYPE="${{env.BUILD_CONFIG}}" `
             -D BUILD_UNICODE=ON -D BUILD_FAILOVER=OFF -D BUILD_LIMITLESS=ON
           cmake --build build_limitless_unicode --config ${{env.BUILD_CONFIG}}
+          if ($LASTEXITCODE -ne 0) { Write-Error "Limitless Unicode integration test build failed"; exit 1 }
           echo "Limitless Unicode Test Built"
           @(".symfix+", 'sxe -c ".echo --- CRASH STACK ---;~* kvn;.echo --- END CRASH STACK ---;g" av', "g") | Set-Content -Path cdb_cmd.txt
           & "${{env.CDB_PATH}}" -G -lines -y ".\build_limitless_unicode\${{env.BUILD_CONFIG}}" -cf cdb_cmd.txt .\build_limitless_unicode\${{env.BUILD_CONFIG}}\integration-test.exe
@@ -1995,8 +2001,10 @@ jobs:
           cmake -S test/integration -B build_bg_ansi -D CMAKE_BUILD_TYPE="${{env.BUILD_CONFIG}}" `
             -D BUILD_UNICODE=OFF -D BUILD_FAILOVER=OFF -D BUILD_LIMITLESS=OFF -D BUILD_BLUE_GREEN=ON
           cmake --build build_bg_ansi --config ${{env.BUILD_CONFIG}}
+          if ($LASTEXITCODE -ne 0) { Write-Error "Blue/Green Ansi integration test build failed"; exit 1 }
           echo "Blue/Green Ansi Test Built"
           gdb -q -x ./.gdbinit .\build_bg_ansi\${{env.BUILD_CONFIG}}\integration-test.exe
+          if ($LASTEXITCODE -ne 0) { Write-Error "Blue/Green Ansi integration test run failed"; exit 1 }
         env:
           TEST_DSN: ${{ env.TEST_DSN_ANSI }}
           TEST_DATABASE: ${{ env.TEST_DATABASE }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -496,6 +496,7 @@ jobs:
           echo "CDB_PATH=$cdb" >> $env:GITHUB_ENV
           Write-Host "Found cdb at: $cdb"
       - name: Build and Run Ansi Integration Tests
+        timeout-minutes: 45
         id: ansi_tests
         shell: pwsh
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
@@ -531,6 +532,7 @@ jobs:
             --cluster-id "${{ env.AURORA_CLUSTER_ID }}" \
             --region "${{ secrets.AWS_DEFAULT_REGION }}"
       - name: Build and Run Unicode Integration Tests
+        timeout-minutes: 45
         id: unicode_tests
         shell: pwsh
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
@@ -559,6 +561,7 @@ jobs:
           TEST_SKIP_IAM: "${{ (matrix.rds_engine == 'aurora-mysql' || matrix.rds_engine == 'multi-az-mysql') && '1' || '' }}"
       # ---- MariaDB Connector/ODBC on the SAME Aurora MySQL cluster (IAM runs here) ----
       - name: Build and Run MariaDB Ansi Integration Tests
+        timeout-minutes: 45
         shell: pwsh
         if: ${{ !cancelled() && matrix.rds_engine == 'aurora-mysql' && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -582,6 +585,7 @@ jobs:
           TEST_DIALECT: "${{ steps.base_driver_info.outputs.database_dialect }}"
           TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
       - name: Build and Run MariaDB Unicode Integration Tests
+        timeout-minutes: 45
         shell: pwsh
         if: ${{ !cancelled() && matrix.rds_engine == 'aurora-mysql' && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -794,6 +798,7 @@ jobs:
         run: |
           curl -L "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" --output "${{ github.workspace }}/rds-global-bundle.pem"
       - name: Build and Run Ansi Integration Tests
+        timeout-minutes: 45
         id: ansi_tests
         shell: bash
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
@@ -824,7 +829,7 @@ jobs:
           ODBCINI: "${{ github.workspace }}/test/resources/odbc.ini"
           ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
           TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
-          TEST_SKIP_IAM: "${{ (matrix.rds_engine == 'aurora-mysql' || matrix.rds_engine == 'multi-az-mysql') && '1' || '' }}"
+          TEST_SKIP_IAM: "${{ (matrix.env.rds_engine == 'aurora-mysql' || matrix.env.rds_engine == 'multi-az-mysql') && '1' || '' }}"
       - name: Stabilize cluster between test runs
         shell: bash
         if: ${{ steps.AuroraClusterSetup.outcome == 'success' && (success() || failure()) }}
@@ -834,6 +839,7 @@ jobs:
             --cluster-id "${{ env.AURORA_CLUSTER_ID }}" \
             --region "${{ secrets.AWS_DEFAULT_REGION }}"
       - name: Build and Run Unicode Integration Tests
+        timeout-minutes: 45
         shell: bash
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -863,7 +869,7 @@ jobs:
           ODBCINI: "${{ github.workspace }}/test/resources/odbc.ini"
           ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
           TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
-          TEST_SKIP_IAM: "${{ (matrix.rds_engine == 'aurora-mysql' || matrix.rds_engine == 'multi-az-mysql') && '1' || '' }}"
+          TEST_SKIP_IAM: "${{ (matrix.env.rds_engine == 'aurora-mysql' || matrix.env.rds_engine == 'multi-az-mysql') && '1' || '' }}"
       - name: Dump RDS events on failure
         if: always()
         shell: bash
@@ -883,6 +889,7 @@ jobs:
           done
       # ---- MariaDB Connector/ODBC on the SAME Aurora MySQL cluster (IAM runs here) ----
       - name: Build and Run MariaDB Ansi Integration Tests
+        timeout-minutes: 45
         shell: bash
         if: ${{ !cancelled() && matrix.env.rds_engine == 'aurora-mysql' && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -912,6 +919,7 @@ jobs:
           ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
           TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
       - name: Build and Run MariaDB Unicode Integration Tests
+        timeout-minutes: 45
         shell: bash
         if: ${{ !cancelled() && matrix.env.rds_engine == 'aurora-mysql' && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -1109,6 +1117,7 @@ jobs:
         run: |
           echo "set auto-load safe-path $PWD" > ~/.gdbinit
       - name: Build and Run Ansi Integration Tests
+        timeout-minutes: 45
         id: ansi_tests
         shell: bash
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
@@ -1150,6 +1159,7 @@ jobs:
             --cluster-id "${{ env.AURORA_CLUSTER_ID }}" \
             --region "${{ secrets.AWS_DEFAULT_REGION }}"
       - name: Build and Run Unicode Integration Tests
+        timeout-minutes: 45
         shell: bash
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -1183,6 +1193,7 @@ jobs:
           TEST_SKIP_IAM: "${{ (matrix.rds_engine == 'aurora-mysql' || matrix.rds_engine == 'multi-az-mysql') && '1' || '' }}"
       # ---- MariaDB Connector/ODBC on the SAME Aurora MySQL cluster (IAM runs here) ----
       - name: Build and Run MariaDB Ansi Integration Tests
+        timeout-minutes: 45
         shell: bash
         if: ${{ !cancelled() && matrix.rds_engine == 'aurora-mysql' && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -1213,6 +1224,7 @@ jobs:
           ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
           TEST_CUSTOM_ENDPOINT_ID: ${{ env.CUSTOM_ENDPOINT_ID }}
       - name: Build and Run MariaDB Unicode Integration Tests
+        timeout-minutes: 45
         shell: bash
         if: ${{ !cancelled() && matrix.rds_engine == 'aurora-mysql' && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -1415,6 +1427,7 @@ jobs:
           echo "CDB_PATH=$cdb" >> $env:GITHUB_ENV
           Write-Host "Found cdb at: $cdb"
       - name: Build and Run Limitless Ansi Integration Tests
+        timeout-minutes: 45
         shell: pwsh
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -1437,6 +1450,7 @@ jobs:
           TEST_PORT: ${{steps.base_driver_info.outputs.dialect_default_port}}
           TEST_DIALECT: "${{ steps.base_driver_info.outputs.database_dialect }}"
       - name: Build and Run Limitless Unicode Integration Tests
+        timeout-minutes: 45
         shell: pwsh
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -1583,6 +1597,7 @@ jobs:
           odbcinst -j 2>/dev/null || true
           cat $ODBCINST 2>/dev/null || cat /etc/odbcinst.ini 2>/dev/null || true
       - name: Build and Run Limitless Ansi Integration Tests
+        timeout-minutes: 45
         shell: bash
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -1610,6 +1625,7 @@ jobs:
           ODBCINI: "${{ github.workspace }}/test/resources/odbc.ini"
           ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
       - name: Build and Run Limitless Unicode Integration Tests
+        timeout-minutes: 45
         shell: bash
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -1749,6 +1765,7 @@ jobs:
         run: |
           echo "set auto-load safe-path $PWD" > ~/.gdbinit
       - name: Build and Run Limitless Ansi Integration Tests
+        timeout-minutes: 45
         shell: bash
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -1777,6 +1794,7 @@ jobs:
           ODBCINI: "${{ github.workspace }}/test/resources/odbc.ini"
           ODBCINST: "${{ github.workspace }}/test/resources/odbcinst.ini"
       - name: Build and Run Limitless Unicode Integration Tests
+        timeout-minutes: 45
         shell: bash
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -1995,6 +2013,7 @@ jobs:
           choco install mingw
           echo "set auto-load safe-path /" > "$HOME/.gdbinit"
       - name: Build and Run Blue/Green Ansi Integration Tests
+        timeout-minutes: 45
         shell: pwsh
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -2147,6 +2166,7 @@ jobs:
           key: ${{steps.base_driver_info.outputs.cache_key}}
           fail-on-cache-miss: true
       - name: Build and Run Blue/Green Ansi Integration Tests
+        timeout-minutes: 45
         shell: bash
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |
@@ -2296,6 +2316,7 @@ jobs:
         run: |
           echo "set auto-load safe-path $PWD" > ~/.gdbinit
       - name: Build and Run Blue/Green Ansi Integration Tests
+        timeout-minutes: 45
         shell: bash
         if: ${{ !cancelled() && steps.AuroraClusterSetup.outcome == 'success' }}
         run: |

--- a/driver/host_list_providers/cluster_topology_monitor.cpp
+++ b/driver/host_list_providers/cluster_topology_monitor.cpp
@@ -305,8 +305,8 @@ std::vector<HostInfo> ClusterTopologyMonitor::OpenAnyConnGetHosts() {
         DBC *local_dbc = static_cast<DBC*>(local_hdbc);
         local_dbc->conn_attr = connection_attributes_;
         local_dbc->plugin_service = this->plugin_service_;
-        local_dbc->attr_map.insert_or_assign(SQL_ATTR_LOGIN_TIMEOUT, std::make_pair(reinterpret_cast<SQLPOINTER>(DEFAULT_TIMEOUT_SECONDS), 0));
-        local_dbc->attr_map.insert_or_assign(SQL_ATTR_CONNECTION_TIMEOUT, std::make_pair(reinterpret_cast<SQLPOINTER>(DEFAULT_TIMEOUT_SECONDS), 0));
+        local_dbc->attr_map.insert_or_assign(SQL_ATTR_LOGIN_TIMEOUT, std::make_pair(reinterpret_cast<SQLPOINTER>(static_cast<intptr_t>(DEFAULT_TIMEOUT_SECONDS)), 0));
+        local_dbc->attr_map.insert_or_assign(SQL_ATTR_CONNECTION_TIMEOUT, std::make_pair(reinterpret_cast<SQLPOINTER>(static_cast<intptr_t>(DEFAULT_TIMEOUT_SECONDS)), 0));
 
         rc = plugin_head_->Connect(local_hdbc, nullptr, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
         if (!SQL_SUCCEEDED(rc)) {
@@ -499,8 +499,8 @@ ClusterTopologyMonitor::NodeMonitoringThread::NodeMonitoringThread(
     this->odbc_helper_ = odbc_helper;
     odbc_helper_->AllocDbc(monitor->henv_, hdbc_);
     DBC *init_dbc = static_cast<DBC*>(hdbc_);
-    init_dbc->attr_map.insert_or_assign(SQL_ATTR_LOGIN_TIMEOUT, std::make_pair(reinterpret_cast<SQLPOINTER>(DEFAULT_TIMEOUT_SECONDS), 0));
-    init_dbc->attr_map.insert_or_assign(SQL_ATTR_CONNECTION_TIMEOUT, std::make_pair(reinterpret_cast<SQLPOINTER>(DEFAULT_TIMEOUT_SECONDS), 0));
+    init_dbc->attr_map.insert_or_assign(SQL_ATTR_LOGIN_TIMEOUT, std::make_pair(reinterpret_cast<SQLPOINTER>(static_cast<intptr_t>(DEFAULT_TIMEOUT_SECONDS)), 0));
+    init_dbc->attr_map.insert_or_assign(SQL_ATTR_CONNECTION_TIMEOUT, std::make_pair(reinterpret_cast<SQLPOINTER>(static_cast<intptr_t>(DEFAULT_TIMEOUT_SECONDS)), 0));
     node_thread_ = std::make_shared<std::thread>(&NodeMonitoringThread::Run, this);
     LOG(INFO) << "Started node monitoring for: " << this->host_info_->GetHost();
 }
@@ -575,8 +575,8 @@ void ClusterTopologyMonitor::NodeMonitoringThread::HandleReconnect() {
     local_dbc->conn_attr = conn_info_;
     local_dbc->plugin_service = main_monitor_->plugin_service_;
     local_dbc->conn_attr.insert_or_assign(KEY_SRW_SKIP, VALUE_BOOL_TRUE);
-    local_dbc->attr_map.insert_or_assign(SQL_ATTR_LOGIN_TIMEOUT, std::make_pair(reinterpret_cast<SQLPOINTER>(DEFAULT_TIMEOUT_SECONDS), 0));
-    local_dbc->attr_map.insert_or_assign(SQL_ATTR_CONNECTION_TIMEOUT, std::make_pair(reinterpret_cast<SQLPOINTER>(DEFAULT_TIMEOUT_SECONDS), 0));
+    local_dbc->attr_map.insert_or_assign(SQL_ATTR_LOGIN_TIMEOUT, std::make_pair(reinterpret_cast<SQLPOINTER>(static_cast<intptr_t>(DEFAULT_TIMEOUT_SECONDS)), 0));
+    local_dbc->attr_map.insert_or_assign(SQL_ATTR_CONNECTION_TIMEOUT, std::make_pair(reinterpret_cast<SQLPOINTER>(static_cast<intptr_t>(DEFAULT_TIMEOUT_SECONDS)), 0));
     const SQLRETURN rc = main_monitor_->plugin_head_->Connect(hdbc_, nullptr, nullptr, 0, nullptr, SQL_DRIVER_NOPROMPT);
     if (!SQL_SUCCEEDED(rc)) {
         odbc_helper_->DisconnectAndFree(&hdbc_);

--- a/driver/odbcapi_rds_helper.cpp
+++ b/driver/odbcapi_rds_helper.cpp
@@ -566,7 +566,7 @@ SQLRETURN RDS_GetConnectAttr(
         } else if (value_pair.second == sizeof(SQLUINTEGER) || value_pair.second == 0) {
             *(static_cast<SQLUINTEGER*>(ValuePtr)) = static_cast<SQLUINTEGER>(reinterpret_cast<uintptr_t>(value_pair.first));
         } else {
-            snprintf(static_cast<char*>(ValuePtr), static_cast<size_t>(BufferLength) / sizeof(SQLTCHAR), "%s", value_pair.first);
+            snprintf(static_cast<char*>(ValuePtr), static_cast<size_t>(BufferLength) / sizeof(SQLTCHAR), "%s", static_cast<const char*>(value_pair.first));
             if (value_pair.second >= BufferLength) {
                 ret = SQL_SUCCESS_WITH_INFO;
             }

--- a/scripts/db_resources.py
+++ b/scripts/db_resources.py
@@ -143,12 +143,12 @@ def remove_ip_from_sg(ec2_client, rds_client, ip, cluster_id, is_rds_instance=Fa
             Filters=[{"Name": "group-id", "Values": [sg]}]
         )
         for rule in response.get("SecurityGroupRules", []):
-            if rule.get("CidrIpv4") == cidr:
-                description = rule.get("Description", "")
-                if description:
-                    return
+            if rule.get("CidrIpv4") == cidr and rule.get("Description"):
+                print(f"  Keeping permanent rule {cidr} on SG {sg}")
+                return
     except Exception as e:
         print(f"  Warning: could not check rule descriptions: {e}")
+    try:
         ec2_client.revoke_security_group_ingress(
             GroupId=sg,
             IpProtocol="tcp",
@@ -156,18 +156,9 @@ def remove_ip_from_sg(ec2_client, rds_client, ip, cluster_id, is_rds_instance=Fa
             FromPort=0,
             ToPort=65535,
         )
-    except ClientError:
-        pass
-        ec2_client.revoke_security_group_ingress(
-            GroupId=sg,
-            IpProtocol="tcp",
-            CidrIp=cidr,
-            FromPort=0,
-            ToPort=65535,
-        )
-    except ClientError:
-        pass
-    print(f"  Removed {cidr} from SG {sg}")
+        print(f"  Removed {cidr} from SG {sg}")
+    except ClientError as e:
+        print(f"  Warning: revoke-security-group-ingress failed: {e}")
 
 
 # ---------------------------------------------------------------------------
@@ -350,6 +341,7 @@ def create_custom_endpoint(rds_client, cluster_id, endpoint_id, num_instances):
         DBClusterIdentifier=cluster_id,
         EndpointType="ANY",
         StaticMembers=members,
+        Tags=[{"Key": "env", "Value": "test-runner"}],
     )
 
     time.sleep(30)
@@ -439,6 +431,7 @@ def create_secrets(sm_client, username, password, engine, cluster_endpoint):
         Name=secret_name,
         Description="Secrets created by GH actions for DB auth",
         SecretString=secret_value,
+        Tags=[{"Key": "env", "Value": "test-runner"}],
     )
     return response["ARN"]
 
@@ -560,6 +553,7 @@ def create_parameter_group(rds_client, name, engine, engine_version):
         DBClusterParameterGroupName=name,
         DBParameterGroupFamily=param_family,
         Description="Custom parameter group for Blue/Green Deployment testing",
+        Tags=[{"Key": "env", "Value": "test-runner"}],
     )
 
     if "mysql" in engine:

--- a/test/common/test_runner.cpp
+++ b/test/common/test_runner.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <iostream>
+#include <string>
 #include "gtest/gtest.h"
 
 class FlushingListener : public testing::EmptyTestEventListener {
@@ -57,7 +58,13 @@ int main(int argc, char** argv) {
     delete listeners.Release(listeners.default_result_printer());
     listeners.Append(new FlushingListener());
 
+    // Each CI step runs this binary more than once with different --gtest_filter
+    // batches, so include the filter in the summary to make it unambiguous which
+    // batch a given "All tests passed" / "Not all tests passed" line refers to.
+    const std::string filter = GTEST_FLAG_GET(filter);
+    const std::string batch = filter.empty() ? "" : " [--gtest_filter=" + filter + "]";
+
     int failures = RUN_ALL_TESTS();
-    std::cout << (failures ? "Not all tests passed." : "All tests passed") << std::endl;
+    std::cout << (failures ? "Not all tests passed." : "All tests passed") << batch << std::endl;
     return failures;
 }

--- a/test/integration/aurora_initial_connection_strategy_integration_test.cpp
+++ b/test/integration/aurora_initial_connection_strategy_integration_test.cpp
@@ -53,6 +53,9 @@ protected:
 
         // Wait for cluster to be available after prior failovers
         WaitForDbReady(rds_client, cluster_id);
+        // Wait for a settled writer before deriving topology below.
+        // A prior failover test may have just promoted a new writer, leaving the SDK reporting a stale writer.
+        WaitForWriterStable(rds_client, cluster_id);
 
         cluster_instances = GetTopologyViaSdk(rds_client, cluster_id);
         if (cluster_instances.empty()) {

--- a/test/integration/base_failover_integration_test.h
+++ b/test/integration/base_failover_integration_test.h
@@ -287,7 +287,7 @@ protected:
     }
 
     static void WaitForDbReady(const Aws::RDS::RDSClient& client, const Aws::String& cluster_id,
-                               std::chrono::seconds timeout = std::chrono::minutes(3)) {
+                               std::chrono::seconds timeout = std::chrono::minutes(5)) {
         const auto start = std::chrono::steady_clock::now();
         Aws::String status = GetDbCluster(client, cluster_id).GetStatus();
 

--- a/test/integration/base_failover_integration_test.h
+++ b/test/integration/base_failover_integration_test.h
@@ -305,7 +305,7 @@ protected:
     // Wait for the cluster to report one writer, stable across consecutive polls.
     // After a failover DescribeDBClusters briefly reports a stale writer, which makes the next test connect to the wrong node.
     static void WaitForWriterStable(const Aws::RDS::RDSClient& client, const Aws::String& cluster_id,
-                                    std::chrono::seconds timeout = std::chrono::minutes(3)) {
+                                    std::chrono::seconds timeout = std::chrono::minutes(5)) {
         const auto start = std::chrono::steady_clock::now();
         std::string last_writer;
         int stable_polls = 0;
@@ -339,7 +339,7 @@ protected:
     }
 
     static void WaitForAllInstancesReady(const Aws::RDS::RDSClient& client, const Aws::String& cluster_id,
-                                         std::chrono::seconds timeout = std::chrono::minutes(3)) {
+                                         std::chrono::seconds timeout = std::chrono::minutes(5)) {
         // Cache the last confirmed-ready time per cluster and skip the re-probe while fresh (writer still reachable).
         // SetUp() probes every test; re-running the full SDK+TCP probe wastes minutes/test and multiplies the timeout when an instance is down.
         static std::mutex ready_cache_mutex;

--- a/test/integration/base_failover_integration_test.h
+++ b/test/integration/base_failover_integration_test.h
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <iostream>
+#include <map>
+#include <mutex>
 
 #include <aws/rds/model/TargetHealth.h>
 #include <aws/rds/model/TargetState.h>
@@ -284,18 +286,80 @@ protected:
         throw std::runtime_error("GetDbCluster: DescribeDBClusters failed after retries");
     }
 
-    static void WaitForDbReady(const Aws::RDS::RDSClient& client, const Aws::String& cluster_id) {
+    static void WaitForDbReady(const Aws::RDS::RDSClient& client, const Aws::String& cluster_id,
+                               std::chrono::seconds timeout = std::chrono::minutes(3)) {
+        const auto start = std::chrono::steady_clock::now();
         Aws::String status = GetDbCluster(client, cluster_id).GetStatus();
 
         while (status != "available") {
+            if (std::chrono::steady_clock::now() - start > timeout) {
+                throw std::runtime_error("WaitForDbReady: cluster '" + std::string(cluster_id.c_str())
+                                         + "' did not become available within timeout. Last status: "
+                                         + std::string(status.c_str()) + ".");
+            }
             std::this_thread::sleep_for(std::chrono::seconds(3));
             status = GetDbCluster(client, cluster_id).GetStatus();
         }
     }
 
+    // Wait for the cluster to report one writer, stable across consecutive polls.
+    // After a failover DescribeDBClusters briefly reports a stale writer, which makes the next test connect to the wrong node.
+    static void WaitForWriterStable(const Aws::RDS::RDSClient& client, const Aws::String& cluster_id,
+                                    std::chrono::seconds timeout = std::chrono::minutes(3)) {
+        const auto start = std::chrono::steady_clock::now();
+        std::string last_writer;
+        int stable_polls = 0;
+        constexpr int required_stable_polls = 3;
+        while (std::chrono::steady_clock::now() - start < timeout) {
+            const auto cluster = GetDbCluster(client, cluster_id);
+            std::string writer;
+            int writer_count = 0;
+            for (const auto& member : cluster.GetDBClusterMembers()) {
+                if (member.GetIsClusterWriter()) {
+                    writer = std::string(member.GetDBInstanceIdentifier());
+                    ++writer_count;
+                }
+            }
+            if (cluster.GetStatus() == "available" && writer_count == 1) {
+                if (writer == last_writer) {
+                    if (++stable_polls >= required_stable_polls) {
+                        return;
+                    }
+                } else {
+                    last_writer = writer;
+                    stable_polls = 1;
+                }
+            } else {
+                stable_polls = 0;
+            }
+            std::this_thread::sleep_for(std::chrono::seconds(5));
+        }
+        std::cout << "[WaitForWriterStable] cluster '" << cluster_id
+                  << "' writer did not stabilize within timeout; proceeding with last known topology." << std::endl;
+    }
+
     static void WaitForAllInstancesReady(const Aws::RDS::RDSClient& client, const Aws::String& cluster_id,
-                                         std::chrono::seconds timeout = std::chrono::minutes(10)) {
+                                         std::chrono::seconds timeout = std::chrono::minutes(3)) {
+        // Cache the last confirmed-ready time per cluster and skip the re-probe while fresh (writer still reachable).
+        // SetUp() probes every test; re-running the full SDK+TCP probe wastes minutes/test and multiplies the timeout when an instance is down.
+        static std::mutex ready_cache_mutex;
+        static std::map<std::string, std::chrono::steady_clock::time_point> ready_cache;
+        constexpr auto ready_cache_ttl = std::chrono::seconds(60);
+        {
+            const std::lock_guard<std::mutex> lock(ready_cache_mutex);
+            const auto cached = ready_cache.find(cluster_id);
+            if (cached != ready_cache.end() && std::chrono::steady_clock::now() - cached->second < ready_cache_ttl) {
+                const auto cluster = GetDbCluster(client, cluster_id);
+                if (TEST_UTILS::CanTcpConnect(cluster.GetEndpoint(), cluster.GetPort(), 10)) {
+                    return;
+                }
+                // Writer endpoint no longer reachable; fall through to a full re-probe.
+                ready_cache.erase(cached);
+            }
+        }
+
         auto start = std::chrono::steady_clock::now();
+        std::string last_blocker = "SDK reported an instance as not 'available'";
         while (std::chrono::steady_clock::now() - start < timeout) {
             auto cluster = GetDbCluster(client, cluster_id);
             auto members = cluster.GetDBClusterMembers();
@@ -316,21 +380,20 @@ protected:
             }
 
             if (all_available) {
-                // SDK reports all instances available. Verify TCP connectivity to the
-                // cluster writer endpoint. Multi-AZ instances may not accept connections
-                // immediately after reporting "available" status.
+                // Verify TCP connectivity to the writer endpoint.
+                // Multi-AZ instances may not accept connections right after reporting "available".
                 const std::string endpoint = cluster.GetEndpoint();
                 const int port = cluster.GetPort();
                 if (!TEST_UTILS::CanTcpConnect(endpoint, port, 10)) {
+                    last_blocker = "writer endpoint " + endpoint + ":" + std::to_string(port) + " not accepting connections";
                     std::cout << "[WaitForAllInstancesReady] Instances available but writer endpoint "
                               << endpoint << ":" << port << " not yet accepting connections." << std::endl;
                     std::this_thread::sleep_for(std::chrono::seconds(5));
                     continue;
                 }
 
-                // Also verify TCP connectivity to each individual instance endpoint.
-                // Tests connect to instance endpoints directly, and these may lag behind
-                // the cluster endpoint after failover.
+                // Verify each instance endpoint too: tests connect to them directly.
+                // Instance endpoints can lag the cluster endpoint after failover.
                 bool all_instances_connectable = true;
                 for (const auto& member : members) {
                     Aws::RDS::Model::DescribeDBInstancesRequest inst_req;
@@ -340,6 +403,8 @@ protected:
                         const std::string instance_endpoint(inst_outcome.GetResult().GetDBInstances()[0].GetEndpoint().GetAddress());
                         const int instance_port = inst_outcome.GetResult().GetDBInstances()[0].GetEndpoint().GetPort();
                         if (!instance_endpoint.empty() && !TEST_UTILS::CanTcpConnect(instance_endpoint, instance_port, 10)) {
+                            last_blocker = "instance endpoint " + instance_endpoint + ":" + std::to_string(instance_port)
+                                           + " (" + member.GetDBInstanceIdentifier() + ") not accepting connections";
                             std::cout << "[WaitForAllInstancesReady] Instance endpoint "
                                       << instance_endpoint << ":" << instance_port
                                       << " not yet accepting connections." << std::endl;
@@ -349,12 +414,15 @@ protected:
                     }
                 }
                 if (all_instances_connectable) {
+                    const std::lock_guard<std::mutex> lock(ready_cache_mutex);
+                    ready_cache[cluster_id] = std::chrono::steady_clock::now();
                     return;
                 }
             }
             std::this_thread::sleep_for(std::chrono::seconds(5));
         }
-        throw std::runtime_error("WaitForAllInstancesReady: Instances not available.");
+        throw std::runtime_error("WaitForAllInstancesReady: cluster '" + std::string(cluster_id.c_str())
+                                 + "' not ready within timeout. Last blocker: " + last_blocker + ".");
     }
 
     static Aws::RDS::Model::DBClusterEndpoint GetCustomEndpointInfo(const Aws::RDS::RDSClient& client, const std::string& endpoint_id) {
@@ -452,9 +520,9 @@ protected:
 
         FailoverCluster(client, cluster_id, target_writer_id);
 
-        std::chrono::nanoseconds timeout = std::chrono::minutes(3);
-        int remaining_attempts = 5;
-        while (!HasWriterChanged(client, cluster_id, initial_writer_id, timeout)) {
+        std::chrono::nanoseconds writer_change_timeout = std::chrono::minutes(1);
+        int remaining_attempts = 3;
+        while (!HasWriterChanged(client, cluster_id, initial_writer_id, writer_change_timeout)) {
             // if writer is not changed, try triggering failover again
             remaining_attempts--;
             if (remaining_attempts == 0) {
@@ -473,7 +541,7 @@ protected:
         auto start = std::chrono::high_resolution_clock::now();
         while (initial_writer_ip == current_writer_ip) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
-            if (std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count() > timeout.count()) {
+            if (std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - start).count() > writer_change_timeout.count()) {
                 GTEST_SKIP() << "Cluster writer did not resolve to the target instance after server failover.";
             }
 

--- a/test/integration/blue_green_integration_test.cpp
+++ b/test/integration/blue_green_integration_test.cpp
@@ -196,7 +196,7 @@ protected:
     std::chrono::steady_clock::time_point empty_time_point{};
     std::chrono::steady_clock::time_point global_start_time;
 
-    ConnectionStringBuilder conn_str_builder;
+    ConnectionStringBuilder conn_str_builder{""};
     std::string test_iam_user = TEST_UTILS::GetEnvVar("TEST_IAM_USER", "");
     std::string test_base_driver = TEST_UTILS::GetEnvVar("TEST_BASE_DRIVER", "");
 

--- a/test/integration/custom_endpoint_integration_test.cpp
+++ b/test/integration/custom_endpoint_integration_test.cpp
@@ -60,6 +60,10 @@ protected:
         }
         rds_client = Aws::RDS::RDSClient(credentials, client_config);
 
+        // Wait for a settled writer before deriving topology below.
+        // A prior failover test may have just promoted a new writer, leaving the SDK reporting a stale writer.
+        WaitForWriterStable(rds_client, cluster_id);
+
         cluster_instances = GetTopologyViaSdk(rds_client, cluster_id);
         if (cluster_instances.empty()) {
             GTEST_SKIP() << "No cluster instances found";

--- a/test/integration/failover_integration_test.cpp
+++ b/test/integration/failover_integration_test.cpp
@@ -54,6 +54,9 @@ protected:
         // Check to see if cluster is available before fetching topology.
         WaitForDbReady(rds_client, cluster_id);
         WaitForAllInstancesReady(rds_client, cluster_id);
+        // Wait for a settled writer before deriving writer_endpoint below.
+        // A prior test may have just failed over, leaving the SDK reporting a stale writer.
+        WaitForWriterStable(rds_client, cluster_id);
 
         cluster_instances = GetTopologyViaSdk(rds_client, cluster_id);
         if (cluster_instances.empty()) {

--- a/test/integration/read_write_splitting_integration_test.cpp
+++ b/test/integration/read_write_splitting_integration_test.cpp
@@ -32,6 +32,7 @@ protected:
     std::string stmt_set_read_only_true;
     std::string stmt_set_read_only_false;
     std::string reader_conn_str;
+    std::string test_cluster_id;
 
     static void SetUpTestSuite() {
         BaseFailoverIntegrationTest::SetUpTestSuite();
@@ -62,9 +63,15 @@ protected:
             stmt_set_read_only_false = "set session characteristics as transaction read write";
         }
 
+        const ::testing::TestInfo* test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+        test_cluster_id = test_info ? test_info->name() : cluster_id;
+
         // Check to see if cluster is available.
         WaitForDbReady(rds_client, cluster_id);
         WaitForAllInstancesReady(rds_client, cluster_id);
+        // Wait for a settled writer before deriving writer_endpoint below.
+        // A prior failover test may have just promoted a new writer, leaving the SDK reporting a stale writer.
+        WaitForWriterStable(rds_client, cluster_id);
 
         cluster_instances = GetTopologyViaSdk(rds_client, cluster_id);
         writer_id = GetWriterId(cluster_instances);
@@ -79,7 +86,7 @@ protected:
             .withDatabase(test_db)
             .withEnableRwSplitting(true)
             .withDatabaseDialect(test_dialect)
-            .withClusterId(cluster_id)
+            .withClusterId(test_cluster_id)
             .getString();
 
         reader_conn_str = ConnectionStringBuilder(test_dsn, GetEndpoint(reader_id), test_port)
@@ -88,7 +95,7 @@ protected:
             .withDatabase(test_db)
             .withEnableRwSplitting(true)
             .withDatabaseDialect(test_dialect)
-            .withClusterId(cluster_id)
+            .withClusterId(test_cluster_id)
             .getString();
     }
 
@@ -162,7 +169,7 @@ TEST_F(ReadWriteSplittingIntegrationTest, ReaderClusterConnectSetReadOnly) {
             .withDatabase(test_db)
             .withEnableRwSplitting(true)
             .withDatabaseDialect(test_dialect)
-            .withClusterId(cluster_id)
+            .withClusterId(test_cluster_id)
             .getString();
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, reader_cluster_conn_str);
     EXPECT_EQ(SQL_SUCCESS, rc);

--- a/test/integration/simple_read_write_splitting_integration_test.cpp
+++ b/test/integration/simple_read_write_splitting_integration_test.cpp
@@ -32,6 +32,7 @@ protected:
     std::string stmt_set_read_only_true;
     std::string stmt_set_read_only_false;
     std::string reader_conn_str;
+    std::string test_cluster_id;
 
     static void SetUpTestSuite() {
         BaseFailoverIntegrationTest::SetUpTestSuite();
@@ -62,8 +63,14 @@ protected:
             stmt_set_read_only_false = "set session characteristics as transaction read write";
         }
 
+        const ::testing::TestInfo* test_info = ::testing::UnitTest::GetInstance()->current_test_info();
+        test_cluster_id = test_info ? test_info->name() : cluster_id;
+
         // Check to see if cluster is available.
         WaitForDbReady(rds_client, cluster_id);
+        // Wait for a settled writer before connecting below.
+        // A prior failover test may have just promoted a new writer, leaving the SDK reporting a stale writer.
+        WaitForWriterStable(rds_client, cluster_id);
 
         conn_str = ConnectionStringBuilder(test_dsn, test_server, test_port)
             .withUID(test_uid)
@@ -71,6 +78,7 @@ protected:
             .withDatabase(test_db)
             .withEnableSrwSplitting(true, test_server, cluster_ro_url, true)
             .withDatabaseDialect(test_dialect)
+            .withClusterId(test_cluster_id)
             .getString();
     }
 
@@ -117,6 +125,7 @@ TEST_F(SimpleReadWriteSplittingIntegrationTest, IncorrectURLs) {
             .withDatabase(test_db)
             .withEnableSrwSplitting(true, test_server, test_server, false)
             .withDatabaseDialect(test_dialect)
+            .withClusterId(test_cluster_id)
             .getString();
     SQLRETURN rc = ODBC_HELPER::DriverConnect(dbc, incorrect_urls_str);
     EXPECT_EQ(SQL_SUCCESS, rc);

--- a/test/unit_test/aurora_initial_connection_strategy_plugin_test.cpp
+++ b/test/unit_test/aurora_initial_connection_strategy_plugin_test.cpp
@@ -22,15 +22,17 @@
 #include "../../driver/plugin/aurora_initial_connection_strategy/aurora_initial_connection_strategy_plugin.h"
 #include "../../driver/util/connection_string_keys.h"
 
+using ::testing::NiceMock;
+
 class AuroraInitialConnectionStrategyPluginTest : public ::testing::Test {
 protected:
-    std::shared_ptr<MOCK_BASE_PLUGIN> mock_base_plugin = nullptr;
-    std::shared_ptr<MOCK_PLUGIN_SERVICE> mock_plugin_service;
-    std::shared_ptr<MOCK_HOST_LIST_PROVIDER> mock_host_list_provider;
-    std::shared_ptr<MOCK_ODBC_HELPER> mock_odbc_helper;
-    std::shared_ptr<MOCK_DIALECT> mock_dialect;
-    std::shared_ptr<MOCK_HOST_SELECTOR> mock_host_selector;
-    std::shared_ptr<MOCK_TOPOLOGY_UTIL> mock_topology_util;
+    std::shared_ptr<NiceMock<MOCK_BASE_PLUGIN>> mock_base_plugin = nullptr;
+    std::shared_ptr<NiceMock<MOCK_PLUGIN_SERVICE>> mock_plugin_service;
+    std::shared_ptr<NiceMock<MOCK_HOST_LIST_PROVIDER>> mock_host_list_provider;
+    std::shared_ptr<NiceMock<MOCK_ODBC_HELPER>> mock_odbc_helper;
+    std::shared_ptr<NiceMock<MOCK_DIALECT>> mock_dialect;
+    std::shared_ptr<NiceMock<MOCK_HOST_SELECTOR>> mock_host_selector;
+    std::shared_ptr<NiceMock<MOCK_TOPOLOGY_UTIL>> mock_topology_util;
     DBC* dbc = nullptr;
     const std::string writer_cluster_dns = "database-test-name.cluster-XYZ.us-east-2.rds.amazonaws.com";
     const std::string reader_cluster_dns = "database-test-name.cluster-ro-XYZ.us-east-2.rds.amazonaws.com";
@@ -48,13 +50,13 @@ protected:
 
     // Runs per test
     void SetUp() override {
-        mock_base_plugin = std::make_shared<MOCK_BASE_PLUGIN>();
-        mock_plugin_service = std::make_shared<MOCK_PLUGIN_SERVICE>();
-        mock_host_list_provider = std::make_shared<MOCK_HOST_LIST_PROVIDER>();
-        mock_odbc_helper = std::make_shared<MOCK_ODBC_HELPER>();
-        mock_dialect = std::make_shared<MOCK_DIALECT>();
-        mock_host_selector = std::make_shared<MOCK_HOST_SELECTOR>();
-        mock_topology_util = std::make_shared<MOCK_TOPOLOGY_UTIL>(mock_odbc_helper, mock_dialect);
+        mock_base_plugin = std::make_shared<NiceMock<MOCK_BASE_PLUGIN>>();
+        mock_plugin_service = std::make_shared<NiceMock<MOCK_PLUGIN_SERVICE>>();
+        mock_host_list_provider = std::make_shared<NiceMock<MOCK_HOST_LIST_PROVIDER>>();
+        mock_odbc_helper = std::make_shared<NiceMock<MOCK_ODBC_HELPER>>();
+        mock_dialect = std::make_shared<NiceMock<MOCK_DIALECT>>();
+        mock_host_selector = std::make_shared<NiceMock<MOCK_HOST_SELECTOR>>();
+        mock_topology_util = std::make_shared<NiceMock<MOCK_TOPOLOGY_UTIL>>(mock_odbc_helper, mock_dialect);
         ON_CALL(*mock_topology_util, GetWriter).WillByDefault(testing::Return(*writer_host));
         ON_CALL(*mock_plugin_service, GetHostListProvider).WillByDefault(testing::Return(mock_host_list_provider));
         ON_CALL(*mock_plugin_service, GetTopologyUtil).WillByDefault(testing::Return(mock_topology_util));
@@ -184,7 +186,7 @@ TEST_F(AuroraInitialConnectionStrategyPluginTest, Connect_Success_Writer_Cannot_
 
     dbc->conn_attr.insert_or_assign(KEY_SERVER, writer_cluster_dns);
     dbc->conn_attr.insert_or_assign(KEY_INITIAL_CONNECTION_RETRY_INTERVAL_MS, "10");
-    dbc->conn_attr.insert_or_assign(KEY_INITIAL_CONNECTION_RETRY_TIMEOUT_MS, "100");
+    dbc->conn_attr.insert_or_assign(KEY_INITIAL_CONNECTION_RETRY_TIMEOUT_MS, "5000");
     AuroraInitialConnectionStrategyPlugin plugin(
         dbc,
         mock_base_plugin,
@@ -324,8 +326,8 @@ TEST_F(AuroraInitialConnectionStrategyPluginTest, Connect_Success_Reader_Network
     .WillRepeatedly(testing::Return(READER));
 
     dbc->conn_attr.insert_or_assign(KEY_SERVER, reader_cluster_dns);
-     dbc->conn_attr.insert_or_assign(KEY_INITIAL_CONNECTION_RETRY_INTERVAL_MS, "10");
-     dbc->conn_attr.insert_or_assign(KEY_INITIAL_CONNECTION_RETRY_TIMEOUT_MS, "100");
+    dbc->conn_attr.insert_or_assign(KEY_INITIAL_CONNECTION_RETRY_INTERVAL_MS, "10");
+    dbc->conn_attr.insert_or_assign(KEY_INITIAL_CONNECTION_RETRY_TIMEOUT_MS, "5000");
     AuroraInitialConnectionStrategyPlugin plugin(
         dbc,
         mock_base_plugin,

--- a/test/unit_test/read_write_splitting_plugin_test.cpp
+++ b/test/unit_test/read_write_splitting_plugin_test.cpp
@@ -52,7 +52,7 @@ protected:
 
     ENV env;
     DBC* dbc = nullptr;
-    std::shared_ptr<MOCK_BASE_PLUGIN> mock_next_plugin;
+    std::shared_ptr<NiceMock<MOCK_BASE_PLUGIN>> mock_next_plugin;
 
     SQLHDBC fake_writer_hdbc = reinterpret_cast<SQLHDBC>(0x1000);
     SQLHDBC fake_reader_hdbc = reinterpret_cast<SQLHDBC>(0x2000);
@@ -77,7 +77,7 @@ protected:
         dbc->transaction_status = TRANSACTION_CLOSED;
         dbc->plugin_service = mock_plugin_service;
 
-        mock_next_plugin = std::make_shared<MOCK_BASE_PLUGIN>();
+        mock_next_plugin = std::make_shared<NiceMock<MOCK_BASE_PLUGIN>>();
         dbc->plugin_head = mock_next_plugin.get();
 
         ON_CALL(*mock_plugin_service, GetOdbcHelper()).WillByDefault(Return(mock_odbc_helper));

--- a/test/unit_test/simple_read_write_splitting_plugin_test.cpp
+++ b/test/unit_test/simple_read_write_splitting_plugin_test.cpp
@@ -47,7 +47,7 @@ protected:
 
     ENV env;
     DBC* dbc = nullptr;
-    std::shared_ptr<MOCK_BASE_PLUGIN> mock_next_plugin;
+    std::shared_ptr<NiceMock<MOCK_BASE_PLUGIN>> mock_next_plugin;
 
     SQLHDBC fake_writer_hdbc = reinterpret_cast<SQLHDBC>(0x3000);
     SQLHDBC fake_reader_hdbc = reinterpret_cast<SQLHDBC>(0x4000);
@@ -67,7 +67,7 @@ protected:
         dbc->transaction_status = TRANSACTION_CLOSED;
         dbc->plugin_service = mock_plugin_service;
 
-        mock_next_plugin = std::make_shared<MOCK_BASE_PLUGIN>();
+        mock_next_plugin = std::make_shared<NiceMock<MOCK_BASE_PLUGIN>>();
         dbc->plugin_head = mock_next_plugin.get();
 
         dbc->conn_attr[KEY_SRW_WRITE_ENDPOINT] = WRITE_ENDPOINT;


### PR DESCRIPTION
### Summary

Improve CI Reliability 

### Description

- Adds job-step timeouts to test steps to prevent it from running too long causing runner timeouts and missing resource deletion steps
- Added some fast-fails
- Fixed IAM not being skipped for MacOS' MySQL runs
Driver
- Resolves some driver warnings with additional casting
DB Resource Creation/Deletion
- Fixes IP removal with additional check on descriptions
- Tagged additional resources (SM & DB Parameter Groups)
Tests
- Add more info when logging if test passed or failed (i.e. print the filter used)
- Added another stabilization wait step for writers
- Reduced DB Stabilization waits to 5m per step
- Explicit cluster ID set for each test to prevent stale cache reuse
- NiceMocks to cleanup Gmock warnings

### Testing

<!-- What did you test and how did you test it -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
