### PR TITLE
chore: ci dependency checksum

### DIFF
--- a/.github/workflows/build_installer.yaml
+++ b/.github/workflows/build_installer.yaml
@@ -16,14 +16,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk-cpp
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -32,7 +32,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Setup Dotnet for WiX
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
       - name: Install WiX
         shell: cmd
         run: |
@@ -44,7 +44,7 @@ jobs:
           ./installer/build_installer.ps1 ${{env.BUILD_CONFIG}}
       - name: Upload Windows installer as artifact
         if: success()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: windows-installer
           path: ${{ github.workspace }}/installer/*.msi
@@ -55,7 +55,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Build Dependencies
         run: |
           brew update && brew upgrade && brew cleanup
@@ -66,7 +66,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk-cpp
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -84,7 +84,7 @@ jobs:
           cpack
       - name: Upload Mac installer as artifact
         if: success()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: macos-installer
           path: ${{ github.workspace }}/build/aws-advanced-odbc-wrapper-*.pkg

--- a/.github/workflows/build_installer.yaml
+++ b/.github/workflows/build_installer.yaml
@@ -16,14 +16,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk-cpp
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -32,7 +32,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Setup Dotnet for WiX
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
       - name: Install WiX
         shell: cmd
         run: |
@@ -44,7 +44,7 @@ jobs:
           ./installer/build_installer.ps1 ${{env.BUILD_CONFIG}}
       - name: Upload Windows installer as artifact
         if: success()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: windows-installer
           path: ${{ github.workspace }}/installer/*.msi
@@ -55,7 +55,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Build Dependencies
         run: |
           brew update && brew upgrade && brew cleanup
@@ -66,7 +66,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk-cpp
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -84,7 +84,7 @@ jobs:
           cpack
       - name: Upload Mac installer as artifact
         if: success()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: macos-installer
           path: ${{ github.workspace }}/build/aws-advanced-odbc-wrapper-*.pkg

--- a/.github/workflows/compatibility_test.yaml
+++ b/.github/workflows/compatibility_test.yaml
@@ -29,6 +29,15 @@ env:
   LOCAL_DB_PWD: 'test_password'
   LOCAL_DB_NAME: 'test_database'
 
+  # SHA-256 checksums for pinned third-party downloads. If a download stops
+  # matching, someone changed the artifact upstream - investigate before bumping.
+  UNIXODBC_VERSION: '2.3.12'
+  UNIXODBC_TARGZ_SHA256: 'f210501445ce21bf607ba51ef8c125e10e22dffdffec377646462df5f01915ec'
+  MYSQL_ODBC_WIN_MSI_SHA256: 'f3938aa26d2cfdb26ab0038070d9ef8c0486547941f1ac88c6ba2afec4826779'
+  MYSQL_ODBC_MACOS_TARGZ_SHA256: '50e185aef779cb4af8a11df19b8a0bbb57fd4a19268fc1f752e331a0e51fa730'
+  MYSQL_ODBC_LINUX_DEB_SHA256: '8811633c5424aadbd8d461eec1ab2f6754cc627931b9a38be1890ed2a026caf0'
+  IODBC_DMG_SHA256: 'a7aa117970f172425c7a8df9cc85a86dbd28ecf73823bf2d8ef3f15212bf531b'
+
 permissions:
   contents: read
 
@@ -50,7 +59,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: psqlodbc
           key: ${{ runner.os }}-psqlodbc-driver-${{ steps.psqlodbc-version.outputs.version }}
@@ -62,8 +71,17 @@ jobs:
           if (-not (Test-Path psqlodbc)) { mkdir psqlodbc }
           if (-not (Test-Path psqlodbc/psqlodbc_x64.msi)) {
             cd psqlodbc
-            $DOWNLOAD_URL=$(gh api repos/postgresql-interfaces/psqlodbc/releases --jq '.[0].assets.[] | select(.name=="psqlodbc_x64.msi") | .browser_download_url')
-            curl.exe -L ${DOWNLOAD_URL} --output psqlodbc_x64.msi
+            # Use releases/latest to match the cache key resolved above, and verify the
+            # download against the SHA-256 digest GitHub records for the release asset.
+            $ASSET=$(gh api repos/postgresql-interfaces/psqlodbc/releases/latest --jq '.assets.[] | select(.name=="psqlodbc_x64.msi") | .browser_download_url + " " + .digest') -split ' '
+            curl.exe --fail -L $ASSET[0] --output psqlodbc_x64.msi
+            $EXPECTED=$ASSET[1] -replace '^sha256:', ''
+            $ACTUAL=(Get-FileHash psqlodbc_x64.msi -Algorithm SHA256).Hash.ToLower()
+            if ($ACTUAL -ne $EXPECTED) {
+              Write-Error "psqlodbc_x64.msi checksum mismatch: expected $EXPECTED, got $ACTUAL"
+              exit 1
+            }
+            Write-Host "psqlodbc_x64.msi checksum OK: $ACTUAL"
           }
         env:
           GH_TOKEN: ${{ github.token }}
@@ -91,15 +109,17 @@ jobs:
           echo "Detected PostgreSQL major version: $PG_MAJOR"
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-pg${{ steps.pg-version.outputs.pg_major }}-${{ steps.psqlodbc-version.outputs.version }}
       - name: Checkout psqlODBC
         if: ${{steps.cache-psqlodbc.outputs.cache-hit != 'true'}}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: postgresql-interfaces/psqlodbc
+          # Build the sources of the release the cache key names, not default-branch HEAD.
+          ref: ${{ steps.psqlodbc-version.outputs.version }}
           path: psqlodbc
       - name: Install Dependencies
         if: ${{steps.cache-psqlodbc.outputs.cache-hit != 'true'}}
@@ -130,15 +150,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-${{ steps.psqlodbc-version.outputs.version }}
       - name: Checkout psqlODBC
         if: ${{steps.cache-psqlodbc.outputs.cache-hit != 'true'}}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: postgresql-interfaces/psqlodbc
+          # Build the sources of the release the cache key names, not default-branch HEAD.
+          ref: ${{ steps.psqlodbc-version.outputs.version }}
           path: psqlodbc
       - name: Install Dependencies
         if: ${{steps.cache-psqlodbc.outputs.cache-hit != 'true'}}
@@ -148,9 +170,10 @@ jobs:
       - name: Download & Build unixODBC
         if: ${{steps.cache-psqlodbc.outputs.cache-hit != 'true'}}
         run: |
-          curl -L https://www.unixodbc.org/unixODBC-2.3.12.tar.gz -o unixODBC.tar
+          curl --fail -L https://www.unixodbc.org/unixODBC-${{ env.UNIXODBC_VERSION }}.tar.gz -o unixODBC.tar
+          echo "${{ env.UNIXODBC_TARGZ_SHA256 }}  unixODBC.tar" | sha256sum --check
           tar xf unixODBC.tar
-          cd unixODBC-2.3.12
+          cd unixODBC-${{ env.UNIXODBC_VERSION }}
           ./configure && make
           sudo make install
       - name: Build psqlodbc
@@ -167,7 +190,7 @@ jobs:
     steps:
       - name: Retrieve mysql-connector Cache
         id: cache-mysql-connector
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: mysql-connector
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -176,7 +199,13 @@ jobs:
         run: |
           mkdir mysql-connector
           cd mysql-connector
-          curl.exe -L "https://dev.mysql.com/get/Downloads/Connector-ODBC/9.5/mysql-connector-odbc-9.5.0-winx64.msi" --output mysql-connector_x64.msi
+          curl.exe --fail -L "https://dev.mysql.com/get/Downloads/Connector-ODBC/9.5/mysql-connector-odbc-9.5.0-winx64.msi" --output mysql-connector_x64.msi
+          $ACTUAL=(Get-FileHash mysql-connector_x64.msi -Algorithm SHA256).Hash.ToLower()
+          if ($ACTUAL -ne "${{ env.MYSQL_ODBC_WIN_MSI_SHA256 }}") {
+            Write-Error "mysql-connector_x64.msi checksum mismatch: expected ${{ env.MYSQL_ODBC_WIN_MSI_SHA256 }}, got $ACTUAL"
+            exit 1
+          }
+          Write-Host "mysql-connector_x64.msi checksum OK: $ACTUAL"
 
   build-macos-mysql:
     name: MacOS - Build MySQL Connector ODBC
@@ -184,7 +213,7 @@ jobs:
     steps:
       - name: Retrieve mysql-connector Cache
         id: cache-mysql-connector
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -192,7 +221,8 @@ jobs:
         if: ${{steps.cache-mysql-connector.outputs.cache-hit != 'true'}}
         run: |
           mkdir mysql-connector
-          curl -L "https://dev.mysql.com/get/Downloads/Connector-ODBC/9.5/mysql-connector-odbc-9.5.0-macos15-arm64.tar.gz" --output mysql-connector_arm64.tar.gz
+          curl --fail -L "https://dev.mysql.com/get/Downloads/Connector-ODBC/9.5/mysql-connector-odbc-9.5.0-macos15-arm64.tar.gz" --output mysql-connector_arm64.tar.gz
+          echo "${{ env.MYSQL_ODBC_MACOS_TARGZ_SHA256 }}  mysql-connector_arm64.tar.gz" | shasum -a 256 --check
           tar xvf mysql-connector_arm64.tar.gz --strip-components 1 -C mysql-connector
 
   build-linux-mysql:
@@ -201,7 +231,7 @@ jobs:
     steps:
       - name: Retrieve mysql-connector Cache
         id: cache-mysql-connector
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -210,9 +240,10 @@ jobs:
         run: |
           mkdir mysql-connector
           cd mysql-connector
-          curl \
+          curl --fail \
             -L "https://dev.mysql.com/get/Downloads/Connector-ODBC/9.5/mysql-connector-odbc_9.5.0-1ubuntu24.04_amd64.deb" \
             --output mysql-connector_x64.deb
+          echo "${{ env.MYSQL_ODBC_LINUX_DEB_SHA256 }}  mysql-connector_x64.deb" | sha256sum --check
 
 # Build Wrapper & Run Tests
   test-win-compat:
@@ -221,14 +252,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -237,7 +268,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Setup Dotnet for WiX
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
       - name: Install WiX
         shell: cmd
         run: |
@@ -253,7 +284,7 @@ jobs:
         run: Start-Process msiexec "/lp! .\test.log /i aws-advanced-odbc-wrapper.msi /quiet /norestart" -Wait;
       # Setup PostgreSQL
       - name: Retrieve psqlODBC Cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: psqlodbc
           key: ${{ runner.os }}-psqlodbc-driver-${{ needs.build-win-psqlodbc.outputs.psqlodbc-version }}
@@ -279,7 +310,7 @@ jobs:
           Write-Host "Detected psqlODBC driver path: $driverPath"
           echo "PSQLODBC_DRIVER_PATH=$driverPath" >> $env:GITHUB_OUTPUT
       - name: Setup Local PostgreSQL Server
-        uses: ikalnytskyi/action-setup-postgres@v8
+        uses: ikalnytskyi/action-setup-postgres@c4dda34aae1c821e3a771b68b73b13af3198a7ee # v8
         with:
           username: ${{env.LOCAL_DB_UID}}
           password: ${{env.LOCAL_DB_PWD}}
@@ -289,7 +320,7 @@ jobs:
           ssl: true
       # Setup MySQL
       - name: Retrieve MySQL Cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: mysql-connector
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -408,7 +439,7 @@ jobs:
           pip3 install deepdiff
           python test/compatibility/compare_results.py wrapper-mysql-dsn --expected mysql-dsn
       - name: Upload Test Results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: odbc-api-compatibility-test-results-windows
@@ -424,7 +455,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Build Dependencies
         run: |
           brew update && brew upgrade && brew cleanup
@@ -435,7 +466,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -451,7 +482,7 @@ jobs:
       # Setup PostgreSQL
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-pg${{ needs.build-macos-psqlodbc.outputs.pg-major-version }}-${{ needs.build-macos-psqlodbc.outputs.psqlodbc-version }}
@@ -478,7 +509,7 @@ jobs:
           odbcinst -j 2>/dev/null || true
           cat /etc/odbcinst.ini 2>/dev/null || true
       - name: Setup Local PostgreSQL Server
-        uses: ikalnytskyi/action-setup-postgres@v8
+        uses: ikalnytskyi/action-setup-postgres@c4dda34aae1c821e3a771b68b73b13af3198a7ee # v8
         with:
           username: ${{env.LOCAL_DB_UID}}
           password: ${{env.LOCAL_DB_PWD}}
@@ -488,7 +519,7 @@ jobs:
           ssl: true
       # Setup MySQL
       - name: Retrieve MySQL Cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -517,7 +548,8 @@ jobs:
           cat /etc/odbcinst.ini 2>/dev/null || true
       - name: Setup iODBC Locally for pre-built MySQL Connector
         run: |
-          curl -L https://sourceforge.net/projects/iodbc/files/iodbc/3.52.16/iODBC-SDK-3.52.16-macOS11.dmg/download --output iodbc.dmg
+          curl --fail -L https://sourceforge.net/projects/iodbc/files/iodbc/3.52.16/iODBC-SDK-3.52.16-macOS11.dmg/download --output iodbc.dmg
+          echo "${{ env.IODBC_DMG_SHA256 }}  iodbc.dmg" | shasum -a 256 --check
           MOUNTDIR=$(echo `hdiutil mount iodbc.dmg | tail -1 \
           | awk '{$1=$2=""; print $0}'` | xargs -0 echo) \
           && sudo installer -pkg "${MOUNTDIR}/"*.pkg -target /
@@ -580,7 +612,7 @@ jobs:
           pip3 install deepdiff
           python3 test/compatibility/compare_results.py wrapper-mysql-dsn --expected mysql-dsn
       - name: Upload Test Results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: odbc-api-compatibility-test-results-macos
@@ -596,7 +628,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Build Dependencies
         run: |
           sudo apt update
@@ -607,7 +639,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -622,7 +654,7 @@ jobs:
       # Setup PostgreSQL
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-${{ needs.build-linux-psqlodbc.outputs.psqlodbc-version }}
@@ -635,7 +667,7 @@ jobs:
           odbcinst -j 2>/dev/null || true
           cat /etc/odbcinst.ini 2>/dev/null || true
       - name: Setup Local PostgreSQL Server
-        uses: ikalnytskyi/action-setup-postgres@v8
+        uses: ikalnytskyi/action-setup-postgres@c4dda34aae1c821e3a771b68b73b13af3198a7ee # v8
         with:
           username: ${{env.LOCAL_DB_UID}}
           password: ${{env.LOCAL_DB_PWD}}
@@ -645,7 +677,7 @@ jobs:
           ssl: true
       # Setup MySQL
       - name: Retrieve MySQL Cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -717,7 +749,7 @@ jobs:
           pip3 install deepdiff
           python3 test/compatibility/compare_results.py wrapper-mysql-dsn --expected mysql-dsn
       - name: Upload Test Results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: odbc-api-compatibility-test-results-linux
@@ -734,14 +766,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -750,7 +782,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Setup Dotnet for WiX
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
       - name: Install WiX
         shell: cmd
         run: |
@@ -766,7 +798,7 @@ jobs:
         run: Start-Process msiexec "/lp! .\test.log /i aws-advanced-odbc-wrapper.msi /quiet /norestart" -Wait;
       # Setup PostgreSQL
       - name: Retrieve psqlODBC Cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: psqlodbc
           key: ${{ runner.os }}-psqlodbc-driver-${{ needs.build-win-psqlodbc.outputs.psqlodbc-version }}
@@ -792,7 +824,7 @@ jobs:
           Write-Host "Detected psqlODBC Unicode driver path: $driverPath"
           echo "PSQLODBC_UNICODE_DRIVER_PATH=$driverPath" >> $env:GITHUB_OUTPUT
       - name: Setup Local PostgreSQL Server
-        uses: ikalnytskyi/action-setup-postgres@v8
+        uses: ikalnytskyi/action-setup-postgres@c4dda34aae1c821e3a771b68b73b13af3198a7ee # v8
         with:
           username: ${{env.LOCAL_DB_UID}}
           password: ${{env.LOCAL_DB_PWD}}
@@ -802,7 +834,7 @@ jobs:
           ssl: true
       # Setup MySQL
       - name: Retrieve MySQL Cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: mysql-connector
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -908,7 +940,7 @@ jobs:
           pip3 install deepdiff
           python test/compatibility/compare_results.py wrapper-mysql-dsn-w --expected mysql-dsn-w
       - name: Upload Test Results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: odbc-api-compatibility-test-results-windows-unicode
@@ -924,7 +956,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Build Dependencies
         run: |
           brew update && brew upgrade && brew cleanup
@@ -935,7 +967,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -951,7 +983,7 @@ jobs:
       # Setup PostgreSQL
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-pg${{ needs.build-macos-psqlodbc.outputs.pg-major-version }}-${{ needs.build-macos-psqlodbc.outputs.psqlodbc-version }}
@@ -970,7 +1002,7 @@ jobs:
           echo "Detected psqlODBC Unicode driver: $PG_DRIVER_W"
           echo "PSQLODBC_UNICODE_DRIVER_PATH=$PG_DRIVER_W" >> "$GITHUB_OUTPUT"
       - name: Setup Local PostgreSQL Server
-        uses: ikalnytskyi/action-setup-postgres@v8
+        uses: ikalnytskyi/action-setup-postgres@c4dda34aae1c821e3a771b68b73b13af3198a7ee # v8
         with:
           username: ${{env.LOCAL_DB_UID}}
           password: ${{env.LOCAL_DB_PWD}}
@@ -980,7 +1012,7 @@ jobs:
           ssl: true
       # Setup MySQL
       - name: Retrieve MySQL Cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -1039,7 +1071,8 @@ jobs:
           python3 test/compatibility/compare_results.py wrapper-pg-dsn --expected pg-dsn
       - name: Setup iODBC and rebuild MySQL Unicode test binary
         run: |
-          curl -L https://sourceforge.net/projects/iodbc/files/iodbc/3.52.16/iODBC-SDK-3.52.16-macOS11.dmg/download --output iodbc.dmg
+          curl --fail -L https://sourceforge.net/projects/iodbc/files/iodbc/3.52.16/iODBC-SDK-3.52.16-macOS11.dmg/download --output iodbc.dmg
+          echo "${{ env.IODBC_DMG_SHA256 }}  iodbc.dmg" | shasum -a 256 --check
           MOUNTDIR=$(echo `hdiutil mount iodbc.dmg | tail -1 \
           | awk '{$1=$2=""; print $0}'` | xargs -0 echo) \
           && sudo installer -pkg "${MOUNTDIR}/"*.pkg -target /
@@ -1091,7 +1124,7 @@ jobs:
           pip3 install deepdiff
           python3 test/compatibility/compare_results.py wrapper-mysql-dsn --expected mysql-dsn
       - name: Upload Test Results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: odbc-api-compatibility-test-results-macos-unicode
@@ -1107,7 +1140,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Build Dependencies
         run: |
           sudo apt update
@@ -1118,7 +1151,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -1133,13 +1166,13 @@ jobs:
       # Setup PostgreSQL
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-${{ needs.build-linux-psqlodbc.outputs.psqlodbc-version }}
           fail-on-cache-miss: true
       - name: Setup Local PostgreSQL Server
-        uses: ikalnytskyi/action-setup-postgres@v8
+        uses: ikalnytskyi/action-setup-postgres@c4dda34aae1c821e3a771b68b73b13af3198a7ee # v8
         with:
           username: ${{env.LOCAL_DB_UID}}
           password: ${{env.LOCAL_DB_PWD}}
@@ -1149,7 +1182,7 @@ jobs:
           ssl: true
       # Setup MySQL
       - name: Retrieve MySQL Cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -1216,7 +1249,7 @@ jobs:
           pip3 install deepdiff
           python3 test/compatibility/compare_results.py wrapper-mysql-dsn --expected mysql-dsn
       - name: Upload Test Results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: odbc-api-compatibility-test-results-linux-unicode

--- a/.github/workflows/compatibility_test.yaml
+++ b/.github/workflows/compatibility_test.yaml
@@ -59,7 +59,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: psqlodbc
           key: ${{ runner.os }}-psqlodbc-driver-${{ steps.psqlodbc-version.outputs.version }}
@@ -109,13 +109,13 @@ jobs:
           echo "Detected PostgreSQL major version: $PG_MAJOR"
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-pg${{ steps.pg-version.outputs.pg_major }}-${{ steps.psqlodbc-version.outputs.version }}
       - name: Checkout psqlODBC
         if: ${{steps.cache-psqlodbc.outputs.cache-hit != 'true'}}
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: postgresql-interfaces/psqlodbc
           # Build the sources of the release the cache key names, not default-branch HEAD.
@@ -150,13 +150,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-${{ steps.psqlodbc-version.outputs.version }}
       - name: Checkout psqlODBC
         if: ${{steps.cache-psqlodbc.outputs.cache-hit != 'true'}}
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: postgresql-interfaces/psqlodbc
           # Build the sources of the release the cache key names, not default-branch HEAD.
@@ -190,7 +190,7 @@ jobs:
     steps:
       - name: Retrieve mysql-connector Cache
         id: cache-mysql-connector
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: mysql-connector
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -213,7 +213,7 @@ jobs:
     steps:
       - name: Retrieve mysql-connector Cache
         id: cache-mysql-connector
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -231,7 +231,7 @@ jobs:
     steps:
       - name: Retrieve mysql-connector Cache
         id: cache-mysql-connector
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -252,14 +252,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -268,7 +268,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Setup Dotnet for WiX
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
       - name: Install WiX
         shell: cmd
         run: |
@@ -284,7 +284,7 @@ jobs:
         run: Start-Process msiexec "/lp! .\test.log /i aws-advanced-odbc-wrapper.msi /quiet /norestart" -Wait;
       # Setup PostgreSQL
       - name: Retrieve psqlODBC Cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: psqlodbc
           key: ${{ runner.os }}-psqlodbc-driver-${{ needs.build-win-psqlodbc.outputs.psqlodbc-version }}
@@ -320,7 +320,7 @@ jobs:
           ssl: true
       # Setup MySQL
       - name: Retrieve MySQL Cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: mysql-connector
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -439,7 +439,7 @@ jobs:
           pip3 install deepdiff
           python test/compatibility/compare_results.py wrapper-mysql-dsn --expected mysql-dsn
       - name: Upload Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: odbc-api-compatibility-test-results-windows
@@ -455,7 +455,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Build Dependencies
         run: |
           brew update && brew upgrade && brew cleanup
@@ -466,7 +466,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -482,7 +482,7 @@ jobs:
       # Setup PostgreSQL
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-pg${{ needs.build-macos-psqlodbc.outputs.pg-major-version }}-${{ needs.build-macos-psqlodbc.outputs.psqlodbc-version }}
@@ -519,7 +519,7 @@ jobs:
           ssl: true
       # Setup MySQL
       - name: Retrieve MySQL Cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -612,7 +612,7 @@ jobs:
           pip3 install deepdiff
           python3 test/compatibility/compare_results.py wrapper-mysql-dsn --expected mysql-dsn
       - name: Upload Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: odbc-api-compatibility-test-results-macos
@@ -628,7 +628,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Build Dependencies
         run: |
           sudo apt update
@@ -639,7 +639,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -654,7 +654,7 @@ jobs:
       # Setup PostgreSQL
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-${{ needs.build-linux-psqlodbc.outputs.psqlodbc-version }}
@@ -677,7 +677,7 @@ jobs:
           ssl: true
       # Setup MySQL
       - name: Retrieve MySQL Cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -749,7 +749,7 @@ jobs:
           pip3 install deepdiff
           python3 test/compatibility/compare_results.py wrapper-mysql-dsn --expected mysql-dsn
       - name: Upload Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: odbc-api-compatibility-test-results-linux
@@ -766,14 +766,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -782,7 +782,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Setup Dotnet for WiX
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
       - name: Install WiX
         shell: cmd
         run: |
@@ -798,7 +798,7 @@ jobs:
         run: Start-Process msiexec "/lp! .\test.log /i aws-advanced-odbc-wrapper.msi /quiet /norestart" -Wait;
       # Setup PostgreSQL
       - name: Retrieve psqlODBC Cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: psqlodbc
           key: ${{ runner.os }}-psqlodbc-driver-${{ needs.build-win-psqlodbc.outputs.psqlodbc-version }}
@@ -834,7 +834,7 @@ jobs:
           ssl: true
       # Setup MySQL
       - name: Retrieve MySQL Cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: mysql-connector
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -940,7 +940,7 @@ jobs:
           pip3 install deepdiff
           python test/compatibility/compare_results.py wrapper-mysql-dsn-w --expected mysql-dsn-w
       - name: Upload Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: odbc-api-compatibility-test-results-windows-unicode
@@ -956,7 +956,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Build Dependencies
         run: |
           brew update && brew upgrade && brew cleanup
@@ -967,7 +967,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -983,7 +983,7 @@ jobs:
       # Setup PostgreSQL
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-pg${{ needs.build-macos-psqlodbc.outputs.pg-major-version }}-${{ needs.build-macos-psqlodbc.outputs.psqlodbc-version }}
@@ -1012,7 +1012,7 @@ jobs:
           ssl: true
       # Setup MySQL
       - name: Retrieve MySQL Cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -1124,7 +1124,7 @@ jobs:
           pip3 install deepdiff
           python3 test/compatibility/compare_results.py wrapper-mysql-dsn --expected mysql-dsn
       - name: Upload Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: odbc-api-compatibility-test-results-macos-unicode
@@ -1140,7 +1140,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Build Dependencies
         run: |
           sudo apt update
@@ -1151,7 +1151,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -1166,7 +1166,7 @@ jobs:
       # Setup PostgreSQL
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-${{ needs.build-linux-psqlodbc.outputs.psqlodbc-version }}
@@ -1182,7 +1182,7 @@ jobs:
           ssl: true
       # Setup MySQL
       - name: Retrieve MySQL Cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -1249,7 +1249,7 @@ jobs:
           pip3 install deepdiff
           python3 test/compatibility/compare_results.py wrapper-mysql-dsn --expected mysql-dsn
       - name: Upload Test Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: odbc-api-compatibility-test-results-linux-unicode

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -75,7 +75,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: psqlodbc
           key: ${{ runner.os }}-psqlodbc-driver-${{ steps.psqlodbc-version.outputs.version }}
@@ -121,13 +121,13 @@ jobs:
           echo "psqlODBC version: $VERSION"
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-${{ steps.psqlodbc-version.outputs.version }}
       - name: Checkout psqlODBC
         if: ${{steps.cache-psqlodbc.outputs.cache-hit != 'true'}}
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: postgresql-interfaces/psqlodbc
           ref: ${{ steps.psqlodbc-version.outputs.version }}
@@ -156,13 +156,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-${{ steps.psqlodbc-version.outputs.version }}
       - name: Checkout psqlODBC
         if: ${{steps.cache-psqlodbc.outputs.cache-hit != 'true'}}
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: postgresql-interfaces/psqlodbc
           ref: ${{ steps.psqlodbc-version.outputs.version }}
@@ -195,7 +195,7 @@ jobs:
     steps:
       - name: Retrieve mysql-connector Cache
         id: cache-mysql-connector
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: mysql-connector
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -227,7 +227,7 @@ jobs:
           rm -rf /tmp/actions-runner-* 2>/dev/null || true
       - name: Retrieve mysql-connector Cache
         id: cache-mysql-connector
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -245,7 +245,7 @@ jobs:
     steps:
       - name: Retrieve mysql-connector Cache
         id: cache-mysql-connector
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -265,7 +265,7 @@ jobs:
     steps:
       - name: Retrieve mariadb-connector Cache
         id: cache-mariadb-connector
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: mariadb-connector
           key: ${{ runner.os }}-mariadb-driver-${{ env.MARIADB_ODBC_VERSION }}
@@ -314,14 +314,14 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=ODBC-Win-${{matrix.rds_engine}}-${{github.run_id}}${{github.run_number}}${{github.run_attempt}}" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -330,7 +330,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Setup Dotnet for WiX
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
       - name: Install WiX
         shell: cmd
         run: |
@@ -345,7 +345,7 @@ jobs:
         working-directory: installer
         run: Start-Process msiexec "/lp! .\test.log /i aws-advanced-odbc-wrapper.msi /quiet /norestart" -Wait;
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -398,14 +398,14 @@ jobs:
             echo "maodbc_path=C:\\Program Files\\MariaDB\\MariaDB ODBC Driver 64-bit\\maodbc.dll" >> $GITHUB_OUTPUT
           fi
       - name: Retrieve Base Driver
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
           fail-on-cache-miss: true
       - name: Retrieve MariaDB Connector
         if: (matrix.rds_engine == 'aurora-mysql')
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: mariadb-connector
           key: ${{steps.base_driver_info.outputs.mariadb_cache_key}}
@@ -694,7 +694,7 @@ jobs:
           echo "TEMP=$env:TEMP" >> $env:GITHUB_OUTPUT
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: 'windows-${{matrix.rds_engine}}-integration-test-logs'
           path: ${{ steps.log_location.outputs.TEMP }}/aws-odbc-wrapper/
@@ -746,14 +746,14 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=ODBC-MacOS-${{matrix.env.rds_engine}}-${{github.run_id}}${{github.run_number}}${{github.run_attempt}}" >> $GITHUB_ENV
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -767,7 +767,7 @@ jobs:
           cmake -S . -B build -DBUILD_UNICODE=ON -DBUILD_ANSI=ON -DBUILD_UNIT_TEST=OFF -DCMAKE_BUILD_TYPE=${{env.BUILD_CONFIG}}
           cmake --build build
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -832,7 +832,7 @@ jobs:
             echo "MARIADB_DRIVER_PATH=/opt/homebrew/Cellar/mariadb-connector-odbc/3.2.8/lib/mariadb/libmaodbc.dylib" >> $GITHUB_ENV
           fi
       - name: Retrieve Base Driver
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -1025,7 +1025,7 @@ jobs:
             $EXTRA_ARGS
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: 'mac-${{matrix.env.rds_engine}}-integration-test-logs'
           path: ${{steps.log_location.outputs.TEMP}}/aws-odbc-wrapper/
@@ -1058,7 +1058,7 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=ODBC-Linux-${{ matrix.rds_engine }}-${{github.run_id}}${{github.run_number}}${{github.run_attempt}}" >> $GITHUB_ENV
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Build Dependencies
         run: |
           sudo apt update
@@ -1069,7 +1069,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -1082,7 +1082,7 @@ jobs:
           cmake -S . -B build -DBUILD_UNICODE=ON -DBUILD_ANSI=ON -DBUILD_UNIT_TEST=OFF -DCMAKE_BUILD_TYPE=${{env.BUILD_CONFIG}}
           cmake --build build
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -1135,7 +1135,7 @@ jobs:
             echo "database_dialect=${{ matrix.database_dialect }}" >> $GITHUB_OUTPUT
           fi
       - name: Retrieve Base Driver
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -1335,7 +1335,7 @@ jobs:
             $EXTRA_ARGS
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: 'linux-${{matrix.rds_engine}}-integration-test-logs'
           path: /tmp/aws-odbc-wrapper/
@@ -1354,14 +1354,14 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=${{ env.LIMITLESS_CLUSTER_ID }}" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -1370,7 +1370,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Setup Dotnet for WiX
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
       - name: Install WiX
         shell: cmd
         run: |
@@ -1385,7 +1385,7 @@ jobs:
         working-directory: installer
         run: Start-Process msiexec "/lp! .\test.log /i aws-advanced-odbc-wrapper.msi /quiet /norestart" -Wait;
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -1424,7 +1424,7 @@ jobs:
           echo "dialect_default_port=5432" >> $GITHUB_OUTPUT
           echo "database_dialect=AURORA_POSTGRESQL" >> $GITHUB_OUTPUT
       - name: Retrieve Base Driver
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -1574,7 +1574,7 @@ jobs:
           echo "TEMP=$env:TEMP" >> $env:GITHUB_OUTPUT
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: 'windows-limitless-test-logs'
           path: ${{ steps.log_location.outputs.TEMP }}/aws-odbc-wrapper/
@@ -1594,14 +1594,14 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=${{ env.LIMITLESS_CLUSTER_ID }}" >> $GITHUB_ENV
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -1615,7 +1615,7 @@ jobs:
           cmake -S . -B build -DBUILD_UNICODE=ON -DBUILD_ANSI=ON -DBUILD_UNIT_TEST=OFF -DCMAKE_BUILD_TYPE=${{env.BUILD_CONFIG}}
           cmake --build build
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -1656,7 +1656,7 @@ jobs:
           echo "dialect_default_port=5432" >> $GITHUB_OUTPUT
           echo "database_dialect=AURORA_POSTGRESQL" >> $GITHUB_OUTPUT
       - name: Retrieve Base Driver
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -1742,7 +1742,7 @@ jobs:
             --shard-id ${{ env.LIMITLESS_SHARD_ID }}
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: 'mac-limitless-test-logs'
           path: ${{steps.log_location.outputs.TEMP}}/aws-odbc-wrapper/
@@ -1760,7 +1760,7 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=${{ env.LIMITLESS_CLUSTER_ID }}" >> $GITHUB_ENV
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Build Dependencies
         run: |
           sudo apt update
@@ -1771,7 +1771,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -1784,7 +1784,7 @@ jobs:
           cmake -S . -B build -DBUILD_UNICODE=ON -DBUILD_ANSI=ON -DBUILD_UNIT_TEST=OFF -DCMAKE_BUILD_TYPE=${{env.BUILD_CONFIG}}
           cmake --build build
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -1825,7 +1825,7 @@ jobs:
           echo "dialect_default_port=5432" >> $GITHUB_OUTPUT
           echo "database_dialect=AURORA_POSTGRESQL" >> $GITHUB_OUTPUT
       - name: Retrieve Base Driver
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -1912,7 +1912,7 @@ jobs:
             --shard-id ${{ env.LIMITLESS_SHARD_ID }}
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: 'linux-limitless-test-logs'
           path: /tmp/aws-odbc-wrapper/
@@ -1934,14 +1934,14 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=ODBC-BG-Win-${{matrix.rds_engine}}-${{github.run_id}}${{github.run_number}}${{github.run_attempt}}" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -1950,7 +1950,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Setup Dotnet for WiX
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
       - name: Install WiX
         shell: cmd
         run: |
@@ -1965,7 +1965,7 @@ jobs:
         working-directory: installer
         run: Start-Process msiexec "/lp! .\test.log /i aws-advanced-odbc-wrapper.msi /quiet /norestart" -Wait;
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -2012,7 +2012,7 @@ jobs:
             echo "database_dialect=AURORA_MYSQL" >> $GITHUB_OUTPUT
           fi
       - name: Retrieve Base Driver
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -2152,7 +2152,7 @@ jobs:
           echo "TEMP=$env:TEMP" >> $env:GITHUB_OUTPUT
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: 'windows-${{matrix.rds_engine}}-test-logs'
           path: ${{ steps.log_location.outputs.TEMP }}/aws-odbc-wrapper/
@@ -2175,14 +2175,14 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=ODBC-BG-MacOS-${{matrix.env.rds_engine}}-${{github.run_id}}${{github.run_number}}${{github.run_attempt}}" >> $GITHUB_ENV
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -2196,7 +2196,7 @@ jobs:
           cmake -S . -B build -DBUILD_UNICODE=ON -DBUILD_ANSI=ON -DBUILD_UNIT_TEST=OFF -DCMAKE_BUILD_TYPE=${{env.BUILD_CONFIG}}
           cmake --build build
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -2245,7 +2245,7 @@ jobs:
             echo "database_dialect=AURORA_MYSQL" >> $GITHUB_OUTPUT
           fi
       - name: Retrieve Base Driver
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -2298,7 +2298,7 @@ jobs:
             --parameter-group parameter-${{ env.AURORA_CLUSTER_ID }}
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: 'mac-${{matrix.env.rds_engine}}-bg-test-logs'
           path: ${{steps.log_location.outputs.TEMP}}/aws-odbc-wrapper/
@@ -2318,7 +2318,7 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=ODBC-BG-Linux-${{ matrix.rds_engine }}-${{github.run_id}}${{github.run_number}}${{github.run_attempt}}" >> $GITHUB_ENV
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Build Dependencies
         run: |
           sudo apt update
@@ -2329,7 +2329,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -2342,7 +2342,7 @@ jobs:
           cmake -S . -B build -DBUILD_UNICODE=ON -DBUILD_ANSI=ON -DBUILD_UNIT_TEST=OFF -DCMAKE_BUILD_TYPE=${{env.BUILD_CONFIG}}
           cmake --build build
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -2391,7 +2391,7 @@ jobs:
             echo "database_dialect=AURORA_MYSQL" >> $GITHUB_OUTPUT
           fi
       - name: Retrieve Base Driver
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -2449,7 +2449,7 @@ jobs:
             --parameter-group parameter-${{ env.AURORA_CLUSTER_ID }}
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: 'linux-${{matrix.rds_engine}}-test-logs'
           path: /tmp/aws-odbc-wrapper/

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -39,6 +39,16 @@ env:
   # Alternate Aurora MySQL base driver; unlike MySQL Connector it supports RDS IAM auth.
   MARIADB_ODBC_VERSION: '3.2.8'
 
+  # SHA-256 checksums for pinned third-party downloads. If a download stops
+  # matching, someone changed the artifact upstream - investigate before bumping.
+  UNIXODBC_VERSION: '2.3.12'
+  UNIXODBC_TARGZ_SHA256: 'f210501445ce21bf607ba51ef8c125e10e22dffdffec377646462df5f01915ec'
+  MYSQL_ODBC_WIN_MSI_SHA256: 'f3938aa26d2cfdb26ab0038070d9ef8c0486547941f1ac88c6ba2afec4826779'
+  MYSQL_ODBC_MACOS_TARGZ_SHA256: '50e185aef779cb4af8a11df19b8a0bbb57fd4a19268fc1f752e331a0e51fa730'
+  MYSQL_ODBC_LINUX_DEB_SHA256: '8811633c5424aadbd8d461eec1ab2f6754cc627931b9a38be1890ed2a026caf0'
+  MARIADB_ODBC_WIN_MSI_SHA256: '9466158b35910de29b58592cc2fa403c37c9e4a1bf39a41b35b1334100c16c79'
+  MARIADB_ODBC_LINUX_DEB_SHA256: '122fe168048422cd30f8da693f844d6ebbeb6e1fe2048b8d9ecc792052c81f46'
+
 concurrency:
   group: integration-test-${{ github.ref }}
   cancel-in-progress: true
@@ -58,12 +68,14 @@ jobs:
       - name: Get psqlODBC latest release version
         id: psqlodbc-version
         run: |
-          $VERSION=$(curl -s https://api.github.com/repos/postgresql-interfaces/psqlodbc/releases | python -c "import sys,json; print(json.load(sys.stdin)[0]['tag_name'])")
+          $VERSION=$(gh api repos/postgresql-interfaces/psqlodbc/releases/latest --jq '.tag_name')
           echo "version=$VERSION" >> $env:GITHUB_OUTPUT
           echo "psqlODBC version: $VERSION"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: psqlodbc
           key: ${{ runner.os }}-psqlodbc-driver-${{ steps.psqlodbc-version.outputs.version }}
@@ -72,8 +84,17 @@ jobs:
         run: |
           mkdir psqlodbc
           cd psqlodbc
-          $DOWNLOAD_URL=$(gh api repos/postgresql-interfaces/psqlodbc/releases --jq '.[0].assets.[] | select(.name=="psqlodbc_x64.msi") | .browser_download_url')
-          curl.exe -L ${DOWNLOAD_URL} --output psqlodbc_x64.msi
+          # Use releases/latest to match the cache key resolved above, and verify the
+          # download against the SHA-256 digest GitHub records for the release asset.
+          $ASSET=$(gh api repos/postgresql-interfaces/psqlodbc/releases/latest --jq '.assets.[] | select(.name=="psqlodbc_x64.msi") | .browser_download_url + " " + .digest') -split ' '
+          curl.exe --fail -L $ASSET[0] --output psqlodbc_x64.msi
+          $EXPECTED=$ASSET[1] -replace '^sha256:', ''
+          $ACTUAL=(Get-FileHash psqlodbc_x64.msi -Algorithm SHA256).Hash.ToLower()
+          if ($ACTUAL -ne $EXPECTED) {
+            Write-Error "psqlodbc_x64.msi checksum mismatch: expected $EXPECTED, got $ACTUAL"
+            exit 1
+          }
+          Write-Host "psqlodbc_x64.msi checksum OK: $ACTUAL"
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -95,20 +116,21 @@ jobs:
       - name: Get psqlODBC latest release version
         id: psqlodbc-version
         run: |
-          VERSION=$(curl -s https://api.github.com/repos/postgresql-interfaces/psqlodbc/releases | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['tag_name'])")
+          VERSION=$(curl -sS --fail https://api.github.com/repos/postgresql-interfaces/psqlodbc/releases/latest | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "psqlODBC version: $VERSION"
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-${{ steps.psqlodbc-version.outputs.version }}
       - name: Checkout psqlODBC
         if: ${{steps.cache-psqlodbc.outputs.cache-hit != 'true'}}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: postgresql-interfaces/psqlodbc
+          ref: ${{ steps.psqlodbc-version.outputs.version }}
           path: psqlodbc
       - name: Build psqlodbc
         if: ${{steps.cache-psqlodbc.outputs.cache-hit != 'true'}}
@@ -127,20 +149,23 @@ jobs:
       - name: Get psqlODBC latest release version
         id: psqlodbc-version
         run: |
-          VERSION=$(curl -s https://api.github.com/repos/postgresql-interfaces/psqlodbc/releases | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['tag_name'])")
+          VERSION=$(gh api repos/postgresql-interfaces/psqlodbc/releases/latest --jq '.tag_name')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "psqlODBC version: $VERSION"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Retrieve psqlODBC Cache
         id: cache-psqlodbc
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: psqlodbc/.libs/
           key: ${{ runner.os }}-psqlodbc-driver-${{ steps.psqlodbc-version.outputs.version }}
       - name: Checkout psqlODBC
         if: ${{steps.cache-psqlodbc.outputs.cache-hit != 'true'}}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: postgresql-interfaces/psqlodbc
+          ref: ${{ steps.psqlodbc-version.outputs.version }}
           path: psqlodbc
       - name: Install Dependencies
         if: ${{steps.cache-psqlodbc.outputs.cache-hit != 'true'}}
@@ -150,9 +175,10 @@ jobs:
       - name: Download & Build unixODBC
         if: ${{steps.cache-psqlodbc.outputs.cache-hit != 'true'}}
         run: |
-          curl -L https://www.unixodbc.org/unixODBC-2.3.12.tar.gz -o unixODBC.tar
+          curl --fail -L https://www.unixodbc.org/unixODBC-${{ env.UNIXODBC_VERSION }}.tar.gz -o unixODBC.tar
+          echo "${{ env.UNIXODBC_TARGZ_SHA256 }}  unixODBC.tar" | sha256sum --check
           tar xf unixODBC.tar
-          cd unixODBC-2.3.12
+          cd unixODBC-${{ env.UNIXODBC_VERSION }}
           ./configure && make
           sudo make install
       - name: Build psqlodbc
@@ -169,7 +195,7 @@ jobs:
     steps:
       - name: Retrieve mysql-connector Cache
         id: cache-mysql-connector
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: mysql-connector
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -178,7 +204,13 @@ jobs:
         run: |
           mkdir mysql-connector
           cd mysql-connector
-          curl.exe -L "https://dev.mysql.com/get/Downloads/Connector-ODBC/9.5/mysql-connector-odbc-9.5.0-winx64.msi" --output mysql-connector_x64.msi
+          curl.exe --fail -L "https://dev.mysql.com/get/Downloads/Connector-ODBC/9.5/mysql-connector-odbc-9.5.0-winx64.msi" --output mysql-connector_x64.msi
+          $ACTUAL=(Get-FileHash mysql-connector_x64.msi -Algorithm SHA256).Hash.ToLower()
+          if ($ACTUAL -ne "${{ env.MYSQL_ODBC_WIN_MSI_SHA256 }}") {
+            Write-Error "mysql-connector_x64.msi checksum mismatch: expected ${{ env.MYSQL_ODBC_WIN_MSI_SHA256 }}, got $ACTUAL"
+            exit 1
+          }
+          Write-Host "mysql-connector_x64.msi checksum OK: $ACTUAL"
 
   build-macos-mysql:
     name: MacOS - Build MySQL Connector ODBC
@@ -195,7 +227,7 @@ jobs:
           rm -rf /tmp/actions-runner-* 2>/dev/null || true
       - name: Retrieve mysql-connector Cache
         id: cache-mysql-connector
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -203,7 +235,8 @@ jobs:
         if: ${{steps.cache-mysql-connector.outputs.cache-hit != 'true'}}
         run: |
           mkdir mysql-connector
-          curl -L "https://dev.mysql.com/get/Downloads/Connector-ODBC/9.5/mysql-connector-odbc-9.5.0-macos15-arm64.tar.gz" --output mysql-connector_arm64.tar.gz
+          curl --fail -L "https://dev.mysql.com/get/Downloads/Connector-ODBC/9.5/mysql-connector-odbc-9.5.0-macos15-arm64.tar.gz" --output mysql-connector_arm64.tar.gz
+          echo "${{ env.MYSQL_ODBC_MACOS_TARGZ_SHA256 }}  mysql-connector_arm64.tar.gz" | shasum -a 256 --check
           tar xvf mysql-connector_arm64.tar.gz --strip-components 1 -C mysql-connector
 
   build-linux-mysql:
@@ -212,7 +245,7 @@ jobs:
     steps:
       - name: Retrieve mysql-connector Cache
         id: cache-mysql-connector
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: mysql-connector/
           key: ${{ runner.os }}-mysql-driver-9.5.0
@@ -221,9 +254,10 @@ jobs:
         run: |
           mkdir mysql-connector
           cd mysql-connector
-          curl \
+          curl --fail \
             -L "https://dev.mysql.com/get/Downloads/Connector-ODBC/9.5/mysql-connector-odbc_9.5.0-1ubuntu24.04_amd64.deb" \
             --output mysql-connector_x64.deb
+          echo "${{ env.MYSQL_ODBC_LINUX_DEB_SHA256 }}  mysql-connector_x64.deb" | sha256sum --check
 
   build-win-mariadb:
     name: Windows - Get MariaDB Connector ODBC
@@ -231,7 +265,7 @@ jobs:
     steps:
       - name: Retrieve mariadb-connector Cache
         id: cache-mariadb-connector
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: mariadb-connector
           key: ${{ runner.os }}-mariadb-driver-${{ env.MARIADB_ODBC_VERSION }}
@@ -245,9 +279,12 @@ jobs:
           # --fail: error on HTTP >=400 instead of saving an HTML error page.
           curl.exe --fail --location --retry 3 --retry-delay 5 "$url" --output $out
           if ($LASTEXITCODE -ne 0) { Write-Error "MariaDB ODBC MSI download failed from $url"; exit 1 }
-          $size = (Get-Item $out).Length
-          Write-Host "Downloaded $out ($size bytes)"
-          if ($size -lt 100000) { Write-Error "Downloaded MSI is suspiciously small ($size bytes); likely not a valid MSI."; exit 1 }
+          $ACTUAL=(Get-FileHash $out -Algorithm SHA256).Hash.ToLower()
+          if ($ACTUAL -ne "${{ env.MARIADB_ODBC_WIN_MSI_SHA256 }}") {
+            Write-Error "mariadb-connector_x64.msi checksum mismatch: expected ${{ env.MARIADB_ODBC_WIN_MSI_SHA256 }}, got $ACTUAL"
+            exit 1
+          }
+          Write-Host "mariadb-connector_x64.msi checksum OK: $ACTUAL"
 
 # Integration - General
   windows-integration-tests:
@@ -277,14 +314,14 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=ODBC-Win-${{matrix.rds_engine}}-${{github.run_id}}${{github.run_number}}${{github.run_attempt}}" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -293,7 +330,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Setup Dotnet for WiX
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
       - name: Install WiX
         shell: cmd
         run: |
@@ -361,14 +398,14 @@ jobs:
             echo "maodbc_path=C:\\Program Files\\MariaDB\\MariaDB ODBC Driver 64-bit\\maodbc.dll" >> $GITHUB_OUTPUT
           fi
       - name: Retrieve Base Driver
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
           fail-on-cache-miss: true
       - name: Retrieve MariaDB Connector
         if: (matrix.rds_engine == 'aurora-mysql')
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: mariadb-connector
           key: ${{steps.base_driver_info.outputs.mariadb_cache_key}}
@@ -423,7 +460,13 @@ jobs:
         shell: pwsh
         run: |
           $caPath = "$env:RUNNER_TEMP\rds-global-bundle.pem"
-          curl.exe -L "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" --output $caPath
+          # The bundle rotates as AWS adds/retires CAs, so a pinned hash would break;
+          # rely on TLS to the AWS PKI endpoint and sanity-check the PEM contents.
+          curl.exe --fail -L "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" --output $caPath
+          if (-not (Select-String -Path $caPath -Pattern "BEGIN CERTIFICATE" -Quiet)) {
+            Write-Error "Downloaded RDS CA bundle does not look like PEM certificates."
+            exit 1
+          }
           echo "RDS_CA_BUNDLE=$caPath" >> $env:GITHUB_ENV
       - name: Resolve Driver Paths
         id: resolved_drivers
@@ -632,7 +675,8 @@ jobs:
       - name: Get Github Action IP
         if: always()
         id: ip
-        uses: haythem/public-ip@v1.3
+        shell: bash
+        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> "$GITHUB_OUTPUT"
       - name: Remove Github Action IP
         if: always()
         run: |
@@ -650,7 +694,7 @@ jobs:
           echo "TEMP=$env:TEMP" >> $env:GITHUB_OUTPUT
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: 'windows-${{matrix.rds_engine}}-integration-test-logs'
           path: ${{ steps.log_location.outputs.TEMP }}/aws-odbc-wrapper/
@@ -702,14 +746,14 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=ODBC-MacOS-${{matrix.env.rds_engine}}-${{github.run_id}}${{github.run_number}}${{github.run_attempt}}" >> $GITHUB_ENV
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -788,7 +832,7 @@ jobs:
             echo "MARIADB_DRIVER_PATH=/opt/homebrew/Cellar/mariadb-connector-odbc/3.2.8/lib/mariadb/libmaodbc.dylib" >> $GITHUB_ENV
           fi
       - name: Retrieve Base Driver
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -804,7 +848,10 @@ jobs:
         if: (matrix.env.rds_engine == 'aurora-mysql')
         shell: bash
         run: |
-          curl -L "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" --output "${{ github.workspace }}/rds-global-bundle.pem"
+          # The bundle rotates as AWS adds/retires CAs, so a pinned hash would break;
+          # rely on TLS to the AWS PKI endpoint and sanity-check the PEM contents.
+          curl --fail -L "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" --output "${{ github.workspace }}/rds-global-bundle.pem"
+          grep -q "BEGIN CERTIFICATE" "${{ github.workspace }}/rds-global-bundle.pem"
       - name: Build and Run Ansi Integration Tests
         timeout-minutes: 45
         id: ansi_tests
@@ -978,7 +1025,7 @@ jobs:
             $EXTRA_ARGS
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: 'mac-${{matrix.env.rds_engine}}-integration-test-logs'
           path: ${{steps.log_location.outputs.TEMP}}/aws-odbc-wrapper/
@@ -1011,7 +1058,7 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=ODBC-Linux-${{ matrix.rds_engine }}-${{github.run_id}}${{github.run_number}}${{github.run_attempt}}" >> $GITHUB_ENV
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Build Dependencies
         run: |
           sudo apt update
@@ -1022,7 +1069,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -1088,7 +1135,7 @@ jobs:
             echo "database_dialect=${{ matrix.database_dialect }}" >> $GITHUB_OUTPUT
           fi
       - name: Retrieve Base Driver
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -1113,6 +1160,7 @@ jobs:
           DEB="mariadb-connector-odbc_${MARIADB_ODBC_VERSION}-1+maria~noble_amd64.deb"
           URL="https://dlm.mariadb.com/Connectors/odbc/connector-odbc-${MARIADB_ODBC_VERSION}/${DEB}"
           curl --fail --location --retry 3 --retry-delay 5 "$URL" --output "$RUNNER_TEMP/$DEB"
+          echo "${{ env.MARIADB_ODBC_LINUX_DEB_SHA256 }}  $RUNNER_TEMP/$DEB" | sha256sum --check
           sudo apt-get update  # apt-get resolves the deb's runtime deps (unixodbc, etc.)
           sudo apt-get install -y "$RUNNER_TEMP/$DEB"
           # Discover the installed path rather than hardcoding it; export for the MariaDB test steps.
@@ -1124,7 +1172,10 @@ jobs:
         if: (matrix.rds_engine == 'aurora-mysql')
         shell: bash
         run: |
-          curl -L "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" --output "${{ github.workspace }}/rds-global-bundle.pem"
+          # The bundle rotates as AWS adds/retires CAs, so a pinned hash would break;
+          # rely on TLS to the AWS PKI endpoint and sanity-check the PEM contents.
+          curl --fail -L "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" --output "${{ github.workspace }}/rds-global-bundle.pem"
+          grep -q "BEGIN CERTIFICATE" "${{ github.workspace }}/rds-global-bundle.pem"
       - name: Setup GDB
         run: |
           echo "set auto-load safe-path $PWD" > ~/.gdbinit
@@ -1284,7 +1335,7 @@ jobs:
             $EXTRA_ARGS
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: 'linux-${{matrix.rds_engine}}-integration-test-logs'
           path: /tmp/aws-odbc-wrapper/
@@ -1303,14 +1354,14 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=${{ env.LIMITLESS_CLUSTER_ID }}" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -1319,7 +1370,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Setup Dotnet for WiX
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
       - name: Install WiX
         shell: cmd
         run: |
@@ -1373,7 +1424,7 @@ jobs:
           echo "dialect_default_port=5432" >> $GITHUB_OUTPUT
           echo "database_dialect=AURORA_POSTGRESQL" >> $GITHUB_OUTPUT
       - name: Retrieve Base Driver
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -1504,7 +1555,8 @@ jobs:
       - name: Get Github Action IP
         if: always()
         id: ip
-        uses: haythem/public-ip@v1.3
+        shell: bash
+        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> "$GITHUB_OUTPUT"
       - name: Remove Github Action IP
         if: always()
         run: |
@@ -1522,7 +1574,7 @@ jobs:
           echo "TEMP=$env:TEMP" >> $env:GITHUB_OUTPUT
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: 'windows-limitless-test-logs'
           path: ${{ steps.log_location.outputs.TEMP }}/aws-odbc-wrapper/
@@ -1542,14 +1594,14 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=${{ env.LIMITLESS_CLUSTER_ID }}" >> $GITHUB_ENV
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -1604,7 +1656,7 @@ jobs:
           echo "dialect_default_port=5432" >> $GITHUB_OUTPUT
           echo "database_dialect=AURORA_POSTGRESQL" >> $GITHUB_OUTPUT
       - name: Retrieve Base Driver
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -1690,7 +1742,7 @@ jobs:
             --shard-id ${{ env.LIMITLESS_SHARD_ID }}
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: 'mac-limitless-test-logs'
           path: ${{steps.log_location.outputs.TEMP}}/aws-odbc-wrapper/
@@ -1708,7 +1760,7 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=${{ env.LIMITLESS_CLUSTER_ID }}" >> $GITHUB_ENV
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Build Dependencies
         run: |
           sudo apt update
@@ -1719,7 +1771,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -1773,7 +1825,7 @@ jobs:
           echo "dialect_default_port=5432" >> $GITHUB_OUTPUT
           echo "database_dialect=AURORA_POSTGRESQL" >> $GITHUB_OUTPUT
       - name: Retrieve Base Driver
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -1860,7 +1912,7 @@ jobs:
             --shard-id ${{ env.LIMITLESS_SHARD_ID }}
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: 'linux-limitless-test-logs'
           path: /tmp/aws-odbc-wrapper/
@@ -1882,14 +1934,14 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=ODBC-BG-Win-${{matrix.rds_engine}}-${{github.run_id}}${{github.run_number}}${{github.run_attempt}}" | Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -1898,7 +1950,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Setup Dotnet for WiX
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
       - name: Install WiX
         shell: cmd
         run: |
@@ -1960,7 +2012,7 @@ jobs:
             echo "database_dialect=AURORA_MYSQL" >> $GITHUB_OUTPUT
           fi
       - name: Retrieve Base Driver
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -2081,7 +2133,8 @@ jobs:
       - name: Get Github Action IP
         if: always()
         id: ip
-        uses: haythem/public-ip@v1.3
+        shell: bash
+        run: echo "ipv4=$(curl -s https://checkip.amazonaws.com)" >> "$GITHUB_OUTPUT"
       - name: Remove Github Action IP
         if: always()
         run: |
@@ -2099,7 +2152,7 @@ jobs:
           echo "TEMP=$env:TEMP" >> $env:GITHUB_OUTPUT
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: 'windows-${{matrix.rds_engine}}-test-logs'
           path: ${{ steps.log_location.outputs.TEMP }}/aws-odbc-wrapper/
@@ -2122,14 +2175,14 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=ODBC-BG-MacOS-${{matrix.env.rds_engine}}-${{github.run_id}}${{github.run_number}}${{github.run_attempt}}" >> $GITHUB_ENV
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -2192,7 +2245,7 @@ jobs:
             echo "database_dialect=AURORA_MYSQL" >> $GITHUB_OUTPUT
           fi
       - name: Retrieve Base Driver
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -2245,7 +2298,7 @@ jobs:
             --parameter-group parameter-${{ env.AURORA_CLUSTER_ID }}
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: 'mac-${{matrix.env.rds_engine}}-bg-test-logs'
           path: ${{steps.log_location.outputs.TEMP}}/aws-odbc-wrapper/
@@ -2265,7 +2318,7 @@ jobs:
         run: |
           echo "AURORA_CLUSTER_ID=ODBC-BG-Linux-${{ matrix.rds_engine }}-${{github.run_id}}${{github.run_number}}${{github.run_attempt}}" >> $GITHUB_ENV
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Build Dependencies
         run: |
           sudo apt update
@@ -2276,7 +2329,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -2338,7 +2391,7 @@ jobs:
             echo "database_dialect=AURORA_MYSQL" >> $GITHUB_OUTPUT
           fi
       - name: Retrieve Base Driver
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{steps.base_driver_info.outputs.cache_path}}
           key: ${{steps.base_driver_info.outputs.cache_key}}
@@ -2396,7 +2449,7 @@ jobs:
             --parameter-group parameter-${{ env.AURORA_CLUSTER_ID }}
       - name: Archive log results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: 'linux-${{matrix.rds_engine}}-test-logs'
           path: /tmp/aws-odbc-wrapper/

--- a/.github/workflows/release_draft.yaml
+++ b/.github/workflows/release_draft.yaml
@@ -24,14 +24,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -40,7 +40,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Setup Dotnet for WiX
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
       - name: Install WiX
         shell: cmd
         run: |
@@ -51,14 +51,14 @@ jobs:
         run: |
           ./installer/build_installer.ps1 ${{env.BUILD_CONFIG}}
       - name: Configure AWS credentials OIDC
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           role-skip-session-tagging: true
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: aws-odbc-win-signer
       - name: Configure AWS credentials Signer
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           role-skip-session-tagging: true
           role-chaining: true
@@ -73,7 +73,7 @@ jobs:
           . ".\sign_artifacts_win.ps1"
           Invoke-SignInstaller ../installer winx64a ${{ github.ref_name }} ${{ secrets.AWS_UNSIGNED_BUCKET }} ${{ secrets.AWS_SIGNED_BUCKET }} ${{ secrets.AWS_S3_KEY }}aws-advanced-odbc-wrapper-${{ github.ref_name }}-winx64a.msi
       - name: Upload installer
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: installers-windows
           path: ./installer/*winx64a.msi
@@ -87,7 +87,7 @@ jobs:
       macos_arm64_unicode: ${{ steps.macos-arm64-unicode.outputs.hash }}
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Build Dependencies
         run: |
           brew update && brew upgrade && brew cleanup
@@ -98,7 +98,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -119,14 +119,14 @@ jobs:
       - name: Install gnu-tar
         run: brew install gnu-tar
       - name: Configure AWS credentials OIDC
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           role-skip-session-tagging: true
           aws-region: us-west-1
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
           role-session-name: aws-odbc-mac-signer
       - name: Configure AWS credentials Signer
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           role-skip-session-tagging: true
           role-chaining: true
@@ -143,7 +143,7 @@ jobs:
         run: |
           ./scripts/macOS/sign_artifacts_mac.sh ${{ github.ref_name }}
       - name: Upload the ANSI & Unicode driver
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: installers-macos
           path: |
@@ -158,7 +158,7 @@ jobs:
       linux_x64_unicode: ${{ steps.linux-x64-unicode.outputs.hash }}
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Build Dependencies
         run: |
           sudo apt-get update
@@ -169,7 +169,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -206,7 +206,7 @@ jobs:
           cd stage
           tar -chf "aws-advanced-odbc-wrapper-${{ github.ref_name }}-linux-x64.tar.gz" --gzip *
       - name: Upload the ANSI & Unicode driver
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: installers-linux
           path: |
@@ -227,11 +227,11 @@ jobs:
       linux_x64_unicode_hash: ${{needs.build-linux.outputs.linux_x64_unicode}}
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
       - name: Download all installers
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: installers
           pattern: installers-*

--- a/.github/workflows/release_draft.yaml
+++ b/.github/workflows/release_draft.yaml
@@ -24,14 +24,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -40,7 +40,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Setup Dotnet for WiX
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
       - name: Install WiX
         shell: cmd
         run: |
@@ -73,7 +73,7 @@ jobs:
           . ".\sign_artifacts_win.ps1"
           Invoke-SignInstaller ../installer winx64a ${{ github.ref_name }} ${{ secrets.AWS_UNSIGNED_BUCKET }} ${{ secrets.AWS_SIGNED_BUCKET }} ${{ secrets.AWS_S3_KEY }}aws-advanced-odbc-wrapper-${{ github.ref_name }}-winx64a.msi
       - name: Upload installer
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: installers-windows
           path: ./installer/*winx64a.msi
@@ -87,7 +87,7 @@ jobs:
       macos_arm64_unicode: ${{ steps.macos-arm64-unicode.outputs.hash }}
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Build Dependencies
         run: |
           brew update && brew upgrade && brew cleanup
@@ -98,7 +98,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -143,7 +143,7 @@ jobs:
         run: |
           ./scripts/macOS/sign_artifacts_mac.sh ${{ github.ref_name }}
       - name: Upload the ANSI & Unicode driver
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: installers-macos
           path: |
@@ -158,7 +158,7 @@ jobs:
       linux_x64_unicode: ${{ steps.linux-x64-unicode.outputs.hash }}
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Build Dependencies
         run: |
           sudo apt-get update
@@ -169,7 +169,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -206,7 +206,7 @@ jobs:
           cd stage
           tar -chf "aws-advanced-odbc-wrapper-${{ github.ref_name }}-linux-x64.tar.gz" --gzip *
       - name: Upload the ANSI & Unicode driver
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: installers-linux
           path: |
@@ -227,17 +227,17 @@ jobs:
       linux_x64_unicode_hash: ${{needs.build-linux.outputs.linux_x64_unicode}}
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
       - name: Download all installers
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@v8
         with:
           path: installers
           pattern: installers-*
           merge-multiple: true
       - name: Extract release notes
-        uses: ffurrer2/extract-release-notes@v3
+        uses: ffurrer2/extract-release-notes@273da39a24fb7db106a35526c8162815faffd31d # v3
         with:
           release_notes_file: RELEASE_DETAILS.md
       - name: Append Checksums
@@ -251,7 +251,7 @@ jobs:
 
           EOF
       - name: Upload to Draft Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           draft: true
           name: "AWS Advanced ODBC Wrapper - v${{ github.ref_name }}"

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Build Dependencies
         run: |
           brew update && brew upgrade && brew cleanup
@@ -41,7 +41,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{ env.BUILD_CONFIG }}-${{ steps.aws-sdk-version.outputs.tag }}
@@ -73,7 +73,7 @@ jobs:
             -d cppcheck \
             ./build_ansi/compile_commands.json
       - name: Upload ANSI reports
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: reports-ansi
           path: reports-ansi/
@@ -85,7 +85,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Build Dependencies
         run: |
           brew update && brew upgrade && brew cleanup
@@ -99,7 +99,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{ env.BUILD_CONFIG }}-${{ steps.aws-sdk-version.outputs.tag }}
@@ -131,7 +131,7 @@ jobs:
             -d cppcheck \
             ./build_unicode/compile_commands.json
       - name: Upload Unicode reports
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: reports-unicode
           path: reports-unicode/
@@ -144,19 +144,19 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install CodeChecker
         run: |
           python3 -m venv ./venv
           source ./venv/bin/activate
           python3 -m pip install CodeChecker==${{ env.CODECHECKER_VERSION }}
       - name: Download ANSI reports
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@v8
         with:
           name: reports-ansi
           path: reports-merged/ansi
       - name: Download Unicode reports
-        uses: actions/download-artifact@v7.0.0
+        uses: actions/download-artifact@v8
         with:
           name: reports-unicode
           path: reports-merged/unicode
@@ -177,7 +177,7 @@ jobs:
             ./reports-merged/unicode || true
       - name: Upload merged HTML report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: static-analysis-html-report
           path: html-report/

--- a/.github/workflows/static_analysis.yaml
+++ b/.github/workflows/static_analysis.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Build Dependencies
         run: |
           brew update && brew upgrade && brew cleanup
@@ -41,7 +41,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{ env.BUILD_CONFIG }}-${{ steps.aws-sdk-version.outputs.tag }}
@@ -73,7 +73,7 @@ jobs:
             -d cppcheck \
             ./build_ansi/compile_commands.json
       - name: Upload ANSI reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: reports-ansi
           path: reports-ansi/
@@ -85,7 +85,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Build Dependencies
         run: |
           brew update && brew upgrade && brew cleanup
@@ -99,7 +99,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{ env.BUILD_CONFIG }}-${{ steps.aws-sdk-version.outputs.tag }}
@@ -131,7 +131,7 @@ jobs:
             -d cppcheck \
             ./build_unicode/compile_commands.json
       - name: Upload Unicode reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: reports-unicode
           path: reports-unicode/
@@ -144,19 +144,19 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install CodeChecker
         run: |
           python3 -m venv ./venv
           source ./venv/bin/activate
           python3 -m pip install CodeChecker==${{ env.CODECHECKER_VERSION }}
       - name: Download ANSI reports
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: reports-ansi
           path: reports-merged/ansi
       - name: Download Unicode reports
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: reports-unicode
           path: reports-merged/unicode
@@ -177,7 +177,7 @@ jobs:
             ./reports-merged/unicode || true
       - name: Upload merged HTML report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: static-analysis-html-report
           path: html-report/

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -30,14 +30,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk-cpp
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -67,7 +67,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Build Dependencies
         run: |
           brew update && brew upgrade && brew cleanup
@@ -78,7 +78,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk-cpp
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Build Dependencies
         run: |
           sudo apt update
@@ -123,7 +123,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk-cpp
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -30,14 +30,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Resolve AWS SDK version
         id: aws-sdk-version
         shell: bash
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_win.ps1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk-cpp
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -46,7 +46,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_win.ps1 ${{env.BUILD_CONFIG}}
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -67,7 +67,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Build Dependencies
         run: |
           brew update && brew upgrade && brew cleanup
@@ -78,7 +78,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk-cpp
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -87,7 +87,7 @@ jobs:
           export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
           ./scripts/compile_aws_sdk_unix.sh ${{env.BUILD_CONFIG}}
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout aws-advanced-odbc-wrapper
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install Build Dependencies
         run: |
           sudo apt update
@@ -123,7 +123,7 @@ jobs:
         run: echo "tag=$(grep AWS_SDK_CPP_TAG scripts/compile_aws_sdk_unix.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Retrieve AWS SDK for C++ Cache
         id: cache-aws-sdk-cpp
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: aws_sdk/install
           key: ${{ runner.os }}-aws-sdk-cpp-${{env.BUILD_CONFIG}}-shared-${{ steps.aws-sdk-version.outputs.tag }}
@@ -132,7 +132,7 @@ jobs:
         run: |
           ./scripts/compile_aws_sdk_unix.sh ${{env.BUILD_CONFIG}}
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE }}

--- a/scripts/compile_aws_sdk_unix.sh
+++ b/scripts/compile_aws_sdk_unix.sh
@@ -17,6 +17,9 @@ CONFIGURATION=$1    # Debug/Release
 export ROOT_REPO_PATH=$(cd "$(dirname "$0")/.."; pwd -P)
 
 export AWS_SDK_CPP_TAG="1.11.835"
+# Commit the tag pointed to when it was vetted; git tags are mutable, so verify
+# the clone landed on this exact commit before building.
+export AWS_SDK_CPP_COMMIT="94e71dee7a4dcb21c31df2b9c8f3d49b337e0a83"
 
 export AWS_SDK_PATH="${ROOT_REPO_PATH}/aws_sdk"
 export SRC_DIR="${AWS_SDK_PATH}/aws_sdk_cpp"
@@ -27,6 +30,15 @@ mkdir -p ${SRC_DIR} ${BUILD_DIR} ${INSTALL_DIR}
 pushd $BUILD_DIR
 
 git clone --recurse-submodules -b "$AWS_SDK_CPP_TAG" "https://github.com/aws/aws-sdk-cpp.git" ${SRC_DIR}
+
+ACTUAL_COMMIT=$(git -C ${SRC_DIR} rev-parse HEAD)
+if [ "$ACTUAL_COMMIT" != "$AWS_SDK_CPP_COMMIT" ]; then
+    echo "ERROR: aws-sdk-cpp tag $AWS_SDK_CPP_TAG resolved to unexpected commit." >&2
+    echo "  expected: $AWS_SDK_CPP_COMMIT" >&2
+    echo "  actual:   $ACTUAL_COMMIT" >&2
+    echo "The upstream tag may have been moved. Verify before updating AWS_SDK_CPP_COMMIT." >&2
+    exit 1
+fi
 
 cmake -S ${SRC_DIR} \
     -B $BUILD_DIR \

--- a/scripts/compile_aws_sdk_win.ps1
+++ b/scripts/compile_aws_sdk_win.ps1
@@ -17,6 +17,9 @@ $CONFIGURATION = $args[0]   # Debug/Release
 $CURRENT_DIR = (Get-Location).Path
 
 $AWS_SDK_CPP_TAG = "1.11.835"
+# Commit the tag pointed to when it was vetted; git tags are mutable, so verify
+# the clone landed on this exact commit before building.
+$AWS_SDK_CPP_COMMIT = "94e71dee7a4dcb21c31df2b9c8f3d49b337e0a83"
 
 $SRC_DIR = "${PSScriptRoot}\..\aws_sdk\aws_sdk_cpp"
 $BUILD_DIR = "${SRC_DIR}\..\build"
@@ -26,6 +29,15 @@ Write-Host $args
 
 New-Item -Path $SRC_DIR -ItemType Directory -Force | Out-Null
 git clone --recurse-submodules -b "$AWS_SDK_CPP_TAG" "https://github.com/aws/aws-sdk-cpp.git" $SRC_DIR
+
+$ACTUAL_COMMIT = (git -C $SRC_DIR rev-parse HEAD)
+if ($ACTUAL_COMMIT -ne $AWS_SDK_CPP_COMMIT) {
+    Write-Error ("aws-sdk-cpp tag $AWS_SDK_CPP_TAG resolved to unexpected commit.`n" +
+        "  expected: $AWS_SDK_CPP_COMMIT`n" +
+        "  actual:   $ACTUAL_COMMIT`n" +
+        "The upstream tag may have been moved. Verify before updating AWS_SDK_CPP_COMMIT.")
+    exit 1
+}
 
 New-Item -Path $BUILD_DIR -ItemType Directory -Force | Out-Null
 Set-Location $BUILD_DIR


### PR DESCRIPTION
### Summary

Adds Checksum for 3rd Party Dependencies & Updates Actions

### Description

- For downloaded files (e.g. w/ curl), a checksum is performed
  - apt, brew, and nuget already perform their own checksums
- Updated actions to newer versions
- Use exact commit hash for lesser-known actions
- Replaced IP fetch action with `curl checkip.amazon.com` as it was not maintained and will reach deprecation due to node24 GH requirement

### Testing

<!-- What did you test and how did you test it -->

### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
