### PR TITLE
refactor: initialize AWS SDK once per process

### DIFF
--- a/driver/plugin/custom_endpoint/custom_endpoint_monitor.cpp
+++ b/driver/plugin/custom_endpoint/custom_endpoint_monitor.cpp
@@ -44,7 +44,7 @@ CustomEndpointMonitor::CustomEndpointMonitor(
       max_refresh_rate_ms_{ max_refresh_rate_ms },
       exponential_backoff_rate_{ exponential_backoff_rate }
 {
-    AwsSdkHelper::Init();
+    AwsSdkHelper::EnsureInitialized();
     is_running_.store(true);
     this->monitoring_thread_ = std::make_shared<std::thread>(&CustomEndpointMonitor::Run, this);
 }
@@ -55,9 +55,6 @@ CustomEndpointMonitor::~CustomEndpointMonitor() {
         monitoring_thread_->join();
     }
     monitoring_thread_ = nullptr;
-    if (sdk_initialized_) {
-        AwsSdkHelper::Shutdown();
-    }
 }
 
 void CustomEndpointMonitor::Run() {

--- a/driver/plugin/custom_endpoint/custom_endpoint_monitor.h
+++ b/driver/plugin/custom_endpoint/custom_endpoint_monitor.h
@@ -37,7 +37,7 @@ public:
 
 protected:
     // For unit testing & mocks. Does not initialize the AWS SDK or start the monitoring thread.
-    CustomEndpointMonitor() : is_running_(false), sdk_initialized_(false) {}
+    CustomEndpointMonitor() : is_running_(false) {}
 
 private:
     void IncreaseDelay();
@@ -47,7 +47,6 @@ private:
 
     std::shared_ptr<std::thread> monitoring_thread_;
     std::atomic<bool> is_running_;
-    bool sdk_initialized_ = true;
 
     std::weak_ptr<PluginService> plugin_service_;
     std::string endpoint_;

--- a/driver/plugin/federated/saml_util.cpp
+++ b/driver/plugin/federated/saml_util.cpp
@@ -32,7 +32,7 @@ SamlUtil::SamlUtil(
     const std::shared_ptr<Aws::STS::STSClient>& sts_client)
 {
     ParseIdpConfig(connection_attributes);
-    AwsSdkHelper::Init();
+    AwsSdkHelper::EnsureInitialized();
     if (http_client) {
         this->http_client = http_client;
     } else {
@@ -74,7 +74,6 @@ SamlUtil::~SamlUtil()
     if (sts_client) {
         sts_client = nullptr;
     }
-    AwsSdkHelper::Shutdown();
 }
 
 Aws::Auth::AWSCredentials SamlUtil::GetAwsCredentials(const std::string &assertion)

--- a/driver/plugin/secrets_manager/secrets_manager_plugin.cpp
+++ b/driver/plugin/secrets_manager/secrets_manager_plugin.cpp
@@ -65,7 +65,7 @@ SecretsManagerPlugin::SecretsManagerPlugin(DBC *dbc, std::shared_ptr<BasePlugin>
 
     secret_key = secret_id + "-" + region;
 
-    AwsSdkHelper::Init();
+    AwsSdkHelper::EnsureInitialized();
     if (client) {
         secrets_manager_client = client;
     } else {
@@ -85,7 +85,6 @@ SecretsManagerPlugin::~SecretsManagerPlugin()
 {
     if (secrets_manager_client) {
         secrets_manager_client.reset();
-        AwsSdkHelper::Shutdown();
     }
 }
 

--- a/driver/util/auth_provider.cpp
+++ b/driver/util/auth_provider.cpp
@@ -27,7 +27,7 @@
 #include "plugin_service.h"
 
 AuthProvider::AuthProvider(const std::string &region) {
-    AwsSdkHelper::Init();
+    AwsSdkHelper::EnsureInitialized();
     SetUpRdsClient(Aws::Auth::DefaultAWSCredentialsProviderChain().GetAWSCredentials(), region);
 }
 
@@ -35,13 +35,13 @@ AuthProvider::AuthProvider(
     const std::string &region,
     const Aws::Auth::AWSCredentials& credentials)
 {
-    AwsSdkHelper::Init();
+    AwsSdkHelper::EnsureInitialized();
     SetUpRdsClient(credentials, region);
 }
 
 AuthProvider::AuthProvider(const std::shared_ptr<Aws::RDS::RDSClient>& rds_client)
 {
-    AwsSdkHelper::Init();
+    AwsSdkHelper::EnsureInitialized();
     this->rds_client = rds_client;
 }
 
@@ -50,7 +50,6 @@ AuthProvider::~AuthProvider()
     if (rds_client) {
         rds_client = nullptr;
     }
-    AwsSdkHelper::Shutdown();
 }
 
 std::pair<std::string, bool> AuthProvider::GetToken(

--- a/driver/util/aws_sdk_helper.cpp
+++ b/driver/util/aws_sdk_helper.cpp
@@ -14,28 +14,28 @@
 
 #include "aws_sdk_helper.h"
 
+#include <mutex>
+
 #include "logger_wrapper.h"
 
 Aws::SDKOptions AwsSdkHelper::sdk_options;
-std::atomic<int> AwsSdkHelper::sdk_reference_count{0};
-std::mutex AwsSdkHelper::sdk_mutex;
+std::atomic<bool> AwsSdkHelper::sdk_initialized{false};
 
-void AwsSdkHelper::Init()
+void AwsSdkHelper::EnsureInitialized()
 {
-    const std::lock_guard<std::mutex> lock(sdk_mutex);
-    if (1 == ++sdk_reference_count) {
+    static std::once_flag init_flag;
+    std::call_once(init_flag, [] {
         Aws::InitAPI(sdk_options);
-        LOG(INFO) << "Created AWS SDK Instance";
-    }
-    LOG(INFO) << "Incremented AWS SDK Instance usage count: " << sdk_reference_count;
+        sdk_initialized.store(true);
+        LOG(INFO) << "Initialized AWS SDK Instance";
+    });
 }
 
-void AwsSdkHelper::Shutdown()
+void AwsSdkHelper::PerformShutdown()
 {
-    const std::lock_guard<std::mutex> lock(sdk_mutex);
-    if (0 == --sdk_reference_count) {
+    bool expected = true;
+    if (sdk_initialized.compare_exchange_strong(expected, false)) {
         Aws::ShutdownAPI(sdk_options);
         LOG(INFO) << "Shut down AWS SDK Instance";
     }
-    LOG(INFO) << "Decremented AWS SDK Instance usage count: " << sdk_reference_count;
 }

--- a/driver/util/aws_sdk_helper.h
+++ b/driver/util/aws_sdk_helper.h
@@ -18,13 +18,18 @@
 #include <aws/core/Aws.h>
 
 #include <atomic>
-#include <mutex>
 
 class AwsSdkHelper {
 public:
     AwsSdkHelper() = default;
-    static void Init();
-    static void Shutdown();
+
+    // Initializes the AWS SDK once per process, lazily on first use; the SDK
+    // cannot be re-initialized, so subsequent calls are no-ops.
+    static void EnsureInitialized();
+
+    // Shuts the SDK down at most once, on a normal thread. The driver never
+    // auto-calls this; in production the OS reclaims SDK globals at process exit.
+    static void PerformShutdown();
 
     // Prevent copy constructors
     AwsSdkHelper(const AwsSdkHelper&) = delete;
@@ -34,8 +39,7 @@ public:
 
 private:
     static Aws::SDKOptions sdk_options;
-    static std::atomic<int> sdk_reference_count;
-    static std::mutex sdk_mutex;
+    static std::atomic<bool> sdk_initialized;
 };
 
 #endif // AWS_SDK_HELPER_H

--- a/test/unit_test/CMakeLists.txt
+++ b/test/unit_test/CMakeLists.txt
@@ -35,6 +35,7 @@ set(TEST_SUITE
     ${CMAKE_CURRENT_SOURCE_DIR}/attribute_validator_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/aurora_initial_connection_strategy_plugin_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/auth_provider_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/aws_sdk_test_environment.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/concurrent_map_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/concurrent_stack_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/connection_string_helper_test.cpp

--- a/test/unit_test/adfs_auth_plugin_test.cpp
+++ b/test/unit_test/adfs_auth_plugin_test.cpp
@@ -43,10 +43,7 @@ protected:
 
     // Runs once per suite
     static void SetUpTestSuite() {
-        AwsSdkHelper::Init();
-    }
-    static void TearDownTestSuite() {
-        AwsSdkHelper::Shutdown();
+        AwsSdkHelper::EnsureInitialized();
     }
 
     // Runs per test

--- a/test/unit_test/adfs_saml_util_test.cpp
+++ b/test/unit_test/adfs_saml_util_test.cpp
@@ -51,10 +51,7 @@ protected:
 
     // Runs once per suite
     static void SetUpTestSuite() {
-        AwsSdkHelper::Init();
-    }
-    static void TearDownTestSuite() {
-        AwsSdkHelper::Shutdown();
+        AwsSdkHelper::EnsureInitialized();
     }
 
     // Runs per test

--- a/test/unit_test/auth_mock_objects.h
+++ b/test/unit_test/auth_mock_objects.h
@@ -33,7 +33,7 @@
 
 class MOCK_SAML_UTIL : public SamlUtil {
 public:
-    MOCK_SAML_UTIL() : SamlUtil() { AwsSdkHelper::Init(); };
+    MOCK_SAML_UTIL() : SamlUtil() { AwsSdkHelper::EnsureInitialized(); };
 
     MOCK_METHOD(Aws::Auth::AWSCredentials, GetAwsCredentials, (const std::string &assertion), ());
     MOCK_METHOD(std::string, GetSamlAssertion, (), ());
@@ -41,7 +41,7 @@ public:
 
 class MOCK_AUTH_PROVIDER : public AuthProvider {
 public:
-    MOCK_AUTH_PROVIDER() : AuthProvider() { AwsSdkHelper::Init(); };
+    MOCK_AUTH_PROVIDER() : AuthProvider() { AwsSdkHelper::EnsureInitialized(); };
 
     MOCK_METHOD((std::pair<std::string, bool>), GetToken, (const std::string &server, const std::string &region,
         const std::string &port, const std::string &username, bool use_cache, bool extra_url_encode,

--- a/test/unit_test/auth_provider_test.cpp
+++ b/test/unit_test/auth_provider_test.cpp
@@ -25,10 +25,7 @@ protected:
     std::shared_ptr<MOCK_RDS_CLIENT> mock_rds_client;
     // Runs once per suite
     static void SetUpTestSuite() {
-        AwsSdkHelper::Init();
-    }
-    static void TearDownTestSuite() {
-        AwsSdkHelper::Shutdown();
+        AwsSdkHelper::EnsureInitialized();
     }
 
     void SetUp() override {

--- a/test/unit_test/aws_sdk_test_environment.cpp
+++ b/test/unit_test/aws_sdk_test_environment.cpp
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "../../driver/util/aws_sdk_helper.h"
+
+// The test exe has no unload hook, so it shuts the SDK down explicitly to stay LSAN-clean
+// Driver relies on process exit.
+namespace {
+
+class AwsSdkTestEnvironment : public ::testing::Environment {
+public:
+    void TearDown() override {
+        AwsSdkHelper::PerformShutdown();
+    }
+};
+
+// Registered during static initialization, before main() calls RUN_ALL_TESTS().
+const ::testing::Environment* const kAwsSdkTestEnvironment =
+    ::testing::AddGlobalTestEnvironment(new AwsSdkTestEnvironment());
+
+} // namespace

--- a/test/unit_test/iam_auth_plugin_test.cpp
+++ b/test/unit_test/iam_auth_plugin_test.cpp
@@ -40,10 +40,7 @@ protected:
 
     // Runs once per suite
     static void SetUpTestSuite() {
-        AwsSdkHelper::Init();
-    }
-    static void TearDownTestSuite() {
-        AwsSdkHelper::Shutdown();
+        AwsSdkHelper::EnsureInitialized();
     }
 
     // Runs per test

--- a/test/unit_test/okta_auth_plugin_test.cpp
+++ b/test/unit_test/okta_auth_plugin_test.cpp
@@ -43,10 +43,7 @@ protected:
 
     // Runs once per suite
     static void SetUpTestSuite() {
-        AwsSdkHelper::Init();
-    }
-    static void TearDownTestSuite() {
-        AwsSdkHelper::Shutdown();
+        AwsSdkHelper::EnsureInitialized();
     }
 
     // Runs per test

--- a/test/unit_test/okta_saml_util_test.cpp
+++ b/test/unit_test/okta_saml_util_test.cpp
@@ -48,10 +48,7 @@ protected:
 
     // Runs once per suite
     static void SetUpTestSuite() {
-        AwsSdkHelper::Init();
-    }
-    static void TearDownTestSuite() {
-        AwsSdkHelper::Shutdown();
+        AwsSdkHelper::EnsureInitialized();
     }
 
     // Runs per test

--- a/test/unit_test/secrets_manager_plugin_test.cpp
+++ b/test/unit_test/secrets_manager_plugin_test.cpp
@@ -69,11 +69,7 @@ protected:
     DBC* dbc;
 
     static void SetUpTestSuite() {
-        AwsSdkHelper::Init();
-    }
-
-    static void TearDownTestSuite() {
-        AwsSdkHelper::Shutdown();
+        AwsSdkHelper::EnsureInitialized();
     }
 
     void SetUp() override {


### PR DESCRIPTION
### Summary

Initialize AWS SDK Once per Process

### Description

The AWS SDK was not built for multiple re-initialization within the same process. This change removes the reference counting and driver calling shutdown to a initialize once call. At program exit, the OS will cleanup the AWS SDK along with other residual processes.

### Testing

<!-- What did you test and how did you test it -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
